### PR TITLE
fix: semaphore proof generation

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -226,7 +226,7 @@ function App() {
         </button>{" "}
         <br />
         <br />
-        <button disabled onClick={() => genSemaphoreProof(MerkleProofType.ARTIFACTS)}>
+        <button onClick={() => genSemaphoreProof(MerkleProofType.ARTIFACTS)}>
           Generate proof from Merkle proof artifacts
         </button>
       </div>

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useCallback } from "react";
 import ReactDOM from "react-dom";
-import { RLN } from "rlnjs/src";
+import { RLN, genExternalNullifier } from "rlnjs";
 import { bigintToHex } from "bigint-conversion";
 import { Identity } from "@semaphore-protocol/identity";
 
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import log from "loglevel";
-import { genExternalNullifier } from "rlnjs/src/utils";
 
 const semaphorePath = {
   circuitFilePath: "http://localhost:8095/semaphore/semaphore.wasm",
@@ -93,15 +92,9 @@ function App() {
         storageAddressOrArtifacts,
       );
 
-      log.debug(`Semaphore proof generated successfully! \n
-            - Public Signals: 
-            \t ${JSON.stringify(proof.fullProof.publicSignals, null, 1)}
-            - fullProof: 
-            \t ${JSON.stringify(proof.fullProof.proof, null, 1)}
-        `);
+      console.log("Semaphore proof generated successfully!", proof);
       toast(`Semaphore proof generated successfully!`, { type: "success" });
     } catch (e) {
-      log.debug("ERROR", e);
       toast("Error while generating Semaphore proof!", { type: "error" });
       console.error(e);
     }
@@ -151,15 +144,9 @@ function App() {
         rlnIdentifierHex,
       );
 
-      log.debug(`RLN proof generated successfully! \n
-            - Public Signals: 
-            \t ${JSON.stringify(proof.publicSignals, null, 1)}
-            - fullProof: 
-            \t ${JSON.stringify(proof.proof, null, 1)}
-        `);
-      toast(`RLN proof generated successfully! ${proof}`, { type: "success" });
+      console.log("RLN proof generated successfully!", proof);
+      toast("RLN proof generated successfully!", { type: "success" });
     } catch (e) {
-      log.debug("ERROR", e);
       toast("Error while generating RLN proof!", { type: "error" });
       console.error(e);
     }
