### PR TITLE
feat: add validation for onboarding page

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -9,7 +9,23 @@
     "^.+\\.(css|scss|svg|png)$": "<rootDir>/src/config/mock/resourceMock.js",
     "@src/(.*)$": "<rootDir>/src/$1"
   },
-  "coveragePathIgnorePatterns": ["/node_modules/", "/test/", "/__tests__/"],
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/test/",
+    "/__tests__/",
+    "/src/server/",
+    "/src/ui/popup.tsx",
+    "/src/background/backgroundPage.ts",
+    "/src/background/appInit.ts"
+  ],
   "coverageReporters": ["clover", "lcov", "json", "json-summary", "text", "text-summary"],
-  "collectCoverageFrom": ["src/**/*.{ts,tsx}"]
+  "collectCoverageFrom": ["src/**/*.{ts,tsx}"],
+  "coverageThreshold": {
+    "global": {
+      "statements": 80,
+      "branches": 80,
+      "functions": 80,
+      "lines": 80
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "redux-thunk": "^2.4.2",
         "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs",
         "subworkers": "^1.0.1",
-        "webextension-polyfill-ts": "^0.26.0"
+        "webextension-polyfill-ts": "^0.26.0",
+        "yup": "^1.0.2"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.21.3",
@@ -14832,6 +14833,11 @@
       "version": "16.13.1",
       "license": "MIT"
     },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -17306,6 +17312,11 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+    },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
       "dev": true,
@@ -17359,6 +17370,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -19113,6 +19129,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.0.2.tgz",
+      "integrity": "sha512-Lpi8nITFKjWtCoK3yQP8MUk78LJmHWqbFd0OOMXTar+yjejlQ4OIIoZgnTW1bnEUKDw6dZBcy3/IdXnt2KDUow==",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -28623,6 +28661,11 @@
         }
       }
     },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "requires": {
@@ -30221,6 +30264,11 @@
         "process": "~0.11.0"
       }
     },
+    "tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+    },
     "tiny-glob": {
       "version": "0.2.9",
       "dev": true,
@@ -30255,6 +30303,11 @@
     },
     "toidentifier": {
       "version": "1.0.1"
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -31390,6 +31443,24 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "yup": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.0.2.tgz",
+      "integrity": "sha512-Lpi8nITFKjWtCoK3yQP8MUk78LJmHWqbFd0OOMXTar+yjejlQ4OIIoZgnTW1bnEUKDw6dZBcy3/IdXnt2KDUow==",
+      "requires": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
     },
     "zustand": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "@fortawesome/free-brands-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@interep/identity": "^0.3.0",
-    "@reduxjs/toolkit": "^1.9.3",
     "@mui/material": "^5.11.13",
+    "@reduxjs/toolkit": "^1.9.3",
     "@semaphore-protocol/group": "^3.2.3",
     "@semaphore-protocol/identity": "^3.2.3",
     "@semaphore-protocol/proof": "^3.2.3",
@@ -144,7 +144,8 @@
     "redux-thunk": "^2.4.2",
     "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs",
     "subworkers": "^1.0.1",
