### PR TITLE
fix: prevent changing active identity

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -9,7 +9,7 @@
     "@src/(.*)$": "<rootDir>/src/$1",
     "^.+\\.(css|scss|svg|png)$": "<rootDir>/src/config/mock/resourceMock.js"
   },
-  "coveragePathIgnorePatterns": ["/node_modules/", "/test/", "/__tests__/"],
+  "coveragePathIgnorePatterns": ["/node_modules/", "/test/", "/__tests__/", "/src/server/"],
   "coverageReporters": ["clover", "lcov", "json", "json-summary", "text", "text-summary"],
   "collectCoverageFrom": ["src/**/*.{ts,tsx}"]
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -9,7 +9,7 @@
     "@src/(.*)$": "<rootDir>/src/$1",
     "^.+\\.(css|scss|svg|png)$": "<rootDir>/src/config/mock/resourceMock.js"
   },
-  "coveragePathIgnorePatterns": ["/node_modules/", "/test/", "/__tests__/", "/src/server/"],
+  "coveragePathIgnorePatterns": ["/node_modules/", "/test/", "/__tests__/"],
   "coverageReporters": ["clover", "lcov", "json", "json-summary", "text", "text-summary"],
   "collectCoverageFrom": ["src/**/*.{ts,tsx}"]
 }


### PR DESCRIPTION
## Explanation

This PR fixes issue when user tries to delete non-active identity and active identity switches to a default one.

## More Information

Closes #180
Blocked by #189 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

1. Try to delete non-active identity
2. Check the active identity is the same as before the removing

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
