### PR TITLE
test: add tests for background controllers

### DIFF
--- a/src/background/controllers/__tests__/browserUtils.test.ts
+++ b/src/background/controllers/__tests__/browserUtils.test.ts
@@ -1,0 +1,58 @@
+import { browser } from "webextension-polyfill-ts";
+
+import BrowserUtils from "../browserUtils";
+
+describe("background/controllers/browserUtils", () => {
+  const defaultTabs = [
+    { id: 1, active: true, highlighted: true },
+    { id: 2, active: true, highlighted: false },
+  ];
+
+  const defaultPopupTab = { id: 3, active: true, highlighted: true };
+
+  const defaultWindow = { id: 1 };
+
+  beforeEach(() => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+
+    (browser.tabs.create as jest.Mock).mockResolvedValue(defaultPopupTab);
+
+    (browser.windows.create as jest.Mock).mockResolvedValue(defaultWindow);
+  });
+
+  test("should open and close popup properly", async () => {
+    const browserUtils = BrowserUtils.getInstance();
+
+    const popup = await browserUtils.openPopup({ params: { redirect: "/" } });
+
+    expect(popup.id).toBe(defaultWindow.id);
+
+    const result = await browserUtils.closePopup();
+
+    expect(result).toBe(true);
+  });
+
+  test("should not open the same popup twice", async () => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue([]);
+    const browserUtils = BrowserUtils.getInstance();
+
+    const popup = await browserUtils.openPopup();
+    expect(popup.id).toBe(defaultWindow.id);
+
+    const cachedPopup = await browserUtils.openPopup();
+    expect(cachedPopup.id).toBe(popup.id);
+  });
+
+  test("should add and remove listeners properly", () => {
+    const browserUtils = BrowserUtils.getInstance();
+    const callback = () => null;
+
+    browserUtils.addRemoveWindowListener(callback);
+    browserUtils.removeRemoveWindowListener(callback);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(browser.windows.onRemoved.addListener).toBeCalledTimes(2);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(browser.windows.onRemoved.removeListener).toBeCalledTimes(1);
+  });
+});

--- a/src/background/controllers/__tests__/handler.test.ts
+++ b/src/background/controllers/__tests__/handler.test.ts
@@ -1,0 +1,25 @@
+import Handler from "../handler";
+
+describe("background/controllers/handler", () => {
+  test("should add handler method properly and process it", async () => {
+    const handler = new Handler();
+
+    handler.add(
+      "counter",
+      (count: number) => count + 1,
+      (count: number) => count + 2,
+      (count: number) => count + 3,
+      (count: number) => count + 4,
+    );
+
+    const result = await handler.handle({ method: "counter", payload: 0 });
+
+    expect(result).toBe(10);
+  });
+
+  test("should throw error if there is no registered method", () => {
+    const handler = new Handler();
+
+    expect(handler.handle({ method: "unknown" })).rejects.toThrowError("method: unknown is not detected");
+  });
+});