-    "webextension-polyfill-ts": "^0.26.0"
+    "webextension-polyfill-ts": "^0.26.0",
+    "yup": "^1.0.2"
   },
   "config": {
     "commitizen": {

--- a/src/background/backgroundPage.ts
+++ b/src/background/backgroundPage.ts
@@ -30,28 +30,24 @@ browser.runtime.onConnect.addListener(async () => {
   log.debug("CryptKeeper onConnect Event, initializing completed...");
 });
 
-function initialize() {
-  try {
-    const app = new ZkKeeperController();
+try {
+  const app = new ZkKeeperController();
 
-    app.initialize();
+  app.initialize();
 
-    browser.runtime.onMessage.addListener(async (request: HandlerRequest) => {
-      try {
-        log.debug("Background: request: ", request);
-        const response = await app.handle(request);
-        log.debug("Background: response: ", response);
-        return [null, response];
-      } catch (e) {
-        return [(e as Error).message, null];
-      }
-    });
+  browser.runtime.onMessage.addListener(async (request: HandlerRequest) => {
+    try {
+      log.debug("Background: request: ", request);
+      const response = await app.handle(request);
+      log.debug("Background: response: ", response);
+      return [null, response];
+    } catch (e) {
+      return [(e as Error).message, null];
+    }
+  });
 
-    log.debug("CryptKeeper initialization complete.");
-    resolveInitialization?.(true);
-  } catch (error) {
-    rejectInitialization?.(error);
-  }
+  log.debug("CryptKeeper initialization complete.");
+  resolveInitialization?.(true);
+} catch (error) {
+  rejectInitialization?.(error);
 }
-
-initialize();

--- a/src/background/controllers/browserUtils.ts
+++ b/src/background/controllers/browserUtils.ts
@@ -43,7 +43,7 @@ export default class BrowserUtils {
       return this.cached;
     }
 
-    const tabs = await browser.tabs.query({});
+    const tabs = await browser.tabs.query({ lastFocusedWindow: true });
     const index = tabs.findIndex((tab) => tab.active && tab.highlighted);
     const searchParams = params ? `?${new URLSearchParams(params).toString()}` : "";
     const tab = await this.createTab({

--- a/src/background/services/__tests__/identityService.test.ts
+++ b/src/background/services/__tests__/identityService.test.ts
@@ -25,7 +25,8 @@ type MockStorage = { get: jest.Mock; set: jest.Mock; clear: jest.Mock };
 
 describe("background/services/identity", () => {
   const defaultTabs = [{ id: 1 }, { id: 2 }];
-  const defaultIdentityCommitment = "15206603389158210388485662342360617949291660595274505642693885456541816400294";
+  const defaultIdentityCommitment =
+    bigintToHex(15206603389158210388485662342360617949291660595274505642693885456541816400294n);
   const defaultIdentities = [[defaultIdentityCommitment, JSON.stringify({ secret: "1234", metadata: {} })]];
   const serializedDefaultIdentities = JSON.stringify(defaultIdentities);
   const mockNotificationService = {

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -87,7 +87,7 @@ export default class IdentityService {
     const { identityCommitment } = payload;
     const activeIdentity = await this.getActiveIdentity();
     const identities = await this.getIdentitiesFromStore();
-    const activeIdentityCommitment = activeIdentity?.genIdentityCommitment().toString();
+    const activeIdentityCommitment = activeIdentity ? bigintToHex(activeIdentity?.genIdentityCommitment()) : undefined;
 
     if (!identities.has(identityCommitment)) {
       return false;
@@ -96,11 +96,9 @@ export default class IdentityService {
     identities.delete(identityCommitment);
     await this.writeIdentities(identities);
 
-    const size = await this.getNumOfIdentites();
-
     await this.refresh();
 
-    if (activeIdentityCommitment === identityCommitment || size === 1) {
+    if (activeIdentityCommitment === identityCommitment) {
       await this.setDefaultIdentity();
     }
 

--- a/src/config/mock/wallet.ts
+++ b/src/config/mock/wallet.ts
@@ -24,4 +24,5 @@ export const defaultWalletHookData: IUseWalletData = {
   onConnect: jest.fn(),
   onConnectEagerly: jest.fn(),
   onDisconnect: jest.fn(),
+  onLock: jest.fn(),
 };

--- a/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
+++ b/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Suspense } from "react";
 
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
@@ -39,11 +39,14 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       ...defaultHookData,
       pendingRequests: [{ id: "1", type: PendingRequestType.INJECT }],
     });
-    render(
+
+    const { container } = render(
       <Suspense>
         <ConfirmRequestModal />
       </Suspense>,
     );
+
+    await waitFor(() => container.firstChild !== null);
 
     const modal = await screen.findByTestId("approval-modal");
 
@@ -55,11 +58,14 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       ...defaultHookData,
       pendingRequests: [{ id: "1", type: PendingRequestType.APPROVE }],
     });
-    render(
+
+    const { container } = render(
       <Suspense>
         <ConfirmRequestModal />
       </Suspense>,
     );
+
+    await waitFor(() => container.firstChild !== null);
 
     const modal = await screen.findByTestId("approval-modal");
 
@@ -71,11 +77,14 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       ...defaultHookData,
       pendingRequests: [{ id: "1", type: PendingRequestType.SEMAPHORE_PROOF }],
     });
-    render(
+
+    const { container } = render(
       <Suspense>
         <ConfirmRequestModal />
       </Suspense>,
     );
+
+    await waitFor(() => container.firstChild !== null);
 
     const title = await screen.findByText("Generate Semaphore Proof");
 
@@ -87,11 +96,14 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       ...defaultHookData,
       pendingRequests: [{ id: "1", type: PendingRequestType.RLN_PROOF }],
     });
-    render(
+
+    const { container } = render(
       <Suspense>
         <ConfirmRequestModal />
       </Suspense>,
     );
+
+    await waitFor(() => container.firstChild !== null);
 
     const title = await screen.findByText("Generate RLN Proof");
 
@@ -103,11 +115,14 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       ...defaultHookData,
       pendingRequests: [{ id: "1", type: "unknown" as unknown as PendingRequestType }],
     });
-    render(
+
+    const { container } = render(
       <Suspense>
         <ConfirmRequestModal />
       </Suspense>,
     );
+
+    await waitFor(() => container.firstChild !== null);
 
     const modal = await screen.findByTestId("default-approval-modal");
 

--- a/src/ui/components/Header/__tests__/Header.test.tsx
+++ b/src/ui/components/Header/__tests__/Header.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { useWallet } from "@src/ui/hooks/wallet";
+
+import { Header } from "..";
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useWallet: jest.fn(),
+}));
+
+describe("ui/components/Header", () => {
+  beforeEach(() => {
+    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    (useWallet as jest.Mock).mockReturnValue({
+      ...defaultWalletHookData,
+      isActive: true,
+    });
+
+    const { findByText } = render(<Header />);
+
+    const chain = await findByText(defaultWalletHookData.chain?.name as string);
+
+    expect(chain).toBeInTheDocument();
+  });
+
+  test("should render properly without connected wallet", async () => {
+    (useWallet as jest.Mock).mockReturnValue({
+      ...defaultWalletHookData,
+      address: undefined,
+      chain: undefined,
+      isActive: false,
+      isActivating: false,
+    });
+
+    const { findByTestId } = render(<Header />);
+
+    const icon = await findByTestId("inactive-wallet-icon");
+
+    expect(icon).toBeInTheDocument();
+  });
+
+  test("should render properly activating state", async () => {
+    (useWallet as jest.Mock).mockReturnValue({
+      ...defaultWalletHookData,
+      address: undefined,
+      chain: undefined,
+      isActive: false,
+      isActivating: true,
+    });
+
+    const { findByTestId } = render(<Header />);
+
+    const icon = await findByTestId("inactive-wallet-icon-activating");
+
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -1,23 +1,16 @@
 import classNames from "classnames";
-import { useCallback } from "react";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 
-import { RPCAction } from "@src/constants";
 import loaderSvg from "@src/static/icons/loader.svg";
 import logoSvg from "@src/static/icons/logo.svg";
 import { Icon } from "@src/ui/components/Icon";
 import { Menuable } from "@src/ui/components/Menuable";
 import { useWallet } from "@src/ui/hooks/wallet";
-import postMessage from "@src/util/postMessage";
 
 import "./header.scss";
 
 export const Header = (): JSX.Element => {
-  const { address, isActivating, isActive, chain, onConnect, onDisconnect } = useWallet();
-
-  const onLock = useCallback(async () => {
-    await postMessage({ method: RPCAction.LOCK });
-  }, []);
+  const { address, isActivating, isActive, chain, onConnect, onDisconnect, onLock } = useWallet();
 
   return (
     <div className="header h-16 flex flex-row items-center px-4">
@@ -50,6 +43,7 @@ export const Header = (): JSX.Element => {
           >
             {!address ? (
               <Icon
+                data-testid={`inactive-wallet-icon${isActivating ? "-activating" : ""}`}
                 fontAwesome={classNames({
                   "fas fa-plug": !isActivating,
                 })}

--- a/src/ui/components/Icon/index.tsx
+++ b/src/ui/components/Icon/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { MouseEventHandler } from "react";
+import { forwardRef, MouseEventHandler, Ref } from "react";
 
 import "./icon.scss";
 
@@ -12,16 +12,20 @@ export interface IconProps {
   onClick?: MouseEventHandler;
 }
 
-export const Icon = ({
-  url = "",
-  size = 0.75,
-  className = "",
-  disabled = false,
-  fontAwesome = "",
-  onClick = undefined,
-  ...rest
-}: IconProps): JSX.Element => (
+const IconUI = (
+  {
+    url = "",
+    size = 0.75,
+    className = "",
+    disabled = false,
+    fontAwesome = "",
+    onClick = undefined,
+    ...rest
+  }: IconProps,
+  ref: Ref<HTMLDivElement>,
+): JSX.Element => (
   <div
+    ref={ref}
     {...rest}
     className={classNames("icon", className, {
       "icon--disabled": disabled,
@@ -38,3 +42,5 @@ export const Icon = ({
     {fontAwesome && <i className={`fas ${fontAwesome}`} />}
   </div>
 );
+
+export const Icon = forwardRef(IconUI);

--- a/src/ui/components/Input/index.tsx
+++ b/src/ui/components/Input/index.tsx
@@ -1,15 +1,16 @@
 import classNames from "classnames";
-import { forwardRef, InputHTMLAttributes, Ref } from "react";
+import { forwardRef, InputHTMLAttributes, ReactElement, Ref } from "react";
 
 import "./input.scss";
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
+  icon?: ReactElement;
   errorMessage?: string;
 }
 
 const InputUI = (
-  { id, label, className, errorMessage = "", ...inputProps }: InputProps,
+  { id, label, className, errorMessage = "", icon = undefined, ...inputProps }: InputProps,
   ref: Ref<HTMLInputElement>,
 ): JSX.Element => (
   <div className={classNames("input-group", className)}>
@@ -23,12 +24,14 @@ const InputUI = (
       <input
         ref={ref}
         className={classNames("input", {
-          "input--full-width": true,
+          "input--full-width": !icon,
         })}
         id={id}
         title={label}
         {...inputProps}
       />
+
+      {icon}
     </div>
 
     <p className="input-group__error-message">{errorMessage}</p>

--- a/src/ui/components/Input/input.scss
+++ b/src/ui/components/Input/input.scss
@@ -44,6 +44,8 @@
     background-color: lighten($black, 15);
     border-bottom: 1px solid transparent;
     border-radius: 0.125rem;
+    display: flex;
+    align-items: center;
 
     &:focus-within {
       background-color: $gray-900;
@@ -51,16 +53,18 @@
     }
 
     .icon {
-      opacity: 0.1;
+      opacity: 1;
       transition: opacity 150ms ease-in-out;
       margin-right: 0.75rem;
+      height: 0.75rem;
+      width: 0.75rem;
 
       &:hover {
-        opacity: 0.2;
+        opacity: 0.7;
       }
 
       &:active {
-        opacity: 0.3;
+        opacity: 0.8;
       }
     }
   }

--- a/src/ui/components/Menuable/Menuable.tsx
+++ b/src/ui/components/Menuable/Menuable.tsx
@@ -10,7 +10,7 @@ import { useMenuable, ItemProps } from "./useMenuable";
 
 export interface MenuableProps {
   items: ItemProps[];
-  children?: ReactNode;
+  children: ReactNode;
   className?: string;
   menuClassName?: string;
   opened?: boolean;
@@ -20,10 +20,10 @@ export interface MenuableProps {
 
 export const Menuable = ({
   items,
+  children,
   opened = false,
   className = "",
   menuClassName = "",
-  children = undefined,
   onOpen = undefined,
   onClose = undefined,
 }: MenuableProps): JSX.Element => {

--- a/src/ui/hooks/validation/__tests__/useValidationResolver.test.ts
+++ b/src/ui/hooks/validation/__tests__/useValidationResolver.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { object, string } from "yup";
+
+import { useValidationResolver } from "..";
+
+describe("ui/hooks/validation", () => {
+  const schema = object().shape({
+    password: string().required("Password is required").min(8, "Min password length is 8 symbols"),
+  });
+
+  test("should return validated values properly", async () => {
+    const { result } = renderHook(() => useValidationResolver(schema));
+
+    const args = { password: "12345678" };
+    const { values, errors } = await result.current(args);
+
+    expect(values).toStrictEqual(args);
+    expect(errors).toStrictEqual({});
+  });
+
+  test("should handle validation errors properly", async () => {
+    const { result } = renderHook(() => useValidationResolver(schema));
+
+    const args = { password: "" };
+    const { values, errors } = await result.current(args);
+
+    expect(values).toStrictEqual(args);
+    expect(errors).toStrictEqual({
+      password: {
+        type: "min",
+        message: "Min password length is 8 symbols",
+      },
+    });
+  });
+});

--- a/src/ui/hooks/validation/index.ts
+++ b/src/ui/hooks/validation/index.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+
+import type { Schema, ValidationError } from "yup";
+
+export type ValidationResolver<T> = (data: T) => Promise<{ values: T; errors: Errors }>;
+type Errors = Record<string, { type: string; message: string }>;
+
+export const useValidationResolver = <T>(validationSchema: Schema<T>): ValidationResolver<T> =>
+  useCallback(
+    async (data: T) =>
+      validationSchema
+        .validate(data, {
+          abortEarly: false,
+          stripUnknown: true,
+          recursive: true,
+        })
+        .then((res) => ({ values: res, errors: {} }))
+        .catch((error: ValidationError) => {
+          const errors = error.inner.reduce(
+            (allErrors: Errors, currentError: ValidationError) => ({
+              ...allErrors,
+              [currentError.path as string]: {
+                type: currentError.type as string,
+                message: currentError.message,
+              },
+            }),
+            {},
+          );
+
+          return { values: data, errors };
+        }),
+    [validationSchema],
+  );

--- a/src/ui/hooks/wallet/__tests__/useWallet.test.ts
+++ b/src/ui/hooks/wallet/__tests__/useWallet.test.ts
@@ -134,4 +134,15 @@ describe("ui/hooks/wallet", () => {
       payload: { isDisconnectedPermanently: true },
     });
   });
+
+  test("should lock properly", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => result.current.onLock());
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.LOCK,
+    });
+  });
 });

--- a/src/ui/hooks/wallet/index.ts
+++ b/src/ui/hooks/wallet/index.ts
@@ -22,6 +22,7 @@ export interface IUseWalletData {
   provider?: BrowserProvider;
   onConnect: () => Promise<void>;
   onConnectEagerly: () => Promise<void>;
+  onLock: () => Promise<void>;
   onDisconnect: () => Promise<void>;
 }
 
@@ -71,6 +72,10 @@ export const useWallet = (): IUseWalletData => {
     await postMessage({ method: RPCAction.SET_CONNECT_WALLET, payload: { isDisconnectedPermanently: true } });
   }, [connector]);
 
+  const onLock = useCallback(async () => {
+    await postMessage({ method: RPCAction.LOCK });
+  }, []);
+
   return {
     isActive,
     isActivating,
@@ -83,5 +88,6 @@ export const useWallet = (): IUseWalletData => {
     onConnect,
     onConnectEagerly,
     onDisconnect,
+    onLock,
   };
 };

--- a/src/ui/pages/Home/Home.tsx
+++ b/src/ui/pages/Home/Home.tsx
@@ -9,7 +9,7 @@ import { useHome } from "./useHome";
 const Home = (): JSX.Element => {
   const {
     scrollRef,
-    fixedTabs,
+    isFixedTabsMode,
     address,
     chain,
     balance,
@@ -26,7 +26,7 @@ const Home = (): JSX.Element => {
       <div
         ref={scrollRef}
         className={classNames("flex flex-col flex-grow flex-shrink overflow-y-auto home__scroller", {
-          "home__scroller--fixed-menu": fixedTabs,
+          "home__scroller--fixed-menu": isFixedTabsMode,
         })}
         onScroll={onScroll}
       >

--- a/src/ui/pages/Home/__tests__/Home.test.tsx
+++ b/src/ui/pages/Home/__tests__/Home.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { useWallet } from "@src/ui/hooks/wallet";
+
+import Home from "..";
+import { IUseHomeData, useHome } from "../useHome";
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
+}));
+
+jest.mock("../useHome", (): unknown => ({
+  useHome: jest.fn(),
+}));
+
+describe("ui/pages/Home", () => {
+  const defaultHookData: IUseHomeData = {
+    isFixedTabsMode: false,
+    identities: [],
+    scrollRef: { current: null },
+    address: defaultWalletHookData.address,
+    balance: defaultWalletHookData.balance,
+    chain: defaultWalletHookData.chain,
+    refreshConnectionStatus: jest.fn().mockResolvedValue(true),
+    onDeleteAllIdentities: jest.fn(),
+    onScroll: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useHome as jest.Mock).mockReturnValue(defaultHookData);
+
+    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { container, findByTestId } = render(
+      <Suspense>
+        <Home />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const page = await findByTestId("home-page");
+
+    expect(page).toBeInTheDocument();
+  });
+});

--- a/src/ui/pages/Home/__tests__/useHome.test.ts
+++ b/src/ui/pages/Home/__tests__/useHome.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { browser } from "webextension-polyfill-ts";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { RPCAction } from "@src/constants";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { IdentityData, useIdentities, fetchIdentities, deleteAllIdentities } from "@src/ui/ducks/identities";
+import { useWallet } from "@src/ui/hooks/wallet";
+import postMessage from "@src/util/postMessage";
+
+import { useHome } from "../useHome";
+
+jest.mock("react", (): unknown => ({
+  ...jest.requireActual("react"),
+  useRef: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/identities", (): unknown => ({
+  fetchIdentities: jest.fn(),
+  deleteAllIdentities: jest.fn(),
+  useIdentities: jest.fn(),
+}));
+
+describe("ui/pages/Home/useHome", () => {
+  const mockDispatch = jest.fn();
+
+  const defaultIdentities: IdentityData[] = [
+    {
+      commitment: "1",
+      metadata: {
+        account: defaultWalletHookData.address as string,
+        name: "Account #1",
+        identityStrategy: "interrep",
+        web2Provider: "twitter",
+      },
+    },
+    {
+      commitment: "2",
+      metadata: {
+        account: defaultWalletHookData.address as string,
+        name: "Account #2",
+        identityStrategy: "random",
+      },
+    },
+  ];
+
+  const defaultTabs = [{ id: 1, url: "http://localhost:3000" }];
+
+  beforeEach(() => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+
+    (useRef as jest.Mock).mockReturnValue({ current: null });
+
+    (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useIdentities as jest.Mock).mockReturnValue(defaultIdentities);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return initial data", () => {
+    const { result } = renderHook(() => useHome());
+
+    expect(result.current.address).toBe(defaultWalletHookData.address);
+    expect(result.current.balance).toStrictEqual(defaultWalletHookData.balance);
+    expect(result.current.chain).toStrictEqual(defaultWalletHookData.chain);
+    expect(result.current.isFixedTabsMode).toBe(false);
+    expect(result.current.scrollRef.current).toBeNull();
+    expect(result.current.identities).toStrictEqual(defaultIdentities);
+    expect(fetchIdentities).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(1);
+  });
+
+  test("should refresh connection status properly", async () => {
+    const { result } = renderHook(() => useHome());
+
+    await act(async () => result.current.refreshConnectionStatus());
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.IS_HOST_APPROVED,
+      payload: defaultTabs[0].url,
+    });
+  });
+
+  test("should not refresh connection status if there is no any tab", async () => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useHome());
+
+    await act(async () => result.current.refreshConnectionStatus());
+
+    expect(postMessage).not.toBeCalled();
+  });
+
+  test("should delete all identities properly", async () => {
+    const { result } = renderHook(() => useHome());
+
+    await act(async () => Promise.resolve(result.current.onDeleteAllIdentities()));
+
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(deleteAllIdentities).toBeCalledTimes(1);
+  });
+
+  test("should set fixed tabs mode properly", async () => {
+    (useRef as jest.Mock).mockReturnValue({ current: { scrollTop: 100 } });
+
+    const { result } = renderHook(() => useHome());
+
+    await act(async () => Promise.resolve(result.current.onScroll()));
+
+    expect(result.current.isFixedTabsMode).toBe(true);
+  });
+
+  test("should not set fixed tabs mode if there is no ref", async () => {
+    const { result } = renderHook(() => useHome());
+
+    await act(async () => Promise.resolve(result.current.onScroll()));
+
+    expect(result.current.isFixedTabsMode).toBe(false);
+  });
+});

--- a/src/ui/pages/Home/useHome.ts
+++ b/src/ui/pages/Home/useHome.ts
@@ -10,47 +10,44 @@ import { useWallet } from "@src/ui/hooks/wallet";
 import postMessage from "@src/util/postMessage";
 
 export interface IUseHomeData {
+  isFixedTabsMode: boolean;
+  identities: IdentityData[];
   scrollRef: RefObject<HTMLDivElement>;
-  fixedTabs: boolean;
   address?: string;
   balance?: BigNumber;
   chain?: Chain;
-  identities: IdentityData[];
   refreshConnectionStatus: () => Promise<boolean>;
   onDeleteAllIdentities: () => void;
   onScroll: () => void;
 }
+
+const SCROLL_THRESHOLD = 92;
 
 export const useHome = (): IUseHomeData => {
   const dispatch = useAppDispatch();
   const identities = useIdentities();
 
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [fixedTabs, fixTabs] = useState(false);
+  const [isFixedTabsMode, setFixTabsMode] = useState(false);
 
   const { address, chain, balance } = useWallet();
-
-  useEffect(() => {
-    dispatch(fetchIdentities());
-  }, [dispatch]);
 
   const onScroll = useCallback(() => {
     if (!scrollRef.current) {
       return;
     }
 
-    fixTabs(scrollRef.current.scrollTop > 92);
-  }, [scrollRef, fixTabs]);
+    setFixTabsMode(scrollRef.current.scrollTop > SCROLL_THRESHOLD);
+  }, [scrollRef, setFixTabsMode]);
 
   const onDeleteAllIdentities = useCallback(() => {
     dispatch(deleteAllIdentities());
   }, [dispatch]);
 
   const refreshConnectionStatus = useCallback(async () => {
-    const tabs = await browser.tabs.query({ active: true, lastFocusedWindow: true });
-    const [tab] = tabs;
+    const [tab] = await browser.tabs.query({ active: true, lastFocusedWindow: true });
 
-    if (!tab.url) {
+    if (!tab?.url) {
       return false;
     }
 
@@ -60,9 +57,13 @@ export const useHome = (): IUseHomeData => {
     });
   }, []);
 
+  useEffect(() => {
+    dispatch(fetchIdentities());
+  }, [dispatch]);
+
   return {
     scrollRef,
-    fixedTabs,
+    isFixedTabsMode,
     address,
     chain,
     balance,

--- a/src/ui/pages/Onboarding/Onboarding.tsx
+++ b/src/ui/pages/Onboarding/Onboarding.tsx
@@ -1,3 +1,5 @@
+import Tooltip from "@mui/material/Tooltip";
+
 import logoSVG from "@src/static/icons/logo.svg";
 import { ButtonType, Button } from "@src/ui/components/Button";
 import { Icon } from "@src/ui/components/Icon";
@@ -12,7 +14,7 @@ const Onboarding = (): JSX.Element => {
   return (
     <form className="flex flex-col flex-nowrap h-full onboarding" data-testid="onboarding-form" onSubmit={onSubmit}>
       <div className="flex flex-col items-center flex-grow p-8 onboarding__content">
-        <Icon url={logoSVG} />
+        <Icon size={8} url={logoSVG} />
 
         <div className="text-lg pt-8">
           <b>Thanks for using CryptKeeper!</b>
@@ -25,10 +27,32 @@ const Onboarding = (): JSX.Element => {
             autoFocus
             className="mb-4"
             errorMessage={errors.password}
+            icon={
+              <Tooltip
+                className="info-tooltip"
+                title={
+                  <div>
+                    <p>Password requirements:</p>
+
+                    <p>- At least 8 characters</p>
+
+                    <p>- At least 1 upper case and letter</p>
+
+                    <p>- At least 1 lower case letter</p>
+
+                    <p>- At least 1 special character (!@#$%^&*)</p>
+
+                    <p>- At least 1 number</p>
+                  </div>
+                }
+              >
+                <Icon className="info-icon" fontAwesome="fa-info" />
+              </Tooltip>
+            }
             id="password"
             label="Password"
             type="password"
-            {...register("password", { required: "Password is required" })}
+            {...register("password")}
           />
 
           <Input
@@ -36,10 +60,7 @@ const Onboarding = (): JSX.Element => {
             id="confirmPassword"
             label="Confirm Password"
             type="password"
-            {...register("confirmPassword", {
-              required: "Confirm your password",
-              validate: (_, values) => (values.password !== values.confirmPassword ? "Passwords must match" : true),
-            })}
+            {...register("confirmPassword")}
           />
         </div>
       </div>

--- a/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
@@ -48,10 +48,12 @@ describe("ui/pages/Onboarding", () => {
     await waitFor(() => container.firstChild !== null);
 
     const passwordInput = await screen.findByLabelText("Password");
-    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "password" } })));
+    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "Password123@" } })));
 
     const confirmPasswordInput = await screen.findByLabelText("Confirm Password");
-    await act(async () => Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "password" } })));
+    await act(async () =>
+      Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "Password123@" } })),
+    );
 
     const button = await screen.findByTestId("submit-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
@@ -66,15 +68,35 @@ describe("ui/pages/Onboarding", () => {
     await waitFor(() => container.firstChild !== null);
 
     const passwordInput = await screen.findByLabelText("Password");
-    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "password1" } })));
+    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "Password123@" } })));
 
     const confirmPasswordInput = await screen.findByLabelText("Confirm Password");
