### PR TITLE
fix: onConnect() event issue for creating a new listener each time it…

### DIFF
--- a/src/background/backgroundPage.ts
+++ b/src/background/backgroundPage.ts
@@ -1,44 +1,42 @@
 import "./appInit";
-import 'subworkers'; 
-import { browser, Runtime } from "webextension-polyfill-ts";
+import "subworkers";
+import { browser } from "webextension-polyfill-ts";
 import { Request } from "@src/types";
 import ZkKeeperController from "./zk-keeper";
-import log from 'loglevel';
-import { checkForLastErrorAndLog } from "./shared/checForLastError";
+import log from "loglevel";
+import { deferredPromise } from "./shared/utils";
 
-globalThis.CRYPTKEEPER_DEBUG = false;
+globalThis.CRYPTKEEPER_DEBUG = true;
 
-log.setDefaultLevel(globalThis.CRYPTKEEPER_DEBUG ? 'debug' : 'info');
+log.setDefaultLevel(globalThis.CRYPTKEEPER_DEBUG ? "debug" : "info");
+
+const { promise: isInitialized, resolve: resolveInitialization, reject: rejectInitialization } = deferredPromise();
 
 browser.runtime.onInstalled.addListener(async args => {
   log.debug("CryptKeeper onInstalled Event, initializing...");
-  await initApp();
+  await isInitialized;
   log.debug("CryptKeeper onInstalled Event, initializing completed...");
 });
 
 browser.runtime.onConnect.addListener(async args => {
   log.debug("CryptKeeper onConnect Event, initializing...");
-  await initApp();
+  await isInitialized;
   log.debug("CryptKeeper onConnect Event, initializing completed...");
 });
 
-const initApp = async (remotePort?: Runtime.Port) => {
-  browser.runtime.onConnect.removeListener(initApp);
-  await initialize(remotePort);
-  await sendReadyMessageToTabs();
-  log.debug('CryptKeeper initialization complete.');
-}
+initialize().catch((e: any) => {
+  log.error("CryptKeeper Initializaiton error.", e);
+});
 
-async function initialize (remotePort?: Runtime.Port) {
+async function initialize() {
   try {
-    log.debug(`initialize remotePort`, remotePort);
     const app: ZkKeeperController = new ZkKeeperController();
 
     app.initialize().then(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      browser.runtime.onMessage.addListener(async (request: Request,_) => {
+      browser.runtime.onMessage.addListener(async (request: Request, _) => {
         try {
-          log.debug("Background: request: ", request)
+          log.debug("Background: request: ", request);
           const response = await app.handle(request);
           log.debug("Background: response: ", response);
           return [null, response];
@@ -47,35 +45,9 @@ async function initialize (remotePort?: Runtime.Port) {
         }
       });
     });
+    log.debug("CryptKeeper initialization complete.");
+    resolveInitialization();
   } catch (error) {
-    log.error("Error in backgound!", error);
+    rejectInitialization(error);
   }
 }
-
-const sendReadyMessageToTabs = async () => {
-  await browser.tabs
-    .query({
-      /**
-       * Only query tabs that our extension can run in. To do this, we query for all URLs that our
-       * extension can inject scripts in, which is by using the "<all_urls>" value and __without__
-       * the "tabs" manifest permission. If we included the "tabs" permission, this would also fetch
-       * URLs that we'd not be able to inject in, e.g. chrome://pages, chrome://extension, which
-       * is not what we'd want.
-       *
-       * You might be wondering, how does the "url" param work without the "tabs" permission?
-       *
-       * @see {@link https://bugs.chromium.org/p/chromium/issues/detail?id=661311#c1}
-       *  "If the extension has access to inject scripts into Tab, then we can return the url
-       *   of Tab (because the extension could just inject a script to message the location.href)."
-       */
-      url: '<all_urls>',
-      windowType: 'normal',
-    })
-    .then((result) => {
-      checkForLastErrorAndLog();
-      return result;
-    })
-    .catch(() => {
-      checkForLastErrorAndLog();
-    });
-};

--- a/src/ui/pages/Home/index.tsx
+++ b/src/ui/pages/Home/index.tsx
@@ -219,7 +219,6 @@ const IdentityList = function (): ReactElement {
   };
 
   useEffect(() => {
-    dispatch(fetchIdentities());
     setDeleteIdentityState(false);
   }, [renameInput, deleteIdentityState, identities]);
 


### PR DESCRIPTION
## Explanation

Before the `onConnect()` when fired up was always creating a new event listener and that was the wrong behavior. Now that should be resolved when the `onConnect()` event is fired instead of creating a new listener it will make sure that the first listener created is still initialized without issues. Therefore, we would have only one listener event. 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

- Fix #73 

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)