### PR TITLE
fix: hide activity tab

### DIFF
--- a/src/ui/pages/Home/index.tsx
+++ b/src/ui/pages/Home/index.tsx
@@ -139,14 +139,14 @@ const HomeList = function (): ReactElement {
         >
           Identities
         </div>
-        <div
+        {/* <div
           className={classNames("home__list__header__tab", {
             "home__list__header__tab--selected": selectedTab === "activity",
           })}
           onClick={() => selectTab("activity")}
         >
           Activity
-        </div>
+        </div> */}
       </div>
       <div className="home__list__fix-header">
         <div
@@ -157,14 +157,14 @@ const HomeList = function (): ReactElement {
         >
           Identities
         </div>
-        <div
+        {/* <div
           className={classNames("home__list__header__tab", {
             "home__list__header__tab--selected": selectedTab === "activity",
           })}
           onClick={() => selectTab("activity")}
         >
           Activity
-        </div>
+        </div> */}
       </div>
       <div className="home__list__content">
         {selectedTab === "identities" ? <IdentityList /> : null}


### PR DESCRIPTION
## Explanation

Just hide activity tab on main screen because we don't have activity data.

## More Information

Fixes #97 

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/14254374/220439601-f9c9c9ae-3d2b-44ea-ba57-6ed60f2318fb.png)

### After

![image](https://user-images.githubusercontent.com/14254374/220439485-462f134e-bcb0-491e-a83d-5eea6d87f2ba.png)

## Manual Testing Steps

Just open extension popup and there must be only "Identities" tab.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)