-    await act(async () => Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "password2" } })));
+    await act(async () =>
+      Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "Password123@4" } })),
+    );
 
     const button = await screen.findByTestId("submit-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
     const error = await screen.findByText("Passwords must match");
+    expect(error).toBeInTheDocument();
+  });
+
+  test("should render weak password error properly", async () => {
+    const { container } = render(<Onboarding />);
+
+    await waitFor(() => container.firstChild !== null);
+
+    const passwordInput = await screen.findByLabelText("Password");
+    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "12345" } })));
+
+    const confirmPasswordInput = await screen.findByLabelText("Confirm Password");
+    await act(async () => Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "12345" } })));
+
+    const button = await screen.findByTestId("submit-button");
+    await act(async () => Promise.resolve(fireEvent.submit(button)));
+
+    const error = await screen.findByText("Password isn't strong");
     expect(error).toBeInTheDocument();
   });
 
@@ -84,16 +106,18 @@ describe("ui/pages/Onboarding", () => {
     await waitFor(() => container.firstChild !== null);
 
     const passwordInput = await screen.findByLabelText("Password");
-    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "password" } })));
+    await act(async () => Promise.resolve(fireEvent.change(passwordInput, { target: { value: "Password123@" } })));
 
     const confirmPasswordInput = await screen.findByLabelText("Confirm Password");