--- a/src/background/controllers/__tests__/requestManager.test.ts
+++ b/src/background/controllers/__tests__/requestManager.test.ts
@@ -1,0 +1,127 @@
+import { PendingRequestType, RequestResolutionStatus } from "@src/types";
+import { setPendingRequest } from "@src/ui/ducks/requests";
+import pushMessage from "@src/util/pushMessage";
+
+import BrowserUtils from "../browserUtils";
+import RequestManager from "../requestManager";
+
+jest.mock("../browserUtils");
+
+describe("background/controllers/requestManager", () => {
+  let removeListeners: ((window?: number) => void)[] = [];
+
+  const defaultBrowserUtils = {
+    openPopup: jest.fn(),
+    closePopup: jest.fn().mockImplementation((windowId?: number) => {
+      removeListeners.forEach((listener) => listener(windowId));
+    }),
+    addRemoveWindowListener: jest.fn().mockImplementation((listener: (windowId?: number) => void) => {
+      removeListeners.push(listener);
+    }),
+    removeRemoveWindowListener: jest.fn(),
+  };
+
+  const defaultWindow = { id: 1 };
+
+  const createTimeout = (): Promise<void> =>
+    new Promise((resolve) => {
+      // need to wait until we get popup and add request to queue
+      setTimeout(resolve, 500);
+    });
+
+  beforeEach(() => {
+    defaultBrowserUtils.openPopup.mockResolvedValue(defaultWindow);
+
+    (BrowserUtils.getInstance as jest.Mock).mockReturnValue(defaultBrowserUtils);
+  });
+
+  afterEach(() => {
+    removeListeners = [];
+    jest.clearAllMocks();
+  });
+
+  test("should create new request and notify properly", async () => {
+    const requestManager = new RequestManager();
+    const nonce = requestManager.getNonce();
+
+    const requestPromise = requestManager.newRequest(PendingRequestType.APPROVE, { origin: "http://localhost:3000" });
+    await Promise.race([requestPromise, createTimeout()]);
+
+    const requests = requestManager.getRequests();
+    expect(requests).toHaveLength(1);
+    expect(pushMessage).toBeCalledTimes(1);
+    expect(pushMessage).toBeCalledWith(setPendingRequest(requests));
+
+    const finalized = await requestManager.finalizeRequest({
+      id: nonce.toString(),
+      status: RequestResolutionStatus.ACCEPT,
+      data: { done: true },
+    });
+
+    expect(finalized).toBe(true);
+  });
+
+  test("should finalize request and notify properly", async () => {
+    const requestManager = new RequestManager();
+    const nonce = requestManager.getNonce();
+
+    const requestPromise = requestManager.newRequest(PendingRequestType.APPROVE, { origin: "http://localhost:3000" });
+    await Promise.race([requestPromise, createTimeout()]);
+
+    const finalized = await requestManager.finalizeRequest({
+      id: nonce.toString(),
+      status: RequestResolutionStatus.ACCEPT,
+      data: { done: true },
+    });
+
+    expect(finalized).toBe(true);
+    expect(requestPromise).resolves.toStrictEqual({ done: true });
+    expect(pushMessage).toBeCalledTimes(2);
+    expect(pushMessage).toBeCalledWith(setPendingRequest([]));
+    expect(defaultBrowserUtils.addRemoveWindowListener).toBeCalledTimes(2);
+    expect(defaultBrowserUtils.removeRemoveWindowListener).toBeCalledTimes(1);
+  });
+
+  test("should reject request properly", async () => {
+    const requestManager = new RequestManager();
+    const nonce = requestManager.getNonce();
+
+    const requestPromise = requestManager.newRequest(PendingRequestType.APPROVE, { origin: "http://localhost:3000" });
+    await Promise.race([requestPromise, createTimeout()]);
+
+    const finalized = await requestManager.finalizeRequest({
+      id: nonce.toString(),
+      status: RequestResolutionStatus.REJECT,
+    });
+
+    expect(finalized).toBe(true);
+    expect(requestPromise).rejects.toStrictEqual(new Error("user rejected."));
+  });
+
+  test("should handle unknown request finalization type properly", async () => {
+    const requestManager = new RequestManager();
+    const nonce = requestManager.getNonce();
+
+    const requestPromise = requestManager.newRequest(PendingRequestType.APPROVE, { origin: "http://localhost:3000" });
+    await Promise.race([requestPromise, createTimeout()]);
+
+    const finalized = await requestManager.finalizeRequest({
+      id: nonce.toString(),
+      status: "unknown" as RequestResolutionStatus,
+    });
+
+    expect(finalized).toBe(true);
+    expect(requestPromise).rejects.toStrictEqual(new Error("action: unknown not supproted"));
+  });
+
+  test("should handle reject request finalization type properly if user closes popup", async () => {
+    const requestManager = new RequestManager();
+
+    const requestPromise = requestManager.newRequest(PendingRequestType.APPROVE, { origin: "http://localhost:3000" });
+    await Promise.race([requestPromise, createTimeout()]);
+
+    await defaultBrowserUtils.closePopup(defaultWindow.id);
+
+    expect(requestPromise).rejects.toStrictEqual(new Error("user rejected."));
+  });
+});

