### PR TITLE
feat: add notifications service and permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,3 @@ Proof generation is enabled in two ways:
 1. `npm run dev`
 2. `npm run merkle`
 3. `cd demo && npm run start`
-
-To run the demo and generate proofs, you additionally need the circuit files for Semaphore and RLN. For compatible Semaphore and RLN zk files you can use the following [link](https://drive.google.com/file/d/1Yi14jwly70VwMSuqJrPCc3j15MWeE7mc/view?usp=sharing).
-Please extract the files into a directory named `zkeyFiles` at the root of this repository.

--- a/src/background/services/__tests__/notificationService.test.ts
+++ b/src/background/services/__tests__/notificationService.test.ts
@@ -1,0 +1,48 @@
+import { browser } from "webextension-polyfill-ts";
+import NotificationService, { CreateNotificationArgs } from "../notification";
+
+describe("background/services/notification", () => {
+  const defaultId = "1";
+  const defaultTabs = [{ id: 1 }, { id: 2 }];
+  const defaultCreateArgs: CreateNotificationArgs = {
+    id: defaultId,
+    options: {
+      title: "Title",
+      message: "Message",
+      iconUrl: "/icon.png",
+      type: "basic",
+    },
+  };
+
+  beforeEach(() => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+
+    (browser.notifications.create as jest.Mock).mockResolvedValue(defaultId);
+
+    (browser.notifications.clear as jest.Mock).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("create", () => {
+    test("should create notification properly", async () => {
+      const service = NotificationService.getInstance();
+      const result = await service.create(defaultCreateArgs);
+
+      expect(result).toStrictEqual([defaultId, defaultId]);
+    });
+  });
+
+  describe("clear", () => {
+    test("should clear notification properly", async () => {
+      const service = NotificationService.getInstance();
+      await service.create(defaultCreateArgs);
+
+      const result = await service.clear(defaultId);
+
+      expect(result).toStrictEqual([true, true]);
+    });
+  });
+});

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -3,6 +3,7 @@ import { browser } from "webextension-polyfill-ts";
 
 import { setIdentities, setSelected } from "@src/ui/ducks/identities";
 import pushMessage from "@src/util/pushMessage";
+import { ellipsify } from "@src/util/account";
 import { IdentityMetadata, IdentityName } from "@src/types";
 
 import ZkIdentityDecorater from "../identityDecorater";
@@ -156,7 +157,7 @@ export default class IdentityService {
     await this.notificationService.create({
       options: {
         title: "New identity has been created.",
-        message: `Identity commitment: ${identityCommitment}`,
+        message: `Identity commitment: ${ellipsify(identityCommitment)}`,
         iconUrl: browser.runtime.getURL("/logo.png"),
         type: "basic",
       },

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -8,6 +8,7 @@ import { IdentityMetadata, IdentityName } from "@src/types";
 import ZkIdentityDecorater from "../identityDecorater";
 import SimpleStorage from "./simpleStorage";
 import LockService from "./lock";
+import NotificationService from "./notification";
 
 const IDENTITY_KEY = "@@ID@@";
 const ACTIVE_IDENTITY_KEY = "@@AID@@";
@@ -17,12 +18,14 @@ export default class IdentityService {
   private identitiesStore: SimpleStorage;
   private activeIdentityStore: SimpleStorage;
   private lockService: LockService;
+  private notificationService: NotificationService;
 
   constructor() {
     this.activeIdentity = undefined;
     this.identitiesStore = new SimpleStorage(IDENTITY_KEY);
     this.activeIdentityStore = new SimpleStorage(ACTIVE_IDENTITY_KEY);
     this.lockService = LockService.getInstance();
+    this.notificationService = NotificationService.getInstance();
   }
 
   public unlock = async (): Promise<boolean> => {
@@ -149,6 +152,15 @@ export default class IdentityService {
 
     identities.set(identityCommitment, newIdentity.serialize());
     await this.writeIdentities(identities);
+
+    await this.notificationService.create({
+      options: {
+        title: "New identity has been created.",
+        message: `Identity commitment: ${identityCommitment}`,
+        iconUrl: browser.runtime.getURL("/logo.png"),
+        type: "basic",
+      },
+    });
 
     await this.setActiveIdentity(identityCommitment);
     await this.refresh();

--- a/src/background/services/notification.ts
+++ b/src/background/services/notification.ts
@@ -1,0 +1,43 @@
+import { browser } from "webextension-polyfill-ts";
+
+export interface CreateNotificationArgs {
+  id?: string;
+  options: {
+    title: string;
+    message: string;
+    type: "basic" | "image" | "list" | "progress";
+    iconUrl?: string;
+  };
+}
+
+export default class NotificationService {
+  private static INSTANCE: NotificationService;
+
+  private constructor() {
+    //
+  }
+
+  public static getInstance(): NotificationService {
+    if (!NotificationService.INSTANCE) {
+      NotificationService.INSTANCE = new NotificationService();
+    }
+
+    return NotificationService.INSTANCE;
+  }
+
+  public create = async ({ id, options }: CreateNotificationArgs): Promise<string[]> => {
+    const tabs = await this.getTabs();
+    const notificationIds = await Promise.all(tabs.map(() => browser.notifications.create(id, options)));
+
+    return notificationIds;
+  };
+
+  public clear = async (id: string): Promise<boolean[]> => {
+    const tabs = await this.getTabs();
+    const result = await Promise.all(tabs.map(() => browser.notifications.clear(id)));
+
+    return result;
+  };
+
+  private getTabs = async (): Promise<{ id?: number }[]> => browser.tabs.query({ active: true });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,7 +27,7 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
   },
-  "permissions": ["clipboardWrite", "activeTab", "storage"],
+  "permissions": ["clipboardWrite", "activeTab", "storage", "notifications"],
   "host_permissions": ["http://*/", "https://*/"],
   "web_accessible_resources": [
     {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -12,7 +12,7 @@ jest.mock("loglevel", () => ({
 type Changes = Record<string, { oldValue: string | null; newValue: string | null }>;
 
 jest.mock("webextension-polyfill-ts", (): unknown => {
-  const listeners: ((changes: Changes, namespace: string) => void)[] = [];
+  const storageListeners: ((changes: Changes, namespace: string) => void)[] = [];
   const namespace = "namespace";
   const defaultChanges = { key: { oldValue: null, newValue: null } };
 
@@ -22,19 +22,29 @@ jest.mock("webextension-polyfill-ts", (): unknown => {
         query: jest.fn(),
         sendMessage: jest.fn(),
       },
+
+      runtime: {
+        getURL: jest.fn(),
+      },
+
+      notifications: {
+        create: jest.fn(),
+        clear: jest.fn(),
+      },
+
       storage: {
         sync: {
           get: jest.fn(),
           set: jest.fn().mockImplementation(() => {
-            listeners.forEach(listener => listener(defaultChanges, namespace));
+            storageListeners.forEach(listener => listener(defaultChanges, namespace));
           }),
           remove: jest.fn().mockImplementation(() => {
-            listeners.forEach(listener => listener(defaultChanges, namespace));
+            storageListeners.forEach(listener => listener(defaultChanges, namespace));
           }),
         },
         onChanged: {
           addListener: (fun: () => void) => {
-            listeners.push(fun);
+            storageListeners.push(fun);
           },
         },
       },


### PR DESCRIPTION
## Explanation

This PR adds Notification service and notification for generated identity.
Notification service uses rich notification api.

## More Information

Closes #33 

## Screenshots/Screencaps

### Before

N/A

### After

![image](https://user-images.githubusercontent.com/14254374/223853193-1a6c9031-ebf3-47e5-9fa0-0d949a6b08b9.png)


## Manual Testing Steps

Try to create new identity and see a notification with identity commitment

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