-    await act(async () => Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "password" } })));
+    await act(async () =>
+      Promise.resolve(fireEvent.change(confirmPasswordInput, { target: { value: "Password123@" } })),
+    );
 
     const button = await screen.findByTestId("submit-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
     expect(mockDispatch).toBeCalledTimes(1);
     expect(setupPassword).toBeCalledTimes(1);
-    expect(setupPassword).toBeCalledWith("password");
+    expect(setupPassword).toBeCalledWith("Password123@");
   });
 });

--- a/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
+++ b/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
@@ -19,6 +19,10 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
 }));
 
+jest.mock("@src/ui/hooks/validation", (): unknown => ({
+  useValidationResolver: jest.fn(),
+}));
+
 describe("ui/pages/Onboarding/useOnboarding", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
 
@@ -43,24 +47,14 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
     const { result } = renderHook(() => useOnboarding());
 
     await act(async () =>
-      Promise.resolve(
-        result.current
-          .register("password")
-          .onChange({ target: { value: "password" } } as ChangeEvent<HTMLInputElement>),
-      ),
+      Promise.resolve(result.current.register("password").onChange({ target: { value: "Password123@" } })),
     );
 
     await act(() =>
-      Promise.resolve(
-        result.current.register("confirmPassword").onChange({
-          target: { value: "password" },
-        } as ChangeEvent<HTMLInputElement>),
-      ),
+      Promise.resolve(result.current.register("confirmPassword").onChange({ target: { value: "Password123@" } })),
     );
 
-    await act(async () =>
-      Promise.resolve(result.current.onSubmit({ preventDefault: jest.fn() } as unknown as FormEvent<HTMLFormElement>)),
-    );
+    await act(async () => Promise.resolve(result.current.onSubmit()));
     await waitFor(() => result.current.isLoading !== true);
 
     expect(result.current.isLoading).toBe(false);
@@ -76,14 +70,14 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
       Promise.resolve(
         result.current
           .register("password")
-          .onChange({ target: { value: "password" } } as ChangeEvent<HTMLInputElement>),
+          .onChange({ target: { value: "Password123@" } } as ChangeEvent<HTMLInputElement>),
       ),
     );
 
     await act(() =>
       Promise.resolve(
         result.current.register("confirmPassword").onChange({
-          target: { value: "password" },
+          target: { value: "Password123@" },
         } as ChangeEvent<HTMLInputElement>),
       ),
     );