--- a/src/background/controllers/browserUtils.ts
+++ b/src/background/controllers/browserUtils.ts
@@ -1,4 +1,3 @@
-import log from "loglevel";
 import { browser, Windows } from "webextension-polyfill-ts";
 
 interface CreateWindowArgs {
@@ -90,16 +89,8 @@ export default class BrowserUtils {
   private focusWindow = (windowId: number) => browser.windows.update(windowId, { focused: true });
 
   private cleanCache = (windowId: number) => {
-    log.debug("Inside removeWindow onRemove");
-
-    try {
-      log.debug("Inside removeWindow onRemove locked");
-      if (this.cached?.id === windowId) {
-        this.cached = null;
-        log.debug("Inside removeWindow onRemove cleaned");
-      }
-    } catch (error) {
-      log.debug("Inside removeWindow onRemove error", error);
+    if (this.cached?.id === windowId) {
+      this.cached = null;
     }
   };
 }

--- a/src/background/controllers/requestManager.ts
+++ b/src/background/controllers/requestManager.ts
@@ -1,55 +1,30 @@
 import { EventEmitter2 } from "eventemitter2";
 
-import { PendingRequest, PendingRequestType, RequestResolutionAction } from "@src/types";
+import { PendingRequest, PendingRequestType, RequestResolutionAction, RequestResolutionStatus } from "@src/types";
 import { setPendingRequest } from "@src/ui/ducks/requests";
 import pushMessage from "@src/util/pushMessage";
 
 import BrowserUtils from "./browserUtils";
 
-let nonce = 0;
-
 export default class RequestManager extends EventEmitter2 {
   private browserService: BrowserUtils;
 
-  private pendingRequests: Array<PendingRequest>;
+  private pendingRequests: PendingRequest[];
+
+  private nonce: number;
 
   public constructor() {
     super();
     this.pendingRequests = [];
+    this.nonce = 0;
     this.browserService = BrowserUtils.getInstance();
 
-    this.browserService.addRemoveWindowListener(this.finilizeRequestOnRemovedWindow);
+    this.browserService.addRemoveWindowListener(this.clearRequests);
   }
 
+  public getNonce = (): number => this.nonce;
+
   public getRequests = (): PendingRequest[] => this.pendingRequests;
-
-  public finalizeRequest = async (action: RequestResolutionAction<unknown>): Promise<boolean> => {
-    const { id } = action;
-    if (!id) throw new Error("id not provided");
-    // TODO add some mutex lock just in case something strange occurs
-    this.pendingRequests = this.pendingRequests.filter((pendingRequest) => pendingRequest.id !== id);
-    this.emit(`${id}:finalized`, action);
-    await pushMessage(setPendingRequest(this.pendingRequests));
-
-    return true;
-  };
-
-  private finilizeRequestOnRemovedWindow = (windowId?: number): boolean => {
-    if (windowId) {
-      this.pendingRequests = this.pendingRequests.filter((pendingRequests) => pendingRequests.windowId !== windowId);
-    }
-
-    return true;
-  };
-
-  public addToQueue = async (type: PendingRequestType, windowId?: number, payload?: unknown): Promise<string> => {
-    // eslint-disable-next-line no-plusplus
-    const id = `${nonce++}`;
-    this.pendingRequests.push({ id, windowId, type, payload });
-    await pushMessage(setPendingRequest(this.pendingRequests));
-
-    return id;
-  };
 
   public newRequest = async (type: PendingRequestType, payload?: unknown): Promise<unknown> => {
     const popup = await this.browserService.openPopup();
@@ -65,13 +40,13 @@ export default class RequestManager extends EventEmitter2 {
 
       this.browserService.addRemoveWindowListener(onPopupClose);
 
-      this.once(`${id}:finalized`, (action: RequestResolutionAction<unknown>) => {
+      this.once(`${id}:finalized`, (action: RequestResolutionAction) => {
         this.browserService.removeRemoveWindowListener(onPopupClose);
         switch (action.status) {
-          case "accept":
+          case RequestResolutionStatus.ACCEPT:
             resolve(action.data);
             return;
-          case "reject":
+          case RequestResolutionStatus.REJECT:
             reject(new Error("user rejected."));
             return;
           default:
@@ -79,5 +54,31 @@ export default class RequestManager extends EventEmitter2 {
         }
       });
     });
+  };
+
+  public finalizeRequest = async (action: RequestResolutionAction<unknown>): Promise<boolean> => {
+    const { id } = action;
+
+    // TODO add some mutex lock just in case something strange occurs
+    this.pendingRequests = this.pendingRequests.filter((pendingRequest) => pendingRequest.id !== id);
+    this.emit(`${id}:finalized`, action);
+    await pushMessage(setPendingRequest(this.pendingRequests));
+
+    return true;
+  };
+
+  private addToQueue = async (type: PendingRequestType, windowId?: number, payload?: unknown): Promise<string> => {
+    // eslint-disable-next-line no-plusplus
+    const id = `${this.nonce++}`;
+    this.pendingRequests.push({ id, windowId, type, payload });
+    await pushMessage(setPendingRequest(this.pendingRequests));
+
+    return id;
+  };
+
+  private clearRequests = (windowId?: number): void => {
+    if (windowId) {
+      this.pendingRequests = this.pendingRequests.filter((pendingRequests) => pendingRequests.windowId !== windowId);
+    }
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,11 +60,16 @@ export interface PendingRequest<P = unknown> {
   payload?: P;
 }
 
-export type RequestResolutionAction<data> = {
+export type RequestResolutionAction<data = unknown> = {
   id: string;
-  status: "accept" | "reject";
+  status: RequestResolutionStatus;
   data?: data;
 };
+
+export enum RequestResolutionStatus {
+  ACCEPT = "accept",
+  REJECT = "reject",
+}
 
 export type IdentityMetadata = {
   account: string;

--- a/src/ui/components/ConfirmRequestModal/__tests__/useConfirmRequestModal.test.ts
+++ b/src/ui/components/ConfirmRequestModal/__tests__/useConfirmRequestModal.test.ts
@@ -5,6 +5,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { RPCAction } from "@src/constants";
+import { RequestResolutionStatus } from "@src/types";
 import { useRequestsPending } from "@src/ui/ducks/requests";
 import postMessage from "@src/util/postMessage";
 
@@ -49,7 +50,7 @@ describe("ui/components/ConfirmRequestModal/useConfirmRequestModal", () => {
       method: RPCAction.FINALIZE_REQUEST,
       payload: {
         id: undefined,
-        status: "accept",
+        status: RequestResolutionStatus.ACCEPT,
         data: undefined,
       },
     });

--- a/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
+++ b/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { RPCAction } from "@src/constants";
-import { PendingRequest, RequestResolutionAction } from "@src/types";
+import { PendingRequest, RequestResolutionAction, RequestResolutionStatus } from "@src/types";
 import { useRequestsPending } from "@src/ui/ducks/requests";
 import postMessage from "@src/util/postMessage";
 
@@ -21,9 +21,9 @@ export const useConfirmRequestModal = (): IUseConfirmRequestModalData => {
 
   const reject = useCallback(
     (err?: Error) => {
-      const req: RequestResolutionAction<Error | undefined> = {
+      const req: RequestResolutionAction<Error> = {
         id: pendingRequest?.id,
-        status: "reject",
+        status: RequestResolutionStatus.REJECT,
         data: err,
       };
 
@@ -40,9 +40,9 @@ export const useConfirmRequestModal = (): IUseConfirmRequestModalData => {
 
   const accept = useCallback(
     (data?: unknown) => {
-      const req: RequestResolutionAction<unknown | undefined> = {
+      const req: RequestResolutionAction = {
         id: pendingRequest?.id,
-        status: "accept",
+        status: RequestResolutionStatus.ACCEPT,
         data,
       };
 

--- a/src/util/__tests__/pushMessage.test.ts
+++ b/src/util/__tests__/pushMessage.test.ts
@@ -12,6 +12,8 @@ jest.mock("webextension-polyfill-ts", (): unknown => ({
   },
 }));
 
+jest.unmock("@src/util/pushMessage");
+
 describe("util/pushMessage", () => {
   beforeEach(() => {
     (browser.runtime.sendMessage as jest.Mock).mockResolvedValue([null, {}]);


### PR DESCRIPTION
## Explanation

This PR adds tests for background controllers: `BrowserUtils`, `RequestManager` and `Handler`.

## More Information

N/A

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
