### PR TITLE
refactor: request modals

### DIFF
--- a/src/config/mock/modal.ts
+++ b/src/config/mock/modal.ts
@@ -1,0 +1,10 @@
+export const createModalRoot = (): void => {
+  const container = document.createElement("div");
+  container.id = "modal";
+  document.body.append(container);
+};
+
+export const deleteModalRoot = (): void => {
+  const container = document.getElementById("modal");
+  document.body.removeChild(container as HTMLElement);
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -9,6 +9,14 @@ jest.mock("loglevel", () => ({
   error: jest.fn(),
 }));
 
+jest.mock("link-preview-js", (): unknown => ({
+  getLinkPreview: jest.fn().mockResolvedValue({
+    favicons: ["http://localhost:3000/favicon.ico"],
+  }),
+}));
+
+jest.mock("@src/util/postMessage");
+
 type Changes = Record<string, { oldValue: string | null; newValue: string | null }>;
 
 jest.mock("webextension-polyfill-ts", (): unknown => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,16 @@ export type ZkInputs = {
   merkleProof?: MerkleProof;
 };
 
+export interface ProofPayload {
+  externalNullifier: string;
+  signal: string;
+  merkleStorageAddress?: string;
+  circuitFilePath: string;
+  verificationKey: string;
+  zkeyFilePath: string;
+  origin: string;
+}
+
 export enum PendingRequestType {
   SEMAPHORE_PROOF,
   RLN_PROOF,
@@ -43,11 +53,11 @@ export enum PendingRequestType {
   INJECT,
 }
 
-export type PendingRequest = {
+export interface PendingRequest<P = unknown> {
   id: string;
   type: PendingRequestType;
-  payload?: unknown;
-};
+  payload?: P;
+}
 
 export type RequestResolutionAction<data> = {
   id: string;

--- a/src/ui/components/Checkbox/index.tsx
+++ b/src/ui/components/Checkbox/index.tsx
@@ -7,18 +7,19 @@ import "./index.scss";
 
 export interface CheckboxProps {
   checked: boolean;
+  id: string;
   className?: string;
   disabled?: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
-export const Checkbox = ({ className, checked, onChange, disabled }: CheckboxProps): JSX.Element => (
+export const Checkbox = ({ id, className, checked, onChange, disabled }: CheckboxProps): JSX.Element => (
   <div
     className={classNames("checkbox", className, {
       "checkbox--checked": checked,
     })}
   >
-    <input checked={checked} disabled={disabled} type="checkbox" onChange={onChange} />
+    <input checked={checked} disabled={disabled} id={id} type="checkbox" onChange={onChange} />
 
     <Icon fontAwesome="fa-check" />
   </div>

--- a/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/ConnectionApprovalModal.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/ConnectionApprovalModal.tsx
@@ -1,0 +1,84 @@
+import { PendingRequest } from "@src/types";
+import { ButtonType, Button } from "@src/ui/components/Button";
+import { Checkbox } from "@src/ui/components/Checkbox";
+import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
+
+import "../../confirm-modal.scss";
+
+import { useConnectionApprovalModal } from "./useConnectionApprovalModal";
+
+export interface ConnectionApprovalModalProps {
+  len: number;
+  loading: boolean;
+  error: string;
+  pendingRequest: PendingRequest<{ origin: string }>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export const ConnectionApprovalModal = ({
+  len,
+  pendingRequest,
+  error,
+  loading,
+  accept,
+  reject,
+}: ConnectionApprovalModalProps): JSX.Element => {
+  const { checked, host, faviconUrl, onAccept, onReject, onSetApproval } = useConnectionApprovalModal({
+    pendingRequest,
+    accept,
+    reject,
+  });
+
+  return (
+    <FullModal className="confirm-modal" data-testid="approval-modal" onClose={onReject}>
+      <FullModalHeader>
+        Connect with CryptKeeper
+        {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
+      </FullModalHeader>
+
+      <FullModalContent className="flex flex-col items-center">
+        <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0">
+          <div
+            className="w-16 h-16"
+            style={{
+              backgroundSize: "contain",
+              backgroundPosition: "center",
+              backgroundRepeat: "no-repeat",
+              backgroundImage: `url(${faviconUrl})`,
+            }}
+          />
+        </div>
+
+        <div className="text-lg font-semibold mb-2 text-center">{`${host} would like to connect to your identity`}</div>
+
+        <div className="text-sm text-gray-500 text-center">
+          This site is requesting access to view your current identity. Always make sure you trust the site you interact
+          with.
+        </div>
+
+        <div className="font-bold mt-4">Permissions</div>
+
+        <div className="flex flex-row items-start">
+          <Checkbox checked={checked} className="mr-2 mt-2 flex-shrink-0" id="approval" onChange={onSetApproval} />
+
+          <label className="text-sm mt-2" htmlFor="approval">
+            Allow host to create proof without approvals
+          </label>
+        </div>
+      </FullModalContent>
+
+      {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
+
+      <FullModalFooter>
+        <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={onReject}>
+          Reject
+        </Button>
+
+        <Button className="ml-2" loading={loading} onClick={onAccept}>
+          Approve
+        </Button>
+      </FullModalFooter>
+    </FullModal>
+  );
+};

--- a/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/ConnectionApprovalModal.test.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/ConnectionApprovalModal.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from "@testing-library/react";
+
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
+import { PendingRequestType } from "@src/types";
+
+import { ConnectionApprovalModal, ConnectionApprovalModalProps } from "..";
+import { useConnectionApprovalModal, IUseConnectionApprovalModalData } from "../useConnectionApprovalModal";
+
+jest.mock("../useConnectionApprovalModal", (): unknown => ({
+  useConnectionApprovalModal: jest.fn(),
+}));
+
+describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal", () => {
+  const defaultProps: ConnectionApprovalModalProps = {
+    len: 1,
+    loading: false,
+    error: "",
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.APPROVE,
+      payload: { origin: "http://localhost:3000" },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const defaultHookData: IUseConnectionApprovalModalData = {
+    host: "http://localhost:3000",
+    checked: false,
+    faviconUrl: "http://localhost:3000/favicon.ico",
+    onAccept: jest.fn(),
+    onReject: jest.fn(),
+    onSetApproval: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useConnectionApprovalModal as jest.Mock).mockReturnValue(defaultHookData);
+
+    createModalRoot();
+  });
+
+  afterEach(() => {
+    deleteModalRoot();
+  });
+
+  test("should render properly", async () => {
+    render(<ConnectionApprovalModal {...defaultProps} />);
+
+    const modal = await screen.findByTestId("approval-modal");
+
+    expect(modal).toBeInTheDocument();
+  });
+
+  test("should render properly with error", async () => {
+    render(<ConnectionApprovalModal {...defaultProps} error="Error" len={2} />);
+
+    const error = await screen.findByText("Error");
+
+    expect(error).toBeInTheDocument();
+  });
+
+  test("should accept approval properly", async () => {
+    render(<ConnectionApprovalModal {...defaultProps} />);
+
+    const button = await screen.findByText("Approve");
+    act(() => button.click());
+
+    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+  });
+
+  test("should reject approval properly", async () => {
+    render(<ConnectionApprovalModal {...defaultProps} />);
+
+    const button = await screen.findByText("Reject");
+    act(() => button.click());
+
+    expect(defaultHookData.onReject).toBeCalledTimes(1);
+  });
+
+  test("should select permanent approval properly", async () => {
+    render(<ConnectionApprovalModal {...defaultProps} />);
+
+    const label = await screen.findByLabelText("Allow host to create proof without approvals");
+    act(() => label.click());
+
+    expect(defaultHookData.onSetApproval).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/useConnectionApprovalModal.test.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/useConnectionApprovalModal.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { RPCAction } from "@src/constants";
+import { PendingRequestType } from "@src/types";
+import postMessage from "@src/util/postMessage";
+
+import type { ChangeEvent } from "react";
+
+import { IUseConnectionApprovalModalArgs, useConnectionApprovalModal } from "../useConnectionApprovalModal";
+
+describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/useConnectionApprovalModal", () => {
+  const defaultArgs: IUseConnectionApprovalModalArgs = {
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.APPROVE,
+      payload: { origin: "http://localhost:3000" },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const defaultPostMessageResponse = { noApproval: true };
+
+  beforeEach(() => {
+    (postMessage as jest.Mock).mockResolvedValue(defaultPostMessageResponse);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return empty data", () => {
+    const { result } = renderHook(() =>
+      useConnectionApprovalModal({ ...defaultArgs, pendingRequest: { id: "1", type: PendingRequestType.APPROVE } }),
+    );
+
+    expect(result.current.checked).toBe(false);
+    expect(result.current.faviconUrl).toBe("");
+    expect(result.current.host).toBe("");
+  });
+
+  test("should return initial data", async () => {
+    const { result } = renderHook(() => useConnectionApprovalModal(defaultArgs));
+    await waitFor(() => result.current.checked === true);
+
+    expect(result.current.checked).toBe(true);
+    expect(result.current.faviconUrl).toBe("http://localhost:3000/favicon.ico");
+    expect(result.current.host).toBe(defaultArgs.pendingRequest.payload?.origin);
+  });
+
+  test("should accept approval properly", async () => {
+    const { result } = renderHook(() => useConnectionApprovalModal(defaultArgs));
+    await waitFor(() => result.current.checked === true);
+
+    act(() => result.current.onAccept());
+
+    expect(defaultArgs.accept).toBeCalledTimes(1);
+  });
+
+  test("should reject approval properly", async () => {
+    const { result } = renderHook(() => useConnectionApprovalModal(defaultArgs));
+    await waitFor(() => result.current.checked === true);
+
+    act(() => result.current.onReject());
+
+    expect(defaultArgs.reject).toBeCalledTimes(1);
+  });
+
+  test("should set approval properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue({ ...defaultPostMessageResponse, noApproval: false });
+
+    const { result } = renderHook(() => useConnectionApprovalModal(defaultArgs));
+    await waitFor(() => result.current.checked === true);
+
+    act(() => result.current.onSetApproval({ target: { checked: false } } as ChangeEvent<HTMLInputElement>));
+    await waitFor(() => result.current.checked === false);
+
+    expect(postMessage).toBeCalledTimes(2);
+    expect(postMessage).toHaveBeenNthCalledWith(1, {
+      method: RPCAction.GET_HOST_PERMISSIONS,
+      payload: defaultArgs.pendingRequest.payload?.origin,
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(2, {
+      method: RPCAction.SET_HOST_PERMISSIONS,
+      payload: {
+        host: defaultArgs.pendingRequest.payload?.origin,
+        noApproval: false,
+      },
+    });
+  });
+});

--- a/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/index.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConnectionApprovalModal";

--- a/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/useConnectionApprovalModal.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/useConnectionApprovalModal.ts
@@ -1,0 +1,78 @@
+import { getLinkPreview } from "link-preview-js";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
+
+import { RPCAction } from "@src/constants";
+import { PendingRequest } from "@src/types";
+import postMessage from "@src/util/postMessage";
+
+export interface IUseConnectionApprovalModalArgs {
+  pendingRequest: PendingRequest<{ origin: string }>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export interface IUseConnectionApprovalModalData {
+  host: string;
+  checked: boolean;
+  faviconUrl: string;
+  onAccept: () => void;
+  onReject: () => void;
+  onSetApproval: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const useConnectionApprovalModal = ({
+  pendingRequest,
+  accept,
+  reject,
+}: IUseConnectionApprovalModalArgs): IUseConnectionApprovalModalData => {
+  const { payload } = pendingRequest;
+  const host = payload?.origin ?? "";
+  const [checked, setChecked] = useState(false);
+  const [faviconUrl, setFaviconUrl] = useState("");
+
+  const onAccept = useCallback(() => {
+    accept();
+  }, [accept]);
+
+  const onReject = useCallback(() => {
+    reject();
+  }, [reject]);
+
+  const onSetApproval = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      postMessage<{ noApproval: boolean }>({
+        method: RPCAction.SET_HOST_PERMISSIONS,
+        payload: {
+          host,
+          noApproval: event.target.checked,
+        },
+      }).then((res) => setChecked(res.noApproval));
+    },
+    [host, setChecked],
+  );
+
+  useEffect(() => {
+    if (!host) {
+      return;
+    }
+
+    getLinkPreview(host).then((data) => {
+      const [favicon] = data.favicons;
+      setFaviconUrl(favicon);
+    });
+
+    postMessage<{ noApproval: boolean }>({
+      method: RPCAction.GET_HOST_PERMISSIONS,
+      payload: host,
+    }).then((res) => setChecked(res.noApproval));
+  }, [host, setChecked, setFaviconUrl]);
+
+  return {
+    host,
+    checked,
+    faviconUrl,
+    onAccept,
+    onReject,
+    onSetApproval,
+  };
+};

--- a/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/DefaultApprovalModal.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/DefaultApprovalModal.tsx
@@ -1,0 +1,46 @@
+import { PendingRequest } from "@src/types";
+import { ButtonType, Button } from "@src/ui/components/Button";
+import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
+
+import "../../confirm-modal.scss";
+
+export interface DefaultApprovalModalProps {
+  len: number;
+  loading: boolean;
+  error: string;
+  pendingRequest: PendingRequest;
+  accept: () => void;
+  reject: () => void;
+}
+
+export const DefaultApprovalModal = ({
+  len,
+  loading,
+  error,
+  pendingRequest,
+  accept,
+  reject,
+}: DefaultApprovalModalProps): JSX.Element => (
+  <FullModal className="confirm-modal" data-testid="default-approval-modal" onClose={reject}>
+    <FullModalHeader>
+      Unhandled Request
+      {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
+    </FullModalHeader>
+
+    <FullModalContent className="flex flex-col">
+      <div className="text-sm font-semibold mb-2 break-all">{JSON.stringify(pendingRequest)}</div>
+    </FullModalContent>
+
+    {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
+
+    <FullModalFooter>
+      <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={reject}>
+        Reject
+      </Button>
+
+      <Button disabled className="ml-2" loading={loading} onClick={accept}>
+        Approve
+      </Button>
+    </FullModalFooter>
+  </FullModal>
+);

--- a/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/__tests__/DefaultApprovalModal.test.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/__tests__/DefaultApprovalModal.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from "@testing-library/react";
+
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
+import { PendingRequestType } from "@src/types";
+
+import { DefaultApprovalModal, DefaultApprovalModalProps } from "..";
+
+describe("ui/components/ConfirmRequestModal/components/DefaultApprovalModal", () => {
+  const defaultProps: DefaultApprovalModalProps = {
+    len: 1,
+    loading: false,
+    error: "",
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.APPROVE,
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  beforeEach(() => {
+    createModalRoot();
+  });
+
+  afterEach(() => {
+    deleteModalRoot();
+  });
+
+  test("should render properly", async () => {
+    render(<DefaultApprovalModal {...defaultProps} />);
+
+    const modal = await screen.findByTestId("default-approval-modal");
+
+    expect(modal).toBeInTheDocument();
+  });
+
+  test("should render properly with error", async () => {
+    render(<DefaultApprovalModal {...defaultProps} error="Error" len={2} />);
+
+    const error = await screen.findByText("Error");
+
+    expect(error).toBeInTheDocument();
+  });
+
+  test("should not approve unknown operations", async () => {
+    render(<DefaultApprovalModal {...defaultProps} />);
+
+    const button = await screen.findByText("Approve");
+    act(() => button.click());
+
+    expect(defaultProps.accept).not.toBeCalled();
+  });
+
+  test("should reject properly", async () => {
+    render(<DefaultApprovalModal {...defaultProps} />);
+
+    const button = await screen.findByText("Reject");
+    act(() => button.click());
+
+    expect(defaultProps.reject).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/index.ts
+++ b/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./DefaultApprovalModal";

--- a/src/ui/components/ConfirmRequestModal/components/ProofModal/ProofModal.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/ProofModal/ProofModal.tsx
@@ -1,0 +1,102 @@
+import { PendingRequest, ProofPayload } from "@src/types";
+import { ButtonType, Button } from "@src/ui/components/Button";
+import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
+import { Icon } from "@src/ui/components/Icon";
+import { Input } from "@src/ui/components/Input";
+
+import "../../confirm-modal.scss";
+
+import { useProofModal } from "./useProofModal";
+
+export interface ProofModalProps {
+  len: number;
+  loading: boolean;
+  error: string;
+  pendingRequest: PendingRequest<ProofPayload>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error }: ProofModalProps): JSX.Element => {
+  const {
+    host,
+    operation,
+    payload,
+    faviconUrl,
+    onAccept,
+    onReject,
+    onOpenCircuitFile,
+    onOpenVerificationKeyFile,
+    onOpenZkeyFile,
+  } = useProofModal({
+    pendingRequest,
+    accept,
+    reject,
+  });
+
+  return (
+    <FullModal className="confirm-modal" data-testid="proof-modal" onClose={onReject}>
+      <FullModalHeader>
+        {operation}
+
+        {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
+      </FullModalHeader>
+
+      <FullModalContent className="flex flex-col items-center">
+        <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0">
+          <div
+            className="w-16 h-16"
+            style={{
+              backgroundSize: "contain",
+              backgroundPosition: "center",
+              backgroundRepeat: "no-repeat",
+              backgroundImage: `url(${faviconUrl}`,
+            }}
+          />
+        </div>
+
+        <div className="text-lg font-semibold mb-2 text-center">{`${host} is requesting a semaphore proof`}</div>
+
+        <div className="semaphore-proof__files flex flex-row items-center mb-2">
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">Circuit</div>
+
+            <Icon data-testid="circuit-file-link" fontAwesome="fas fa-link" onClick={onOpenCircuitFile} />
+          </div>
+
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">ZKey</div>
+
+            <Icon data-testid="zkey-file-link" fontAwesome="fas fa-link" onClick={onOpenZkeyFile} />
+          </div>
+
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">Verification</div>
+
+            <Icon
+              data-testid="verification-key-file-link"
+              fontAwesome="fas fa-link"
+              onClick={onOpenVerificationKeyFile}
+            />
+          </div>
+        </div>
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.externalNullifier} label="External Nullifier" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.signal} label="Signal" />
+      </FullModalContent>
+
+      {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
+
+      <FullModalFooter>
+        <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={onReject}>
+          Reject
+        </Button>
+
+        <Button className="ml-2" loading={loading} onClick={onAccept}>
+          Approve
+        </Button>
+      </FullModalFooter>
+    </FullModal>
+  );
+};

--- a/src/ui/components/ConfirmRequestModal/components/ProofModal/__tests__/ProofModal.test.tsx
+++ b/src/ui/components/ConfirmRequestModal/components/ProofModal/__tests__/ProofModal.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from "@testing-library/react";
+
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
+import { PendingRequestType } from "@src/types";
+
+import { ProofModal, ProofModalProps } from "..";
+import { IUseProofModalData, useProofModal } from "../useProofModal";
+
+jest.mock("../useProofModal", (): unknown => ({
+  useProofModal: jest.fn(),
+}));
+
+describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
+  const defaultProps: ProofModalProps = {
+    len: 1,
+    loading: false,
+    error: "",
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.SEMAPHORE_PROOF,
+      payload: {
+        externalNullifier: "externalNullifier",
+        signal: "0x1",
+        circuitFilePath: "circuitFilePath",
+        verificationKey: "verificationKey",
+        zkeyFilePath: "zkeyFilePath",
+        origin: "http://localhost:3000",
+      },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const defaultHookData: IUseProofModalData = {
+    host: defaultProps.pendingRequest.payload?.origin as string,
+    faviconUrl: "",
+    operation: "Generate Semaphore Proof",
+    payload: defaultProps.pendingRequest.payload,
+    onAccept: jest.fn(),
+    onReject: jest.fn(),
+    onOpenCircuitFile: jest.fn(),
+    onOpenZkeyFile: jest.fn(),
+    onOpenVerificationKeyFile: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useProofModal as jest.Mock).mockReturnValue(defaultHookData);
+
+    createModalRoot();
+  });
+
+  afterEach(() => {
+    deleteModalRoot();
+  });
+
+  test("should render properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const modal = await screen.findByTestId("proof-modal");
+
+    expect(modal).toBeInTheDocument();
+  });
+
+  test("should render properly with error", async () => {
+    render(<ProofModal {...defaultProps} error="Error" len={2} />);
+
+    const error = await screen.findByText("Error");
+
+    expect(error).toBeInTheDocument();
+  });
+
+  test("should approve generation properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const button = await screen.findByText("Approve");
+    act(() => button.click());
+
+    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+  });
+
+  test("should reject proof generation properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const button = await screen.findByText("Reject");
+    act(() => button.click());
+
+    expect(defaultHookData.onReject).toBeCalledTimes(1);
+  });
+
+  test("should open circuit file properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("circuit-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenCircuitFile).toBeCalledTimes(1);
+  });
+
+  test("should open zkey file properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("zkey-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenZkeyFile).toBeCalledTimes(1);
+  });
+
+  test("should open verification key file properly", async () => {
+    render(<ProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("verification-key-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenVerificationKeyFile).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/ConfirmRequestModal/components/ProofModal/__tests__/useProofModal.test.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ProofModal/__tests__/useProofModal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { PendingRequestType } from "@src/types";
+
+import { IUseProofModalArgs, useProofModal } from "../useProofModal";
+
+describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal", () => {
+  const defaultArgs: IUseProofModalArgs = {
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.SEMAPHORE_PROOF,
+      payload: {
+        externalNullifier: "externalNullifier",
+        signal: "0x1",
+        circuitFilePath: "circuitFilePath",
+        verificationKey: "verificationKey",
+        zkeyFilePath: "zkeyFilePath",
+        origin: "http://localhost:3000",
+      },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return empty data", () => {
+    const { result } = renderHook(() =>
+      useProofModal({
+        ...defaultArgs,
+        pendingRequest: {
+          ...defaultArgs.pendingRequest,
+          type: -1 as unknown as PendingRequestType,
+          payload: undefined,
+        },
+      }),
+    );
+
+    expect(result.current.operation).toBe("Generate proof");
+    expect(result.current.faviconUrl).toBe("");
+    expect(result.current.host).toBe("");
+    expect(result.current.payload).toBeUndefined();
+  });
+
+  test("should return initial data", async () => {
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    expect(result.current.operation).toBe("Generate Semaphore Proof");
+    expect(result.current.faviconUrl).toBe("http://localhost:3000/favicon.ico");
+    expect(result.current.host).toBe(defaultArgs.pendingRequest.payload?.origin);
+    expect(result.current.payload).toStrictEqual(defaultArgs.pendingRequest.payload);
+  });
+
+  test("should accept proof generation properly", async () => {
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    act(() => result.current.onAccept());
+
+    expect(defaultArgs.accept).toBeCalledTimes(1);
+  });
+
+  test("should reject proof generation properly", async () => {
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    act(() => result.current.onReject());
+
+    expect(defaultArgs.reject).toBeCalledTimes(1);
+  });
+
+  test("should open circuit file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    act(() => result.current.onOpenCircuitFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
+  });
+
+  test("should open zkey file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    act(() => result.current.onOpenZkeyFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
+  });
+
+  test("should open verification key file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useProofModal(defaultArgs));
+    await waitFor(() => result.current.faviconUrl !== "");
+
+    act(() => result.current.onOpenVerificationKeyFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
+  });
+});

--- a/src/ui/components/ConfirmRequestModal/components/ProofModal/index.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ProofModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProofModal";

--- a/src/ui/components/ConfirmRequestModal/components/ProofModal/useProofModal.ts
+++ b/src/ui/components/ConfirmRequestModal/components/ProofModal/useProofModal.ts
@@ -1,0 +1,75 @@
+import { getLinkPreview } from "link-preview-js";
+import { useCallback, useEffect, useState } from "react";
+
+import { PendingRequest, PendingRequestType, ProofPayload } from "@src/types";
+
+export interface IUseProofModalArgs {
+  pendingRequest: PendingRequest<ProofPayload>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export interface IUseProofModalData {
+  host: string;
+  faviconUrl: string;
+  operation: string;
+  payload?: ProofPayload;
+  onAccept: () => void;
+  onReject: () => void;
+  onOpenCircuitFile: () => void;
+  onOpenZkeyFile: () => void;
+  onOpenVerificationKeyFile: () => void;
+}
+
+type ProofType = PendingRequestType.SEMAPHORE_PROOF | PendingRequestType.RLN_PROOF;
+
+const PROOF_MODAL_TITLES: Record<ProofType, string> = {
+  [PendingRequestType.SEMAPHORE_PROOF]: "Generate Semaphore Proof",
+  [PendingRequestType.RLN_PROOF]: "Generate RLN Proof",
+};
+
+export const useProofModal = ({ pendingRequest, accept, reject }: IUseProofModalArgs): IUseProofModalData => {
+  const [faviconUrl, setFaviconUrl] = useState("");
+  const operation = PROOF_MODAL_TITLES[pendingRequest?.type as ProofType] || "Generate proof";
+  const { origin: host = "", circuitFilePath, zkeyFilePath, verificationKey } = pendingRequest.payload || {};
+
+  const onAccept = useCallback(() => {
+    accept();
+  }, [accept]);
+
+  const onReject = useCallback(() => {
+    reject();
+  }, [reject]);
+
+  const onOpenCircuitFile = useCallback(() => window.open(circuitFilePath, "_blank"), [window, circuitFilePath]);
+
+  const onOpenZkeyFile = useCallback(() => window.open(zkeyFilePath, "_blank"), [window, zkeyFilePath]);
+
+  const onOpenVerificationKeyFile = useCallback(
+    () => window.open(verificationKey, "_blank"),
+    [window, verificationKey],
+  );
+
+  useEffect(() => {
+    if (!host) {
+      return;
+    }
+
+    getLinkPreview(host).then((data) => {
+      const [favicon] = data.favicons;
+      setFaviconUrl(favicon);
+    });
+  }, [host, setFaviconUrl]);
+
+  return {
+    host,
+    payload: pendingRequest.payload,
+    operation,
+    faviconUrl,
+    onAccept,
+    onReject,
+    onOpenCircuitFile,
+    onOpenZkeyFile,
+    onOpenVerificationKeyFile,
+  };
+};

--- a/src/ui/components/ConfirmRequestModal/components/index.ts
+++ b/src/ui/components/ConfirmRequestModal/components/index.ts
@@ -1,0 +1,3 @@
+export * from "./ProofModal";
+export * from "./ConnectionApprovalModal";
+export * from "./DefaultApprovalModal";

--- a/src/ui/components/ConfirmRequestModal/index.tsx
+++ b/src/ui/components/ConfirmRequestModal/index.tsx
@@ -1,290 +1,12 @@
-import { getLinkPreview } from "link-preview-js";
-import { ChangeEvent, useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { RPCAction } from "@src/constants";
-import { PendingRequest, PendingRequestType, RequestResolutionAction } from "@src/types";
-import { ButtonType, Button } from "@src/ui/components/Button";
-import { Checkbox } from "@src/ui/components/Checkbox";
-import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
-import { Icon } from "@src/ui/components/Icon";
-import { Input } from "@src/ui/components/Input";
+import { PendingRequest, PendingRequestType, ProofPayload, RequestResolutionAction } from "@src/types";
 import { useRequestsPending } from "@src/ui/ducks/requests";
 import postMessage from "@src/util/postMessage";
 
+import { ProofModal, ConnectionApprovalModal, DefaultApprovalModal } from "./components";
 import "./confirm-modal.scss";
-
-interface ConnectionModalProps {
-  len: number;
-  loading: boolean;
-  error: string;
-  pendingRequest: PendingRequest;
-  accept: () => void;
-  reject: () => void;
-}
-
-const ConnectionApprovalModal = ({ len, pendingRequest, error, loading, accept, reject }: ConnectionModalProps) => {
-  const { payload } = pendingRequest;
-  const host = (payload as { origin: string } | undefined)?.origin ?? "";
-  const [checked, setChecked] = useState(false);
-  const [faviconUrl, setFaviconUrl] = useState("");
-
-  const handleAccept = useCallback(() => {
-    accept();
-  }, [accept]);
-
-  const handleReject = useCallback(() => {
-    reject();
-  }, [reject]);
-
-  const handleSetApproval = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      postMessage<{ noApproval: boolean }>({
-        method: RPCAction.SET_HOST_PERMISSIONS,
-        payload: {
-          host,
-          noApproval: event.target.checked,
-        },
-      }).then((res) => setChecked(res?.noApproval));
-    },
-    [host, setChecked],
-  );
-
-  useEffect(() => {
-    if (host) {
-      postMessage<{ noApproval: boolean }>({
-        method: RPCAction.GET_HOST_PERMISSIONS,
-        payload: host,
-      }).then((res) => setChecked(res?.noApproval));
-    }
-  }, [host, setChecked]);
-
-  useEffect(() => {
-    if (host) {
-      getLinkPreview(host)
-        .then((data) => {
-          const [favicon] = data.favicons;
-          setFaviconUrl(favicon);
-        })
-        .catch(() => undefined);
-    }
-  }, [host, setFaviconUrl]);
-
-  return (
-    <FullModal className="confirm-modal" onClose={() => null}>
-      <FullModalHeader>
-        Connect with CryptKeeper
-        {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
-      </FullModalHeader>
-
-      <FullModalContent className="flex flex-col items-center">
-        <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0">
-          <div
-            className="w-16 h-16"
-            style={{
-              backgroundSize: "contain",
-              backgroundPosition: "center",
-              backgroundRepeat: "no-repeat",
-              backgroundImage: `url(${faviconUrl})`,
-            }}
-          />
-        </div>
-
-        <div className="text-lg font-semibold mb-2 text-center">{`${host} would like to connect to your identity`}</div>
-
-        <div className="text-sm text-gray-500 text-center">
-          This site is requesting access to view your current identity. Always make sure you trust the site you interact
-          with.
-        </div>
-
-        <div className="font-bold mt-4">Permissions</div>
-
-        <div className="flex flex-row items-start">
-          <Checkbox checked={checked} className="mr-2 mt-2 flex-shrink-0" onChange={handleSetApproval} />
-
-          <div className="text-sm mt-2">Allow host to create proof without approvals</div>
-        </div>
-      </FullModalContent>
-
-      {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
-
-      <FullModalFooter>
-        <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={handleReject}>
-          Reject
-        </Button>
-
-        <Button className="ml-2" loading={loading} onClick={handleAccept}>
-          Approve
-        </Button>
-      </FullModalFooter>
-    </FullModal>
-  );
-};
-
-interface DefaultApprovalModalProps {
-  len: number;
-  loading: boolean;
-  error: string;
-  pendingRequest: PendingRequest;
-  accept: () => void;
-  reject: () => void;
-}
-
-const DefaultApprovalModal = ({ len, loading, error, pendingRequest, accept, reject }: DefaultApprovalModalProps) => (
-  <FullModal className="confirm-modal" onClose={() => null}>
-    <FullModalHeader>
-      Unhandled Request
-      {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
-    </FullModalHeader>
-
-    <FullModalContent className="flex flex-col">
-      <div className="text-sm font-semibold mb-2 break-all">{JSON.stringify(pendingRequest)}</div>
-    </FullModalContent>
-
-    {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
-
-    <FullModalFooter>
-      <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={reject}>
-        Reject
-      </Button>
-
-      <Button disabled className="ml-2" loading={loading} onClick={accept}>
-        Approve
-      </Button>
-    </FullModalFooter>
-  </FullModal>
-);
-
-interface ProofModalProps {
-  len: number;
-  loading: boolean;
-  error: string;
-  pendingRequest: PendingRequest;
-  accept: () => void;
-  reject: () => void;
-}
-
-type ProofType = PendingRequestType.SEMAPHORE_PROOF | PendingRequestType.RLN_PROOF;
-
-const PROOF_MODAL_TITLES: Record<ProofType, string> = {
-  [PendingRequestType.SEMAPHORE_PROOF]: "Generate Semaphore Proof",
-  [PendingRequestType.RLN_PROOF]: "Generate RLN Proof",
-};
-
-interface ProofRequest {
-  externalNullifier: string;
-  signal: string;
-  merkleStorageAddress?: string;
-  circuitFilePath: string;
-  verificationKey: string;
-  zkeyFilePath: string;
-  origin: string;
-}
-
-const ProofModal = ({ pendingRequest, len, reject, accept, loading, error }: ProofModalProps) => {
-  const { payload } = pendingRequest;
-  const {
-    circuitFilePath,
-    externalNullifier,
-    signal,
-    zkeyFilePath,
-    origin: host = "",
-    verificationKey,
-  } = (payload || {}) as Partial<ProofRequest>;
-  const operation = PROOF_MODAL_TITLES[pendingRequest?.type as ProofType] || "Generate proof";
-
-  const [faviconUrl, setFaviconUrl] = useState("");
-
-  const handleAccept = useCallback(() => {
-    accept();
-  }, [accept]);
-
-  const handleReject = useCallback(() => {
-    reject();
-  }, [reject]);
-
-  useEffect(() => {
-    if (host) {
-      getLinkPreview(host)
-        .then((data) => {
-          const [favicon] = data?.favicons || [];
-          setFaviconUrl(favicon);
-        })
-        .catch(() => undefined);
-    }
-  }, [host, setFaviconUrl]);
-
-  return (
-    <FullModal className="confirm-modal" onClose={() => null}>
-      <FullModalHeader>
-        {operation}
-
-        {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
-      </FullModalHeader>
-
-      <FullModalContent className="flex flex-col items-center">
-        <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0">
-          <div
-            className="w-16 h-16"
-            style={{
-              backgroundSize: "contain",
-              backgroundPosition: "center",
-              backgroundRepeat: "no-repeat",
-              backgroundImage: `url(${faviconUrl}`,
-            }}
-          />
-        </div>
-
-        <div className="text-lg font-semibold mb-2 text-center">{`${host} is requesting a semaphore proof`}</div>
-
-        <div className="semaphore-proof__files flex flex-row items-center mb-2">
-          <div className="semaphore-proof__file">
-            <div className="semaphore-proof__file__title">Circuit</div>
-
-            <Icon fontAwesome="fas fa-link" onClick={() => window.open(circuitFilePath, "_blank")} />
-          </div>
-
-          <div className="semaphore-proof__file">
-            <div className="semaphore-proof__file__title">ZKey</div>
-
-            <Icon fontAwesome="fas fa-link" onClick={() => window.open(zkeyFilePath, "_blank")} />
-          </div>
-
-          <div className="semaphore-proof__file">
-            <div className="semaphore-proof__file__title">Verification</div>
-
-            <Icon fontAwesome="fas fa-link" onClick={() => window.open(verificationKey, "_blank")} />
-          </div>
-
-          {/* TODO: check Merkle output */}
-          {/* <div className="semaphore-proof__file">
-            <div className="semaphore-proof__file__title">Merkle</div>
-            {typeof merkleProof === "string" ? (
-              <Icon fontAwesome="fas fa-link" onClick={() => window.open(merkleProof, "_blank")} />
-            ) : (
-              <Icon fontAwesome="fas fa-copy" onClick={() => copy(JSON.stringify(merkleProof))} />
-            )}
-          </div> */}
-        </div>
-
-        <Input readOnly className="w-full mb-2" defaultValue={externalNullifier} label="External Nullifier" />
-
-        <Input readOnly className="w-full mb-2" defaultValue={signal} label="Signal" />
-      </FullModalContent>
-
-      {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
-
-      <FullModalFooter>
-        <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={handleReject}>
-          Reject
-        </Button>
-
-        <Button className="ml-2" loading={loading} onClick={handleAccept}>
-          Approve
-        </Button>
-      </FullModalFooter>
-    </FullModal>
-  );
-};
 
 export const ConfirmRequestModal = (): JSX.Element | null => {
   const pendingRequests = useRequestsPending();
@@ -336,13 +58,14 @@ export const ConfirmRequestModal = (): JSX.Element | null => {
 
   switch (pendingRequest.type) {
     case PendingRequestType.INJECT:
+    case PendingRequestType.APPROVE:
       return (
         <ConnectionApprovalModal
           accept={() => approve()}
           error={error}
           len={pendingRequests.length}
           loading={loading}
-          pendingRequest={pendingRequest}
+          pendingRequest={pendingRequest as PendingRequest<{ origin: string }>}
           reject={() => reject()}
         />
       );
@@ -354,7 +77,7 @@ export const ConfirmRequestModal = (): JSX.Element | null => {
           error={error}
           len={pendingRequests.length}
           loading={loading}
-          pendingRequest={pendingRequest}
+          pendingRequest={pendingRequest as PendingRequest<ProofPayload>}
           reject={reject}
         />
       );

--- a/src/ui/components/ConnectionModal/index.tsx
+++ b/src/ui/components/ConnectionModal/index.tsx
@@ -107,6 +107,7 @@ export const ConnectionModal = ({ refreshConnectionStatus, onClose }: Connection
           <Checkbox
             checked={checked}
             className="mr-2 mt-2 flex-shrink-0"
+            id="approval"
             onChange={(e) => {
               setApproval(e.target.checked);
             }}

--- a/src/ui/hooks/wallet/__tests__/useWallet.test.ts
+++ b/src/ui/hooks/wallet/__tests__/useWallet.test.ts
@@ -18,8 +18,6 @@ jest.mock("@web3-react/core", (): unknown => ({
   useWeb3React: jest.fn(),
 }));
 
-jest.mock("@src/util/postMessage");
-
 describe("ui/hooks/wallet", () => {
   const defaultHooks = { usePriorityChainId: jest.fn(), usePriorityAccount: jest.fn(), usePriorityProvider: jest.fn() };
 

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -4,6 +4,7 @@
 
 import { act, render, screen } from "@testing-library/react";
 
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { IDENTITY_TYPES, WEB2_PROVIDER_OPTIONS } from "@src/constants";
 
 import { CreateIdentity } from "..";
@@ -30,16 +31,13 @@ describe("ui/pages/CreateIdentity", () => {
   beforeEach(() => {
     (useCreateIdentity as jest.Mock).mockReturnValue(defaultHookData);
 
-    const container = document.createElement("div");
-    container.id = "modal";
-    document.body.append(container);
+    createModalRoot();
   });
 
   afterEach(() => {
     jest.resetAllMocks();
 
-    const container = document.getElementById("modal");
-    document.body.removeChild(container as HTMLElement);
+    deleteModalRoot();
   });
 
   test("should render properly", async () => {

--- a/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -5,6 +5,7 @@
 import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { ZERO_ADDRESS } from "@src/config/const";
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { IdentityMetadata } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -68,16 +69,13 @@ describe("ui/pages/Home/components/IdentityList", () => {
 
     (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
-    const container = document.createElement("div");
-    container.id = "modal";
-    document.body.append(container);
+    createModalRoot();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
 
-    const container = document.getElementById("modal");
-    document.body.removeChild(container as HTMLElement);
+    deleteModalRoot();
   });
 
   test("should render properly", async () => {

--- a/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
+++ b/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
@@ -4,6 +4,7 @@
 
 import { act, render, screen } from "@testing-library/react";
 
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { sliceAddress } from "@src/util/account";
 
@@ -18,16 +19,13 @@ describe("ui/pages/Home/components/Info", () => {
   };
 
   beforeEach(() => {
-    const container = document.createElement("div");
-    container.id = "modal";
-    document.body.append(container);
+    createModalRoot();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
 
-    const container = document.getElementById("modal");
-    document.body.removeChild(container as HTMLElement);
+    deleteModalRoot();
   });
 
   test("should render properly", async () => {

--- a/src/util/__tests__/postMessage.test.ts
+++ b/src/util/__tests__/postMessage.test.ts
@@ -12,6 +12,8 @@ jest.mock("webextension-polyfill-ts", (): unknown => ({
   },
 }));
 
+jest.unmock("@src/util/postMessage");
+
 describe("util/postMessage", () => {
   beforeEach(() => {
     (browser.runtime.sendMessage as jest.Mock).mockResolvedValue([null, {}]);


### PR DESCRIPTION
## Explanation

This PR moves request modals to separate components with refactoring and tests.
This is a part of PR #183

Details are below:
- [x] Move request modal to separate components
- [x] Move logic to hook layer
- [x] Add tests

## More Information

Related to #140 
Related to #181 
Blocked by #183 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