--- a/src/ui/pages/Onboarding/onboarding.scss
+++ b/src/ui/pages/Onboarding/onboarding.scss
@@ -4,9 +4,14 @@
   color: $primary-green;
 
   &__content {
-    .icon {
-      width: 8rem !important;
-      height: 8rem !important;
+    .info-tooltip {
+      height: 0.75rem;
+      width: 0.75rem;
+    }
+
+    .info-icon {
+      color: $primary-green;
+      cursor: pointer;
     }
   }
 }

--- a/src/ui/pages/Onboarding/useOnboarding.ts
+++ b/src/ui/pages/Onboarding/useOnboarding.ts
@@ -1,8 +1,10 @@
 import { BaseSyntheticEvent, useCallback } from "react";
 import { useForm, UseFormRegister } from "react-hook-form";
+import { object, ref, string } from "yup";
 
 import { setupPassword } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { useValidationResolver } from "@src/ui/hooks/validation";
 
 export interface IUseOnboardingData {
   isLoading: boolean;
@@ -16,13 +18,28 @@ interface FormFields {
   confirmPassword: string;
 }
 
+const passwordRules = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/;
+
+const validationSchema = object({
+  password: string()
+    .matches(passwordRules, {
+      message: "Password isn't strong",
+    })
+    .required("Password is required"),
+  confirmPassword: string()
+    .oneOf([ref("password"), ""], "Passwords must match")
+    .required("Confirm your password"),
+});
+
 export const useOnboarding = (): IUseOnboardingData => {
+  const resolver = useValidationResolver(validationSchema);
   const {
     formState: { isLoading, isSubmitting, errors },
     setError,
     register,
     handleSubmit,
   } = useForm<FormFields>({
+    resolver,
     defaultValues: {
       password: "",
       confirmPassword: "",


### PR DESCRIPTION
## Explanation

This PR adds password strength rules for onboarding page and some testing chores.

Details are below:
- [x] Add password strength rules
- [x] Integrate yup and react-hook-form
- [x] Add missing tests for Home and Header
- [x] Set coverage threshold

## More Information

Closes #191
Blocked by #200 

## Screenshots/Screencaps

### Before

N/A

### After

![image](https://user-images.githubusercontent.com/14254374/228951903-1097bf62-e38e-46b3-a6cc-086392b81133.png)
![image](https://user-images.githubusercontent.com/14254374/228951963-edb685bb-b124-4e7d-90b1-9b2826823040.png)

## Manual Testing Steps

1. Go to onboarding page
2. Try to check different types and combinations of passwords and then submit the form
3. Check validation messages

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
