### PR TITLE
feat: delete all identities

### DIFF
--- a/src/background/services/__tests__/identityService.test.ts
+++ b/src/background/services/__tests__/identityService.test.ts
@@ -1,7 +1,7 @@
 import { browser } from "webextension-polyfill-ts";
 
 import { ZERO_ADDRESS } from "@src/config/const";
-import { setIdentities, setSelected } from "@src/ui/ducks/identities";
+import { setSelected } from "@src/ui/ducks/identities";
 import pushMessage from "@src/util/pushMessage";
 
 import IdentityService from "../identity";
@@ -162,9 +162,6 @@ describe("background/services/identity", () => {
       expect(result).toBe(true);
       expect(identityStorage.clear).toBeCalledTimes(1);
       expect(pushMessage).toBeCalledTimes(3);
-      expect(pushMessage).toHaveBeenNthCalledWith(1, setSelected(ZERO_ADDRESS));
-      expect(pushMessage).toHaveBeenNthCalledWith(2, setSelected(""));
-      expect(pushMessage).toHaveBeenNthCalledWith(3, setIdentities([]));
     });
 
     test("should not delete all identities if there is no any identity", async () => {

--- a/src/background/services/__tests__/identityService.test.ts
+++ b/src/background/services/__tests__/identityService.test.ts
@@ -1,0 +1,287 @@
+import { browser } from "webextension-polyfill-ts";
+
+import { ZERO_ADDRESS } from "@src/config/const";
+import { setIdentities, setSelected } from "@src/ui/ducks/identities";
+import pushMessage from "@src/util/pushMessage";
+
+import IdentityService from "../identity";
+import LockService from "../lock";
+import SimpleStorage from "../simpleStorage";
+import ZkIdentityDecorater from "@src/background/identityDecorater";
+import { Identity } from "@semaphore-protocol/identity";
+
+jest.mock("@src/util/pushMessage");
+
+jest.mock("../lock", (): unknown => ({
+  decrypt: jest.fn(),
+  encrypt: jest.fn(),
+}));
+
+jest.mock("../simpleStorage");
+
+describe("background/services/identity", () => {
+  const service = new IdentityService();
+  const defaultTabs = [{ id: 1 }, { id: 2 }];
+  const defaultIdentityCommitment = ZERO_ADDRESS;
+  const defaultIdentities = [[defaultIdentityCommitment, JSON.stringify({ secret: "1234", metadata: {} })]];
+  const serializedDefaultIdentities = JSON.stringify(defaultIdentities);
+
+  beforeEach(() => {
+    (LockService.decrypt as jest.Mock).mockResolvedValue(serializedDefaultIdentities);
+
+    (LockService.encrypt as jest.Mock).mockResolvedValue(serializedDefaultIdentities);
+
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("unlock", () => {
+    test("should unlock properly and set active identity", async () => {
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.unlock();
+
+      expect(result).toBe(true);
+      expect(pushMessage).toBeCalledTimes(1);
+      expect(pushMessage).toBeCalledWith(setSelected(ZERO_ADDRESS));
+      expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
+
+      for (let index = 0; index < defaultTabs.length; index += 1) {
+        expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(
+          index + 1,
+          defaultTabs[index].id,
+          setSelected(ZERO_ADDRESS),
+        );
+      }
+    });
+
+    test("should unlock properly with empty store", async () => {
+      const service = new IdentityService();
+
+      for (const instance of (SimpleStorage as jest.Mock).mock.instances) {
+        instance.get.mockReturnValue(undefined);
+      }
+
+      const result = await service.unlock();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("set active identity", () => {
+    test("should set active identity properly", async () => {
+      const service = new IdentityService();
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.setActiveIdentity(ZERO_ADDRESS);
+
+      expect(result).toBe(true);
+      expect(pushMessage).toBeCalledTimes(1);
+      expect(pushMessage).toBeCalledWith(setSelected(ZERO_ADDRESS));
+      expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
+
+      for (let index = 0; index < defaultTabs.length; index += 1) {
+        expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(
+          index + 1,
+          defaultTabs[index].id,
+          setSelected(ZERO_ADDRESS),
+        );
+      }
+    });
+
+    test("should not set active identity if there is no any saved identities", async () => {
+      const service = new IdentityService();
+
+      for (const instance of (SimpleStorage as jest.Mock).mock.instances) {
+        instance.get.mockReturnValue(undefined);
+      }
+
+      const result = await service.setActiveIdentity(ZERO_ADDRESS);
+
+      expect(result).toBe(false);
+      expect(pushMessage).not.toBeCalled();
+      expect(browser.tabs.sendMessage).not.toBeCalled();
+    });
+  });
+
+  describe("set identity name", () => {
+    test("should set identity name properly", async () => {
+      const service = new IdentityService();
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.setIdentityName({ identityCommitment: ZERO_ADDRESS, name: "New name" });
+
+      expect(result).toBe(true);
+    });
+
+    test("should not set identity name if there is no such identity", async () => {
+      const service = new IdentityService();
+
+      const result = await service.setIdentityName({ identityCommitment: ZERO_ADDRESS, name: "New name" });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("delete identity", () => {
+    test("should delete identity properly", async () => {
+      const service = new IdentityService();
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.deleteIdentity({ identityCommitment: ZERO_ADDRESS });
+
+      expect(result).toBe(true);
+    });
+
+    test("should not delete identity if there is no any identity", async () => {
+      const service = new IdentityService();
+
+      const result = await service.deleteIdentity({ identityCommitment: ZERO_ADDRESS });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("delete all identities", () => {
+    test("should delete all identities properly", async () => {
+      const service = new IdentityService();
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const isIdentitySet = await service.setActiveIdentity(ZERO_ADDRESS);
+      const result = await service.deleteAllIdentities();
+
+      expect(isIdentitySet).toBe(true);
+      expect(result).toBe(true);
+      expect(identityStorage.clear).toBeCalledTimes(1);
+      expect(pushMessage).toBeCalledTimes(3);
+      expect(pushMessage).toHaveBeenNthCalledWith(1, setSelected(ZERO_ADDRESS));
+      expect(pushMessage).toHaveBeenNthCalledWith(2, setSelected(""));
+      expect(pushMessage).toHaveBeenNthCalledWith(3, setIdentities([]));
+    });
+
+    test("should not delete all identities if there is no any identity", async () => {
+      const service = new IdentityService();
+
+      const result = await service.deleteAllIdentities();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("get active identity", () => {
+    test("should get active identity properly", async () => {
+      const service = new IdentityService();
+
+      (LockService.decrypt as jest.Mock)
+        .mockResolvedValueOnce(ZERO_ADDRESS)
+        .mockResolvedValue(serializedDefaultIdentities);
+
+      const [identityStorage, activeIdentityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+      activeIdentityStorage.get.mockReturnValue(ZERO_ADDRESS);
+
+      const result = await service.getActiveIdentity();
+
+      expect(result).toBeDefined();
+    });
+
+    test("should not get active identity if there is no any active identity", async () => {
+      const service = new IdentityService();
+
+      const result = await service.getActiveIdentity();
+
+      expect(result).toBeUndefined();
+    });
+
+    test("should not get active identity if there is no any identity", async () => {
+      const service = new IdentityService();
+
+      (LockService.decrypt as jest.Mock).mockResolvedValueOnce(ZERO_ADDRESS).mockResolvedValue(undefined);
+
+      const [identityStorage, activeIdentityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(undefined);
+      activeIdentityStorage.get.mockReturnValue(ZERO_ADDRESS);
+
+      const result = await service.getActiveIdentity();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("get identities", () => {
+    test("should get identity commitments properly", async () => {
+      const service = new IdentityService();
+
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const { commitments, identities } = await service.getIdentityCommitments();
+
+      expect(commitments).toStrictEqual([ZERO_ADDRESS]);
+      expect(identities.size).toBe(defaultIdentities.length);
+    });
+
+    test("should get identities properly", async () => {
+      const service = new IdentityService();
+
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const identities = await service.getIdentities();
+
+      expect(identities).toHaveLength(defaultIdentities.length);
+    });
+
+    test("should get number of identities properly", async () => {
+      const service = new IdentityService();
+
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.getNumOfIdentites();
+
+      expect(result).toBe(defaultIdentities.length);
+    });
+  });
+
+  describe("insert", () => {
+    test("should insert identity properly", async () => {
+      const service = new IdentityService();
+
+      const result = await service.insert(
+        new ZkIdentityDecorater(new Identity(), {
+          account: ZERO_ADDRESS,
+          name: "Name",
+          identityStrategy: "random",
+        }),
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test("should not insert identity if there is the same identity in the store", async () => {
+      const service = new IdentityService();
+
+      const [identityStorage] = (SimpleStorage as jest.Mock).mock.instances;
+      identityStorage.get.mockReturnValue(serializedDefaultIdentities);
+
+      const result = await service.insert(
+        new ZkIdentityDecorater({ getCommitment: () => defaultIdentityCommitment } as unknown as Identity, {
+          account: ZERO_ADDRESS,
+          name: "Name",
+          identityStrategy: "random",
+        }),
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -1,5 +1,4 @@
 import { bigintToHex } from "bigint-conversion";
-import log from "loglevel";
 import { browser } from "webextension-polyfill-ts";
 
 import { setIdentities, setSelected } from "@src/ui/ducks/identities";
@@ -14,181 +13,124 @@ const IDENTITY_KEY = "@@ID@@";
 const ACTIVE_IDENTITY_KEY = "@@AID@@";
 
 export default class IdentityService {
-  identities: Map<string, string>;
-  activeIdentity?: ZkIdentityDecorater;
-  identitiesStore: SimpleStorage;
-  activeIdentityStore: SimpleStorage;
+  private activeIdentity?: ZkIdentityDecorater;
+  private identitiesStore: SimpleStorage;
+  private activeIdentityStore: SimpleStorage;
 
   constructor() {
-    this.identities = new Map();
     this.activeIdentity = undefined;
     this.identitiesStore = new SimpleStorage(IDENTITY_KEY);
     this.activeIdentityStore = new SimpleStorage(ACTIVE_IDENTITY_KEY);
-    log.debug("IdentityService constructor identities", this.identities);
-    log.debug("IdentityService constructor typeof identities", typeof this.identities);
   }
 
-  unlock = async () => {
+  public unlock = async (): Promise<boolean> => {
     await this.setDefaultIdentity();
-    await pushMessage(setIdentities(await this.getIdentities()));
 
     return true;
   };
 
-  refresh = async () => {
-    // if the first identity just added, set it to active
+  public setActiveIdentity = async (identityCommitment: string): Promise<boolean> => {
     const identities = await this.getIdentitiesFromStore();
-    if (identities.size === 1) {
-      await this.setDefaultIdentity();
+    const identity = identities.get(identityCommitment);
+
+    if (!identity) {
+      return false;
     }
 
-    await pushMessage(setIdentities(await this.getIdentities()));
+    this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identity);
+    await this.writeActiveIdentity(identityCommitment);
+
+    return true;
   };
 
-  setDefaultIdentity = async () => {
+  public setIdentityName = async (payload: IdentityName): Promise<boolean> => {
     const identities = await this.getIdentitiesFromStore();
-
-    if (!identities.size) {
-      await this.clearActiveIdentity();
-      return;
-    }
-
-    const { value: firstKey } = identities.keys().next();
-
-    await this.setActiveIdentity(firstKey);
-  };
-
-  setActiveIdentity = async (identityCommitment: string) => {
-    const identities = await this.getIdentitiesFromStore();
-
-    if (identities.has(identityCommitment)) {
-      this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identities.get(identityCommitment) as string);
-      await this.saveActiveIdentity(identityCommitment);
-    }
-  };
-
-  setIdentityName = async (payload: IdentityName): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
-
-    log.debug("payload", payload);
     const { identityCommitment, name } = payload;
-    log.debug("payload commitment", identityCommitment);
-    log.debug("payload name", name);
-    const id = identities.get(identityCommitment);
+    const rawIdentity = identities.get(identityCommitment);
 
-    if (id) {
-      const identity = ZkIdentityDecorater.genFromSerialized(id);
-      identity.setIdentityMetadataName(name);
-      identities.set(identityCommitment, identity.serialize());
-
-      const serializedIdentities = JSON.stringify(Array.from(identities.entries()));
-      const cipertext = await LockService.encrypt(serializedIdentities);
-      await this.identitiesStore.set(cipertext);
-      await pushMessage(setIdentities(await this.getIdentities()));
-
-      return true;
-    } else {
-      log.debug("setIdentityName id not exist");
+    if (!rawIdentity) {
       return false;
     }
+
+    const identity = ZkIdentityDecorater.genFromSerialized(rawIdentity);
+    identity.setIdentityMetadataName(name);
+    identities.set(identityCommitment, identity.serialize());
+    await this.writeIdentities(identities);
+    await this.refresh();
+
+    return true;
   };
 
-  deleteIdentity = async (payload: any): Promise<boolean> => {
+  public deleteIdentity = async (payload: { identityCommitment: string }): Promise<boolean> => {
+    const { identityCommitment } = payload;
     const identities = await this.getIdentitiesFromStore();
 
-    const { identityCommitment } = payload;
-    const id = identities.get(identityCommitment);
-    if (id) {
-      log.debug("deleteIdentity id deleted");
-      identities.delete(identityCommitment);
-
-      const serializedIdentities = JSON.stringify(Array.from(identities.entries()));
-      const cipertext = await LockService.encrypt(serializedIdentities);
-      await this.identitiesStore.set(cipertext);
-      await this.setDefaultIdentity();
-      await pushMessage(setIdentities(await this.getIdentities()));
-
-      return true;
-    } else {
-      log.debug("deleteIdentity id is not deleted");
+    if (!identities.has(identityCommitment)) {
       return false;
     }
+
+    identities.delete(identityCommitment);
+    await this.writeIdentities(identities);
+
+    await this.setDefaultIdentity();
+    await this.refresh();
+
+    return true;
   };
 
-  deleteAllIdentities = async () => {
+  public deleteAllIdentities = async (): Promise<boolean> => {
     const identities = await this.getIdentitiesFromStore();
 
     if (!identities.size) {
-      return;
+      return false;
     }
 
     await this.identitiesStore.clear();
     await this.clearActiveIdentity();
     await pushMessage(setIdentities([]));
+
+    return true;
   };
 
-  private clearActiveIdentity = async () => {
-    if (!this.activeIdentity) {
-      return;
-    }
-
-    this.activeIdentity = undefined;
-    await this.saveActiveIdentity("");
-  };
-
-  private saveActiveIdentity = async (commitment: string) => {
-    const identityCommitmentCipher = await LockService.encrypt(commitment);
-    await this.activeIdentityStore.set(identityCommitmentCipher);
-    await pushMessage(setSelected(commitment));
-
-    const tabs = await browser.tabs.query({ active: true });
-    for (const tab of tabs) {
-      await browser.tabs.sendMessage(tab.id as number, setSelected(commitment));
-    }
-  };
-
-  getActiveIdentity = async (): Promise<ZkIdentityDecorater | undefined> => {
+  public getActiveIdentity = async (): Promise<ZkIdentityDecorater | undefined> => {
     const acitveIdentityCommitmentCipher = await this.activeIdentityStore.get<string>();
 
     if (!acitveIdentityCommitmentCipher) {
       return undefined;
     }
 
-    const acitveIdentityCommitment = await LockService.decrypt(acitveIdentityCommitmentCipher);
+    const activeIdentityCommitment = await LockService.decrypt(acitveIdentityCommitmentCipher);
     const identities = await this.getIdentitiesFromStore();
+    const identity = identities.get(activeIdentityCommitment);
 
-    if (identities.has(acitveIdentityCommitment)) {
-      this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identities.get(acitveIdentityCommitment) as string);
-
-      return this.activeIdentity;
+    if (!identity) {
+      return undefined;
     }
 
-    return undefined;
+    this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identity);
+
+    return this.activeIdentity;
   };
 
-  getIdentityCommitments = async () => {
+  public getIdentityCommitments = async (): Promise<{ commitments: string[]; identities: Map<string, string> }> => {
     const commitments: string[] = [];
     const identities = await this.getIdentitiesFromStore();
 
     for (const key of identities.keys()) {
-      log.debug("getIdentityCOmmitments: ", key);
       commitments.push(key);
     }
 
     return { commitments, identities };
   };
 
-  getIdentities = async (): Promise<{ commitment: string; metadata: IdentityMetadata }[]> => {
+  public getIdentities = async (): Promise<{ commitment: string; metadata: IdentityMetadata }[]> => {
     const { commitments, identities } = await this.getIdentityCommitments();
-    log.debug("IdentityService getIdentities: ", commitments);
 
     return commitments
-      .filter(commitment => typeof identities.get(commitment) != undefined)
+      .filter(commitment => identities.has(commitment))
       .map(commitment => {
         const serializedIdentity = identities.get(commitment) as string;
         const identity = ZkIdentityDecorater.genFromSerialized(serializedIdentity);
-        log.debug("getIdentities: commitments", commitments);
-        log.debug("getIdentities: metadata", identity?.metadata);
 
         return {
           commitment,
@@ -197,56 +139,77 @@ export default class IdentityService {
       });
   };
 
-  insert = async (newIdentity: ZkIdentityDecorater): Promise<boolean> => {
-    log.debug("IdentityService insert newIdentity", newIdentity);
-    log.debug("IdentityService insert typeof newIdentity", typeof newIdentity);
+  public insert = async (newIdentity: ZkIdentityDecorater): Promise<boolean> => {
     const identities = await this.getIdentitiesFromStore();
-    log.debug("IdentityService insert identities:", identities);
-    log.debug(`IdentityService insert type identities: ${typeof identities}`);
     const identityCommitment = bigintToHex(newIdentity.genIdentityCommitment());
-    const existing = identities.has(identityCommitment);
 
-    if (existing) {
+    if (identities.has(identityCommitment)) {
       return false;
     }
 
     identities.set(identityCommitment, newIdentity.serialize());
-    const serializedIdentities = JSON.stringify(Array.from(identities.entries()));
-    const cipertext = await LockService.encrypt(serializedIdentities);
-    await this.identitiesStore.set(cipertext);
+    await this.writeIdentities(identities);
 
-    log.debug("IdentityService ciphertext value 1");
-    await this.refresh();
-    log.debug("IdentityService ciphertext value 2");
     await this.setActiveIdentity(identityCommitment);
-    log.debug("IdentityService ciphertext value 3");
+    await this.refresh();
+
     return true;
   };
 
-  getNumOfIdentites = async (): Promise<number> => {
+  public getNumOfIdentites = async (): Promise<number> => {
     const identities = await this.getIdentitiesFromStore();
     return identities.size;
   };
 
-  async getIdentitiesFromStore(): Promise<Map<string, string>> {
-    const cipertext = await this.identitiesStore.get<string>();
+  private setDefaultIdentity = async (): Promise<void> => {
+    const identities = await this.getIdentitiesFromStore();
 
-    log.debug("IdentityService getIdentitiesFromStore EXIST cipertext 1", cipertext);
-    log.debug("IdentityService getIdentitiesFromStore EXIST cipertext 2", typeof cipertext);
-    log.debug("IdentityService getIdentitiesFromStore EXIST cipertext 3", JSON.stringify(cipertext));
+    if (!identities.size) {
+      await this.clearActiveIdentity();
+      return;
+    }
 
-    if (cipertext) {
-      const identitesDecrepted = await LockService.decrypt(cipertext);
-      log.debug("IdentityService getIdentitiesFromStore EXIST identitesDecrepted 1" + identitesDecrepted);
-      log.debug(typeof identitesDecrepted);
-      log.debug(identitesDecrepted);
-      log.debug("IdentityService getIdentitiesFromStore EXIST identitesDecrepted 2");
-      const identitiesParsed = JSON.parse(identitesDecrepted);
-      log.debug("IdentityService getIdentitiesFromStore EXIST identitiesParsed" + identitiesParsed);
-      return new Map(identitiesParsed);
-    } else {
-      log.debug("IdentityService getIdentitiesFromStore NEW identitesObj", cipertext);
+    const { value: firstCommitment } = identities.keys().next();
+    await this.setActiveIdentity(firstCommitment);
+  };
+
+  private clearActiveIdentity = async (): Promise<void> => {
+    if (!this.activeIdentity) {
+      return;
+    }
+
+    this.activeIdentity = undefined;
+    await this.writeActiveIdentity("");
+  };
+
+  private writeIdentities = async (identities: Map<string, string>): Promise<void> => {
+    const serializedIdentities = JSON.stringify(Array.from(identities.entries()));
+    const cipherText = await LockService.encrypt(serializedIdentities);
+    await this.identitiesStore.set(cipherText);
+  };
+
+  private writeActiveIdentity = async (commitment: string): Promise<void> => {
+    const cipherText = await LockService.encrypt(commitment);
+    await this.activeIdentityStore.set(cipherText);
+    await pushMessage(setSelected(commitment));
+
+    const tabs = await browser.tabs.query({ active: true });
+    await Promise.all(tabs.map(tab => browser.tabs.sendMessage(tab.id as number, setSelected(commitment))));
+  };
+
+  private getIdentitiesFromStore = async (): Promise<Map<string, string>> => {
+    const cipherText = await this.identitiesStore.get<string>();
+
+    if (!cipherText) {
       return new Map();
     }
-  }
+
+    const identitesDecrypted = await LockService.decrypt(cipherText);
+    return new Map(JSON.parse(identitesDecrypted));
+  };
+
+  private refresh = async (): Promise<void> => {
+    const identities = await this.getIdentities();
+    await pushMessage(setIdentities(identities));
+  };
 }

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -85,9 +85,7 @@ export default class IdentityService {
       return false;
     }
 
-    await this.identitiesStore.clear();
-    await this.clearActiveIdentity();
-    await pushMessage(setIdentities([]));
+    await Promise.all([pushMessage(setIdentities([])), this.clearActiveIdentity(), this.identitiesStore.clear()]);
 
     return true;
   };

--- a/src/background/services/simpleStorage.ts
+++ b/src/background/services/simpleStorage.ts
@@ -17,16 +17,16 @@ export default class SimpleStorage {
     });
   }
 
-  get = async <T>(): Promise<T | null> => {
+  public async get<T>(): Promise<T | null> {
     const content = await browser.storage.sync.get(this.key);
     return content?.[this.key] ?? null;
-  };
+  }
 
-  set = async <T>(value: T): Promise<void> => {
+  public async set<T>(value: T): Promise<void> {
     browser.storage.sync.set({ [this.key]: value });
-  };
+  }
 
-  clear = async (): Promise<void> => {
+  public async clear(): Promise<void> {
     browser.storage.sync.remove(this.key);
-  };
+  }
 }

--- a/src/background/zkKeeper.ts
+++ b/src/background/zkKeeper.ts
@@ -108,9 +108,7 @@ export default class ZkKeeperController extends Handler {
       this.identityService.deleteIdentity(payload),
     );
 
-    this.add(RPCAction.DELETE_ALL_IDENTITIES, LockService.ensure, async () =>
-      this.identityService.deleteAllIdentities(),
-    );
+    this.add(RPCAction.DELETE_ALL_IDENTITIES, LockService.ensure, this.identityService.deleteAllIdentities);
 
     this.add(RPCAction.GET_ACTIVE_IDENTITY, LockService.ensure, async () => {
       const identity = await this.identityService.getActiveIdentity();

--- a/src/background/zkKeeper.ts
+++ b/src/background/zkKeeper.ts
@@ -103,11 +103,15 @@ export default class ZkKeeperController extends Handler {
       LockService.ensure,
       async (payload: IdentityName) => await this.identityService.setIdentityName(payload),
     );
-    this.add(
-      RPCAction.DELETE_IDENTITY,
-      LockService.ensure,
-      async (payload: IdentityName) => await this.identityService.deleteIdentity(payload),
+
+    this.add(RPCAction.DELETE_IDENTITY, LockService.ensure, async (payload: IdentityName) =>
+      this.identityService.deleteIdentity(payload),
     );
+
+    this.add(RPCAction.DELETE_ALL_IDENTITIES, LockService.ensure, async () =>
+      this.identityService.deleteAllIdentities(),
+    );
+
     this.add(RPCAction.GET_ACTIVE_IDENTITY, LockService.ensure, async () => {
       const identity = await this.identityService.getActiveIdentity();
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -18,6 +18,10 @@ jest.mock("webextension-polyfill-ts", (): unknown => {
 
   return {
     browser: {
+      tabs: {
+        query: jest.fn(),
+        sendMessage: jest.fn(),
+      },
       storage: {
         sync: {
           get: jest.fn(),

--- a/src/ui/ducks/identities.ts
+++ b/src/ui/ducks/identities.ts
@@ -85,6 +85,12 @@ export const deleteIdentity = (identityCommitment: string) => async (dispatch: A
   });
 };
 
+export const deleteAllIdentities = () => async (dispatch: AppDispatch) => {
+  return postMessage({
+    method: RPCAction.DELETE_ALL_IDENTITIES,
+  });
+};
+
 export const setSelected = (identityCommitment: string) => ({
   type: ActionType.SET_SELECTED,
   payload: identityCommitment,

--- a/src/ui/pages/Home/home.scss
+++ b/src/ui/pages/Home/home.scss
@@ -18,10 +18,6 @@
     }
 
     &--fixed-menu {
-      .home__list__header {
-        //display: none;
-      }
-
       .home__list__fix-header {
         display: flex;
         position: absolute;
@@ -84,7 +80,7 @@
 
       &__tab {
         @extend %row-nowrap;
-        justify-content: center;
+        justify-content: space-between;
         align-items: center;
         flex: 1 1 auto;
         cursor: pointer;

--- a/src/ui/pages/Home/index.tsx
+++ b/src/ui/pages/Home/index.tsx
@@ -125,8 +125,8 @@ const HomeList = function (): ReactElement {
   const dispatch = useAppDispatch();
   const [selectedTab, selectTab] = useState<"identities" | "activity">("identities");
 
-  const onDeleteAllIdentities = useCallback(async () => {
-    await dispatch(deleteAllIdentities());
+  const onDeleteAllIdentities = useCallback(() => {
+    dispatch(deleteAllIdentities());
   }, [dispatch]);
 
   return (

--- a/src/ui/pages/Home/index.tsx
+++ b/src/ui/pages/Home/index.tsx
@@ -1,13 +1,15 @@
 import { ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import postMessage from "@src/util/postMessage";
 import RPCAction from "@src/util/constants";
-import { fetchIdentities } from "@src/ui/ducks/identities";
+import { deleteAllIdentities, fetchIdentities } from "@src/ui/ducks/identities";
 import Header from "@src/ui/components/Header";
 import classNames from "classnames";
 import { browser } from "webextension-polyfill-ts";
 import "./home.scss";
 import { sliceAddress } from "@src/util/account";
 import ConnectionModal from "@src/ui/components/ConnectionModal";
+import Icon from "@src/ui/components/Icon";
+import Menuable from "@src/ui/components/Menuable";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { metamask } from "@src/connectors";
 import { useWallet } from "@src/ui/hooks/wallet";
@@ -120,7 +122,12 @@ const HomeInfo = function (): ReactElement {
 };
 
 const HomeList = function (): ReactElement {
+  const dispatch = useAppDispatch();
   const [selectedTab, selectTab] = useState<"identities" | "activity">("identities");
+
+  const onDeleteAllIdentities = useCallback(async () => {
+    await dispatch(deleteAllIdentities());
+  }, [dispatch]);
 
   return (
     <div className="home__list">
@@ -131,7 +138,11 @@ const HomeList = function (): ReactElement {
           })}
           onClick={() => selectTab("identities")}
         >
-          Identities
+          <span>Identities</span>
+
+          <Menuable className="flex user-menu" items={[{ label: "Delete all", onClick: onDeleteAllIdentities }]}>
+            <Icon className="identity-row__menu-icon" fontAwesome="fas fa-ellipsis-h" />
+          </Menuable>
         </div>
         {/* <div
           className={classNames("home__list__header__tab", {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -12,6 +12,7 @@ enum RPCAction {
   SET_ACTIVE_IDENTITY = "rpc/identity/setActiveIdentity",
   SET_IDENTITY_NAME = "rpc/identity/setIdentityName",
   DELETE_IDENTITY = "rpc/identity/deleteIdentity",
+  DELETE_ALL_IDENTITIES = "rpc/identity/deleteAllIdentities",
   GET_ACTIVE_IDENTITY = "rpc/identity/getActiveidentity",
   GET_COMMITMENTS = "rpc/identity/getIdentityCommitments",
   GET_IDENTITIES = "rpc/identity/getIdentities",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./",
     "rootDir": "./",
     "paths": {
-      "@src/*": ["src/*"],
+      "@src/*": ["src/*"]
     },
     "typeRoots": ["./node_modules/@types", "./src/custom.d.ts"],
     "target": "ES2020",


### PR DESCRIPTION
## Explanation

This PR adds support for removing all the identities and setting active identity when removing.

Details are below:
- [x] Add menu for Identities tab on Home screen
- [x] Support RPC method for removing all the identities
- [x] Set active identity after removing or clear if there is no any identities

## More Information

Closes #27 

## Screenshots/Screencaps

### Before

N/A

### After

![image](https://user-images.githubusercontent.com/14254374/222538000-04134efe-80a0-453d-a472-33406ca0cb19.png)

## Manual Testing Steps

1. Reinstall extension
2. Create identities
3. Try to delete all of them

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