@@ -233,12 +220,12 @@ function App() {
       <hr />
       <div>
         <h2>RLN</h2>
-        <button disabled onClick={() => genRLNProof(MerkleProofType.STORAGE_ADDRESS)}>
+        <button onClick={() => genRLNProof(MerkleProofType.STORAGE_ADDRESS)}>
           Generate proof from Merkle proof storage address
         </button>{" "}
         <br />
         <br />
-        <button disabled onClick={() => genRLNProof(MerkleProofType.ARTIFACTS)}>
+        <button onClick={() => genRLNProof(MerkleProofType.ARTIFACTS)}>
           Generate proof from Merkle proof artifacts
         </button>
       </div>

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -17563,7 +17563,7 @@
         },
         "rlnjs": {
             "version": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#fa4f4b8ea47f525aec7fe7efe436d089059e0cbc",
-            "from": "rlnjs@https://github.com/Rate-Limiting-Nullifier/rlnjs.git",
+            "from": "rlnjs@github:Rate-Limiting-Nullifier/rlnjs",
             "requires": {
                 "@ethersproject/bytes": "^5.6.1",
                 "@ethersproject/solidity": "^5.6.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Crypt-keeper-demo",
+    "name": "crypt-keeper-demo",
     "version": "0.1.0",
     "scripts": {
         "start": "parcel serve --open --no-cache index.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@semaphore-protocol/group": "^3.0.0",
         "@semaphore-protocol/identity": "^3.0.0",
         "@semaphore-protocol/proof": "^3.0.0",
-        "@types/classnames": "^2.3.0",
         "@zk-kit/incremental-merkle-tree": "^1.0.0",
         "@zk-kit/protocols": "^1.11.1",
         "bigint-conversion": "^2.3.0",
@@ -38,15 +37,15 @@
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
-        "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs#refactor/v2",
+        "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs",
         "subworkers": "^1.0.1",
-        "web-worker": "^1.2.0",
         "web3": "^1.8.0",
         "webextension-polyfill-ts": "^0.20.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
+        "@types/classnames": "^2.3.1",
         "@types/cors": "^2.8.13",
         "@types/eventemitter2": "^4.1.0",
         "@types/express": "^4.17.16",
@@ -3239,6 +3238,7 @@
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
       "deprecated": "This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.",
+      "dev": true,
       "dependencies": {
         "classnames": "*"
       }
@@ -17026,8 +17026,8 @@
       }
     },
     "node_modules/rlnjs": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#ff79956d3a9635dec71226589b999e71237f5ddc",
+      "version": "2.0.0-alpha.2",
+      "resolved": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#fa4f4b8ea47f525aec7fe7efe436d089059e0cbc",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
@@ -23005,6 +23005,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
+      "dev": true,
       "requires": {
         "classnames": "*"
       }
@@ -33716,8 +33717,8 @@
       }
     },
     "rlnjs": {
-      "version": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#ff79956d3a9635dec71226589b999e71237f5ddc",
-      "from": "rlnjs@github:Rate-Limiting-Nullifier/rlnjs#refactor/v2",
+      "version": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#fa4f4b8ea47f525aec7fe7efe436d089059e0cbc",
+      "from": "rlnjs@github:Rate-Limiting-Nullifier/rlnjs",
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/solidity": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@types/classnames": "^2.3.1",
     "@types/cors": "^2.8.13",
     "@types/eventemitter2": "^4.1.0",
     "@types/express": "^4.17.16",
@@ -89,7 +90,6 @@
     "@semaphore-protocol/group": "^3.0.0",
     "@semaphore-protocol/identity": "^3.0.0",
     "@semaphore-protocol/proof": "^3.0.0",
-    "@types/classnames": "^2.3.0",
     "@zk-kit/incremental-merkle-tree": "^1.0.0",
     "@zk-kit/protocols": "^1.11.1",
     "bigint-conversion": "^2.3.0",
@@ -113,9 +113,8 @@
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.4.2",
-    "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs#refactor/v2",
+    "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs",
     "subworkers": "^1.0.1",
-    "web-worker": "^1.2.0",
     "web3": "^1.8.0",
     "webextension-polyfill-ts": "^0.20.0"
   },

--- a/scripts/mock-merkle-proof.ts
+++ b/scripts/mock-merkle-proof.ts
@@ -69,6 +69,5 @@ app.post("/merkleProof/:type", (req, res) => {
 });
 
 app.listen(8090, () => {
-  console.log(btoa(atob("")));
   log.debug("Merkle service is listening");
 });

