### PR TITLE
fix: resolving getActiveIdentity bug issue #84

### DIFF
--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -95,7 +95,8 @@ export default class IdentityService extends SimpleStorage {
     const identities = await this.getIdentitiesFromStore();
 
     if (identities.has(identityCommitment)) {
-      await this.activeIdentityStore.set(identityCommitment as string);
+      const identityCommitmentCipher = await LockService.encrypt(identityCommitment);
+      await this.activeIdentityStore.set(identityCommitmentCipher as string);
       this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identities.get(identityCommitment) as string);
       pushMessage(setSelected(identityCommitment));
       const tabs = await browser.tabs.query({ active: true });
@@ -154,7 +155,8 @@ export default class IdentityService extends SimpleStorage {
   };
 
   getActiveidentity = async (): Promise<ZkIdentityDecorater | undefined> => {
-    const acitveIdentityCommitment = await this.activeIdentityStore.get();
+    const acitveIdentityCommitmentCipher = await this.activeIdentityStore.get();
+    const acitveIdentityCommitment = await LockService.decrypt(acitveIdentityCommitmentCipher);
     const identities = await this.getIdentitiesFromStore();
 
     if (identities.has(acitveIdentityCommitment)) {


### PR DESCRIPTION
## Explanation

Resolving the bug of not being able to get the active identity once the user pops-up the CK extension. Now, the last activated identity commitment from the user is being encrypted and stored in chrome storage, 

Details are below:
- [x] Fix `getActiveidentity()`  and `setActiveIdentity()` fns
- [x] Encrypted the activated identity commitment. 
- [x] Stroing the activated identity commitment in chrome storage. 
- [x] Allowing Dapps to reach out directly to the activated identity commitment after sign-in. 

What is missing: 
- [ ] Writing testing script for IdentityService
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

Fix #84 

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

N/A
<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

N/A
<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

N/A
<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

- Follow how to install the extension in your Chrome browser from the README. 
- Create a new Identity if you haven't already.
- Run the demo app (Checkout Readme).
- Then the app will be able to connect to CK and read the current active identity. 
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)