--- a/src/background/backgroundPage.ts
+++ b/src/background/backgroundPage.ts
@@ -35,11 +35,10 @@ initialize().catch((e: any) => {
 
 async function initialize() {
   try {
-    const app: ZkKeeperController = new ZkKeeperController();
+    const app = new ZkKeeperController();
 
     app.initialize().then(() => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      browser.runtime.onMessage.addListener(async (request: Request, _) => {
+      browser.runtime.onMessage.addListener(async (request: Request) => {
         try {
           log.debug("Background: request: ", request);
           const response = await app.handle(request);

--- a/src/background/services/lock.ts
+++ b/src/background/services/lock.ts
@@ -1,137 +1,136 @@
-import CryptoJS from 'crypto-js'
-import pushMessage from '@src/util/pushMessage'
-import { setStatus } from '@src/ui/ducks/app'
-import { browser } from 'webextension-polyfill-ts'
-import SimpleStorage from './simple-storage'
-import browserUtils from '../controllers/browser-utils'
-import log from 'loglevel'
+import CryptoJS from "crypto-js";
+import pushMessage from "@src/util/pushMessage";
+import { setStatus } from "@src/ui/ducks/app";
+import { browser } from "webextension-polyfill-ts";
+import SimpleStorage from "./simple-storage";
+import browserUtils from "../controllers/browser-utils";
+import log from "loglevel";
 
-const passwordKey: string = '@password@'
+const passwordKey = "@password@";
 
 class LockService extends SimpleStorage {
-    private isUnlocked: boolean
-    private password?: string
-    private passwordChecker: string
-    private unlockCB?: any
+  private isUnlocked: boolean;
+  private password?: string;
+  private passwordChecker: string;
+  private unlockCB?: any;
 
-    constructor() {
-        super(passwordKey)
-        this.isUnlocked = false
-        this.password = undefined
-        this.passwordChecker = 'Password is correct'
+  constructor() {
+    super(passwordKey);
+    this.isUnlocked = false;
+    this.password = undefined;
+    this.passwordChecker = "Password is correct";
+  }
+
+  /**
+   *  This method is called when install event occurs
+   */
+  setupPassword = async (password: string) => {
+    const ciphertext: string = CryptoJS.AES.encrypt(this.passwordChecker, password).toString();
+    await this.set(ciphertext);
+    await this.unlock(password);
+    await pushMessage(setStatus(await this.getStatus()));
+  };
+
+  getStatus = async () => {
+    const ciphertext = await this.get();
+
+    return {
+      initialized: !!ciphertext,
+      unlocked: this.isUnlocked,
+    };
+  };
+
+  awaitUnlock = async () => {
+    if (this.isUnlocked) return;
+
+    return new Promise(resolve => {
+      this.unlockCB = resolve;
+    });
+  };
+
+  onUnlocked = () => {
+    if (this.unlockCB) {
+      this.unlockCB();
+      this.unlockCB = undefined;
+    }
+    return true;
+  };
+
+  unlock = async (password: string): Promise<boolean> => {
+    if (this.isUnlocked) return true;
+
+    const ciphertext = await this.get();
+
+    if (!ciphertext) {
+      throw new Error("Something badly gone wrong (reinstallation probably required)");
     }
 
-    /**
-     *  This method is called when install event occurs
-     */
-    setupPassword = async (password: string) => {
-        const ciphertext: string = CryptoJS.AES.encrypt(this.passwordChecker, password).toString()
-        await this.set(ciphertext)
-        await this.unlock(password)
-        await pushMessage(setStatus(await this.getStatus()))
+    if (!password) {
+      throw new Error("Password is not provided");
     }
 
-    getStatus = async () => {
-        const ciphertext = await this.get()
+    const bytes = CryptoJS.AES.decrypt(ciphertext, password);
+    const retrievedPasswordChecker: string = bytes.toString(CryptoJS.enc.Utf8);
 
-        return {
-            initialized: !!ciphertext,
-            unlocked: this.isUnlocked
+    if (retrievedPasswordChecker !== this.passwordChecker) {
+      throw new Error("Incorrect password");
+    }
+
+    this.password = password;
+    this.isUnlocked = true;
+
+    const status = await this.getStatus();
+    await pushMessage(setStatus(status));
+    const tabs = await browser.tabs.query({ active: true });
+    for (const tab of tabs) {
+      await browser.tabs.sendMessage(tab.id as number, setStatus(status));
+    }
+    return true;
+  };
+
+  internalLogout = async () => {
+    this.isUnlocked = false;
+    this.password = undefined;
+    const status = await this.getStatus();
+    await pushMessage(setStatus(status));
+    return status;
+  };
+
+  logout = async (): Promise<boolean> => {
+    const status = await this.internalLogout();
+    log.debug("logout 1");
+    const tabs = await browser.tabs.query({ active: true });
+    log.debug("logout 2", tabs);
+    browserUtils.activatedTabs(async () => {
+      for (const tab of tabs) {
+        try {
+          await browserUtils.sendMessageTabs(tab.id as number, setStatus(status));
+        } catch (error) {
+          log.debug("Lock error: ", error);
         }
+      }
+    });
+    return true;
+  };
+
+  ensure = async (payload: any = null) => {
+    if (!this.isUnlocked || !this.password) {
+      log.debug("state is locked!");
+      return false;
     }
+    return payload;
+  };
 
-    awaitUnlock = async () => {
-        if (this.isUnlocked) return
+  encrypt = async (payload: string): Promise<string> => {
+    await this.ensure();
+    return CryptoJS.AES.encrypt(payload, this.password).toString();
+  };
 
-        return new Promise((resolve) => {
-            this.unlockCB = resolve
-        })
-    }
-
-    onUnlocked = () => {
-        if (this.unlockCB) {
-            this.unlockCB()
-            this.unlockCB = undefined
-        }
-        return true
-    }
-
-    unlock = async (password: string): Promise<boolean> => {
-        if (this.isUnlocked) return true
-
-        const ciphertext = await this.get()
-
-        if (!ciphertext) {
-            throw new Error('Something badly gone wrong (reinstallation probably required)')
-        }
-
-        if (!password) {
-            throw new Error('Password is not provided')
-        }
-
-        const bytes = CryptoJS.AES.decrypt(ciphertext, password)
-        const retrievedPasswordChecker: string = bytes.toString(CryptoJS.enc.Utf8)
-
-        if (retrievedPasswordChecker !== this.passwordChecker) {
-            throw new Error('Incorrect password')
-        }
-
-        this.password = password
-        this.isUnlocked = true
-
-        const status = await this.getStatus()
-        await pushMessage(setStatus(status))
-        const tabs = await browser.tabs.query({ active: true })
-        for (const tab of tabs) {
-            await browser.tabs.sendMessage(tab.id as number, setStatus(status))
-        }
-        return true
-    }
-
-
-    internalLogout = async () => {
-        this.isUnlocked = false
-        this.password = undefined
-        const status = await this.getStatus()
-        await pushMessage(setStatus(status))
-        return status
-    }
-
-    logout = async (): Promise<boolean> => {
-        const status = await this.internalLogout();
-        log.debug("logout 1")
-        const tabs = await browser.tabs.query({ active: true })
-        log.debug("logout 2", tabs)
-        browserUtils.activatedTabs(async () => {
-            for (const tab of tabs) {
-                try {
-                    await browserUtils.sendMessageTabs(tab.id as number, setStatus(status));
-                } catch (error) {
-                    log.debug("Lock error: ", error);
-                }
-            } 
-        });
-        return true
-    }
-
-    ensure = async (payload: any = null) => {
-        if (!this.isUnlocked || !this.password) {
-            log.debug("state is locked!");
-            return false
-        }
-        return payload
-    }
-
-    encrypt = async (payload: string): Promise<string> => {
-        await this.ensure()
-        return CryptoJS.AES.encrypt(payload, this.password).toString()
-    }
-
-    decrypt = async (ciphertext: string): Promise<string> => {
-        await this.ensure()
-        const bytes = CryptoJS.AES.decrypt(ciphertext, this.password)
-        return bytes.toString(CryptoJS.enc.Utf8)
-    }
+  decrypt = async (ciphertext: string): Promise<string> => {
+    await this.ensure();
+    const bytes = CryptoJS.AES.decrypt(ciphertext, this.password);
+    return bytes.toString(CryptoJS.enc.Utf8);
+  };
 }
 
-export default new LockService()
+export default new LockService();

--- a/src/background/services/protocols/rln.ts
+++ b/src/background/services/protocols/rln.ts
@@ -44,7 +44,7 @@ export default class RLNService {
         merkleProof = generateMerkleProof({ treeDepth: proofArtifacts.depth, member: identityCommitment });
       }
 
-      const fullProof: RLNFullProof = await rln.genProof(signal, merkleProof, externalNullifier);
+      const fullProof: RLNFullProof = await rln.generateProof(signal, merkleProof, externalNullifier);
       return fullProof;
     } catch (e) {
       throw new Error(`Error while generating RLN proof: ${e}`);

--- a/src/background/services/protocols/semaphore.ts
+++ b/src/background/services/protocols/semaphore.ts
@@ -38,9 +38,11 @@ export default class SemaphoreService {
       } else {
         const proofArtifacts = merkleProofArtifacts as MerkleProofArtifacts;
 
-        //const leaves = proofArtifacts.leaves.map((leaf) => hexToBigint(leaf))
-
-        merkleProof = generateMerkleProof({ treeDepth: proofArtifacts.depth, member: identityCommitment });
+        merkleProof = generateMerkleProof({
+          treeDepth: proofArtifacts.depth,
+          member: identityCommitment,
+          members: [identityCommitment],
+        });
       }
 
       // TODO: do we need to leave `SnarkArtifacts` param as undefinded?

--- a/src/background/services/protocols/semaphore.ts
+++ b/src/background/services/protocols/semaphore.ts
@@ -8,7 +8,6 @@ import log from "loglevel";
 import ZkIdentityDecorater from "@src/background/identity-decorater";
 
 export default class SemaphoreService {
-  // eslint-disable-next-line class-methods-use-this
   async genProof(identity: ZkIdentityDecorater, request: SemaphoreProofRequest): Promise<SemaphoreProof> {
     try {
       const {

--- a/src/background/services/zk-validator.ts
+++ b/src/background/services/zk-validator.ts
@@ -1,25 +1,25 @@
-import { ZkInputs } from '@src/types'
+import { ZkInputs } from "@src/types";
 
 export default class ZkValidator {
-    // eslint-disable-next-line class-methods-use-this
-    validateZkInputs(payload: Required<ZkInputs>) {
-        const { circuitFilePath, zkeyFilePath, merkleProofArtifacts, merkleProof } = payload
+  // eslint-disable-next-line class-methods-use-this
+  validateZkInputs(payload: Required<ZkInputs>) {
+    const { circuitFilePath, zkeyFilePath, merkleProofArtifacts, merkleProof } = payload;
 
-        if (!circuitFilePath) throw new Error('circuitFilePath not provided')
-        if (!zkeyFilePath) throw new Error('zkeyFilePath not provided')
+    if (!circuitFilePath) throw new Error("circuitFilePath not provided");
+    if (!zkeyFilePath) throw new Error("zkeyFilePath not provided");
 
-        if (merkleProof) {
-            if (!merkleProof.root) throw new Error('invalid merkleProof.root value')
-            if (!merkleProof.siblings.length) throw new Error('invalid merkleProof.siblings value')
-            if (!merkleProof.pathIndices.length) throw new Error('invalid merkleProof.pathIndices value')
-            if (!merkleProof.leaf) throw new Error('invalid merkleProof.leaf value')
-        } else if (merkleProofArtifacts) {
-            if (!merkleProofArtifacts.leaves.length || merkleProofArtifacts.leaves.length === 0)
-                throw new Error('invalid merkleProofArtifacts.leaves value')
-            if (!merkleProofArtifacts.depth) throw new Error('invalid merkleProofArtifacts.depth value')
-            if (!merkleProofArtifacts.leavesPerNode) throw new Error('invalid merkleProofArtifacts.leavesPerNode value')
-        }
-
-        return payload
+    if (merkleProof) {
+      if (!merkleProof.root) throw new Error("invalid merkleProof.root value");
+      if (!merkleProof.siblings.length) throw new Error("invalid merkleProof.siblings value");
+      if (!merkleProof.pathIndices.length) throw new Error("invalid merkleProof.pathIndices value");
+      if (!merkleProof.leaf) throw new Error("invalid merkleProof.leaf value");
+    } else if (merkleProofArtifacts) {
+      if (!merkleProofArtifacts.leaves.length || merkleProofArtifacts.leaves.length === 0)
+        throw new Error("invalid merkleProofArtifacts.leaves value");
+      if (!merkleProofArtifacts.depth) throw new Error("invalid merkleProofArtifacts.depth value");
+      if (!merkleProofArtifacts.leavesPerNode) throw new Error("invalid merkleProofArtifacts.leavesPerNode value");
     }
+
+    return payload;
+  }
 }

--- a/src/background/zk-keeper.ts
+++ b/src/background/zk-keeper.ts
@@ -125,14 +125,14 @@ export default class ZkKeeperController extends Handler {
       if (!identity) {
         return null;
       }
-      const identityCommitment: bigint = identity.genIdentityCommitment();
+      const identityCommitment = identity.genIdentityCommitment();
       const identityCommitmentHex = bigintToHex(identityCommitment);
       return identityCommitmentHex;
     });
 
     // protocols
     this.add(
-      RPCAction.SEMAPHORE_PROOF,
+      RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST,
       LockService.ensure,
       this.zkValidator.validateZkInputs,
       async (payload: SemaphoreProofRequest, meta: any) => {
@@ -158,12 +158,12 @@ export default class ZkKeeperController extends Handler {
             });
           }
 
-          await BrowserUtils.closePopup();
-
-          return this.semaphoreService.genProof(identity, payload);
+          return { identity: identity.serialize(), payload };
         } catch (err) {
-          await BrowserUtils.closePopup();
           throw err;
+        } finally {
+          // TODO: maybe we need to keep popup open and show generation progress
+          await BrowserUtils.closePopup();
         }
       },
     );

--- a/src/contentscripts/injected.ts
+++ b/src/contentscripts/injected.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { MerkleProofArtifacts } from "@src/types";
-import RPCAction from "@src/util/constants";
 import { MerkleProof } from "@zk-kit/incremental-merkle-tree";
 import log from "loglevel";
+
+import { MerkleProofArtifacts } from "@src/types";
+import RPCAction from "@src/util/constants";
+import { ISemaphoreGenerateArgs, SemaphoreProofGenerator } from "./proof";
 
 export type IRequest = {
   method: string;
@@ -96,8 +98,8 @@ async function semaphoreProof(
   const merkleStorageAddress =
     typeof merkleProofArtifactsOrStorageAddress === "string" ? merkleProofArtifactsOrStorageAddress : undefined;
 
-  return post({
-    method: RPCAction.SEMAPHORE_PROOF,
+  const request = await post({
+    method: RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST,
     payload: {
       externalNullifier,
       signal,
@@ -108,6 +110,8 @@ async function semaphoreProof(
       merkleProof,
     },
   });
+
+  return SemaphoreProofGenerator.getInstance().generate(request as ISemaphoreGenerateArgs);
 }
 
 async function rlnProof(

--- a/src/contentscripts/proof/index.ts
+++ b/src/contentscripts/proof/index.ts
@@ -1,0 +1,1 @@
+export * from "./semaphore";

--- a/src/contentscripts/proof/semaphore.ts
+++ b/src/contentscripts/proof/semaphore.ts
@@ -1,0 +1,35 @@
+import ZkIdentityDecorater from "@src/background/identity-decorater";
+import SemaphoreService from "@src/background/services/protocols/semaphore";
+
+import type { SemaphoreProof, SemaphoreProofRequest } from "@src/background/services/protocols/interfaces";
+
+export interface ISemaphoreGenerateArgs {
+  identity: string;
+  payload: SemaphoreProofRequest;
+}
+
+/**
+ * Proof generation is running on content-script side.
+ * It's because it's not possible to send data back to nested web worker from service worker.
+ */
+export class SemaphoreProofGenerator {
+  private static INSTANCE?: SemaphoreProofGenerator;
+
+  private semaphoreService: SemaphoreService;
+
+  private constructor() {
+    this.semaphoreService = new SemaphoreService();
+  }
+
+  static getInstance(): SemaphoreProofGenerator {
+    if (!SemaphoreProofGenerator.INSTANCE) {
+      SemaphoreProofGenerator.INSTANCE = new SemaphoreProofGenerator();
+    }
+
+    return SemaphoreProofGenerator.INSTANCE as SemaphoreProofGenerator;
+  }
+
+  generate({ identity, payload }: ISemaphoreGenerateArgs): Promise<SemaphoreProof> {
+    return this.semaphoreService.genProof(ZkIdentityDecorater.genFromSerialized(identity), payload);
+  }
+}

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -1,33 +1,30 @@
-import * as React from 'react'
+import * as React from "react";
 import ReactDOM from "react-dom/client";
-import { browser, Runtime } from 'webextension-polyfill-ts'
-import Popup from '@src/ui/pages/Popup'
-import { Provider } from 'react-redux'
-import { store } from '@src/ui/store/configureAppStore'
-import { HashRouter } from 'react-router-dom'
-import { isManifestV3 } from '@src/background/shared/checkManifestV3';
-import log from 'loglevel';
+import { browser } from "webextension-polyfill-ts";
+import Popup from "@src/ui/pages/Popup";
+import { Provider } from "react-redux";
+import { store } from "@src/ui/store/configureAppStore";
+import { HashRouter } from "react-router-dom";
+import log from "loglevel";
 
+log.setDefaultLevel(globalThis.CRYPTKEEPER_UI_DEBUG ? "debug" : "info");
 
-log.setDefaultLevel(globalThis.CRYPTKEEPER_UI_DEBUG ? 'debug' : 'info');
-
-
-browser.runtime.onMessage.addListener((action) => {
-    if (action?.type) {
-        store.dispatch(action)
-    }
+browser.runtime.onMessage.addListener(action => {
+  if (action?.type) {
+    store.dispatch(action);
+  }
 });
 
 browser.tabs.query({ active: true, currentWindow: true }).then(() => {
-    browser.runtime.connect();
+  browser.runtime.connect();
 
-    const root = ReactDOM.createRoot(document.getElementById("popup") as HTMLElement);
-    root.render(
-        <Provider store={store}>
-            <HashRouter>
-                <Popup />        
-            </HashRouter>
-        </Provider>
-    );
-    log.debug('CryptKeeper UI initialization complete.');
+  const root = ReactDOM.createRoot(document.getElementById("popup") as HTMLElement);
+  root.render(
+    <Provider store={store}>
+      <HashRouter>
+        <Popup />
+      </HashRouter>
+    </Provider>,
+  );
+  log.debug("CryptKeeper UI initialization complete.");
 });

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,7 +18,7 @@ enum RPCAction {
   GET_REQUEST_PENDING_STATUS = "rpc/identity/getRequestPendingStatus",
   FINALIZE_REQUEST = "rpc/requests/finalize",
   GET_PENDING_REQUESTS = "rpc/requests/get",
-  SEMAPHORE_PROOF = "rpc/protocols/semaphore/genProof",
+  PREPARE_SEMAPHORE_PROOF_REQUEST = "rpc/protocols/semaphore/prepareProofRequest",
   RLN_PROOF = "rpc/protocols/rln/genProof",
   NRLN_PROOF = "rpc/protocols/nrln/genProof",
   DUMMY_REQUEST = "rpc/protocols/semaphore/dummyReuqest",


### PR DESCRIPTION
## Explanation

There is an issue with proof generation because `ffjavascript` in `snarkjs` package creates web workers.
For now it's not supported yet in Manifest V3 to spawn web workers from service worker.

As a solution, I moved semaphore proof generation to content script side to not lose the worker scope.  

Details are bellow:

- [x] Move semaphore proof generation to content script side
- [x] Some prettier and linter fixes

## More Information

Fixes #89

## Screenshots/Screencaps

N/A

## Manual Testing Steps

1. Complete all steps in readme for demo launch
2. Connect with CK extension
3. Try to generate semaphore proof
4. You will see a success message that proof was generated

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)