### PR TITLE
refactor: use duck as a separate layer of logic

### DIFF
--- a/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
+++ b/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
@@ -9,13 +9,25 @@ import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { PendingRequestType } from "@src/types";
 
 import ConfirmRequestModal from "..";
+import {
+  IUseConnectionApprovalModalData,
+  useConnectionApprovalModal,
+} from "../components/ConnectionApprovalModal/useConnectionApprovalModal";
 import { IUseConfirmRequestModalData, useConfirmRequestModal } from "../useConfirmRequestModal";
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
 
 jest.mock("../useConfirmRequestModal", (): unknown => ({
   useConfirmRequestModal: jest.fn(),
 }));
 
-describe("ui/components/ConnectionModal/ConnectionModal", () => {
+jest.mock("../components/ConnectionApprovalModal/useConnectionApprovalModal", (): unknown => ({
+  useConnectionApprovalModal: jest.fn(),
+}));
+
+describe("ui/components/ConfirmRequestModal", () => {
   const defaultHookData: IUseConfirmRequestModalData = {
     error: "",
     loading: false,
@@ -24,8 +36,19 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
     reject: jest.fn(),
   };
 
+  const defaultConnectionModalHookData: IUseConnectionApprovalModalData = {
+    host: "http://localhost:3000",
+    checked: false,
+    faviconUrl: "http://localhost:3000/favicon.ico",
+    onAccept: jest.fn(),
+    onReject: jest.fn(),
+    onSetApproval: jest.fn(),
+  };
+
   beforeEach(() => {
     (useConfirmRequestModal as jest.Mock).mockReturnValue(defaultHookData);
+
+    (useConnectionApprovalModal as jest.Mock).mockReturnValue(defaultConnectionModalHookData);
 
     createModalRoot();
   });

--- a/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
+++ b/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
@@ -1,9 +1,8 @@
 import { useCallback, useState } from "react";
 
-import { RPCAction } from "@src/constants";
 import { PendingRequest, RequestResolutionAction, RequestResolutionStatus } from "@src/types";
-import { usePendingRequests } from "@src/ui/ducks/requests";
-import postMessage from "@src/util/postMessage";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { finalizeRequest, usePendingRequests } from "@src/ui/ducks/requests";
 
 export interface IUseConfirmRequestModalData {
   error: string;
@@ -15,6 +14,7 @@ export interface IUseConfirmRequestModalData {
 
 export const useConfirmRequestModal = (): IUseConfirmRequestModalData => {
   const pendingRequests = usePendingRequests();
+  const dispatch = useAppDispatch();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [pendingRequest] = pendingRequests;
@@ -28,14 +28,11 @@ export const useConfirmRequestModal = (): IUseConfirmRequestModalData => {
       };
 
       setLoading(true);
-      postMessage({
-        method: RPCAction.FINALIZE_REQUEST,
-        payload: req,
-      })
+      dispatch(finalizeRequest(req))
         .catch((e: Error) => setError(e.message))
         .finally(() => setLoading(false));
     },
-    [pendingRequest?.id, setLoading, setError],
+    [pendingRequest?.id, setLoading, setError, dispatch],
   );
 
   const accept = useCallback(
@@ -47,10 +44,7 @@ export const useConfirmRequestModal = (): IUseConfirmRequestModalData => {
       };
 
       setLoading(true);
-      postMessage({
-        method: RPCAction.FINALIZE_REQUEST,
-        payload: req,
-      })
+      dispatch(finalizeRequest(req))
         .catch((e: Error) => setError(e.message))
         .finally(() => setLoading(false));
     },

--- a/src/ui/ducks/__tests__/permissions.test.tsx
+++ b/src/ui/ducks/__tests__/permissions.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+
+import { RPCAction } from "@src/constants";
+import { store } from "@src/ui/store/configureAppStore";
+import postMessage from "@src/util/postMessage";
+
+import {
+  checkHostApproval,
+  fetchHostPermissions,
+  removeHost,
+  setHostPermissions,
+  useHostPermission,
+} from "../permissions";
+
+describe("ui/ducks/permissions", () => {
+  const defaultHost = "http://localhost:3000";
+  const defaultPermission = {
+    noApproval: true,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should fetch host permissions properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue(defaultPermission);
+
+    await Promise.resolve(store.dispatch(fetchHostPermissions(defaultHost)));
+    const { permissions } = store.getState();
+    const { result } = renderHook(() => useHostPermission(defaultHost), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    expect(permissions.noApprovals).toStrictEqual({ [defaultHost]: { host: defaultHost, ...defaultPermission } });
+    expect(result.current).toStrictEqual({ host: defaultHost, ...defaultPermission });
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.GET_HOST_PERMISSIONS,
+      payload: defaultHost,
+    });
+  });
+
+  test("should set host permission properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue({ ...defaultPermission, noApproval: false });
+
+    await Promise.resolve(store.dispatch(setHostPermissions({ host: defaultHost, noApproval: false })));
+    const { permissions } = store.getState();
+    const { result } = renderHook(() => useHostPermission(defaultHost), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    expect(permissions.noApprovals).toStrictEqual({ [defaultHost]: { host: defaultHost, noApproval: false } });
+    expect(result.current).toStrictEqual({ host: defaultHost, noApproval: false });
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.SET_HOST_PERMISSIONS,
+      payload: {
+        host: defaultHost,
+        noApproval: false,
+      },
+    });
+  });
+
+  test("should remove host properly", async () => {
+    await Promise.resolve(store.dispatch(removeHost(defaultHost)));
+    const { permissions } = store.getState();
+    const { result } = renderHook(() => useHostPermission(defaultHost), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    expect(permissions.noApprovals).toStrictEqual({});
+    expect(result.current).toBeUndefined();
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.REMOVE_HOST,
+      payload: {
+        host: defaultHost,
+      },
+    });
+  });
+
+  test("should check host approval properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue(true);
+
+    const result = await store.dispatch(checkHostApproval(defaultHost));
+
+    expect(result).toBe(true);
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.IS_HOST_APPROVED,
+      payload: defaultHost,
+    });
+  });
+});

--- a/src/ui/ducks/__tests__/requests.test.tsx
+++ b/src/ui/ducks/__tests__/requests.test.tsx
@@ -5,11 +5,12 @@
 import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 
-import { PendingRequest, PendingRequestType } from "@src/types";
+import { RPCAction } from "@src/constants";
+import { PendingRequest, PendingRequestType, RequestResolutionStatus } from "@src/types";
 import { store } from "@src/ui/store/configureAppStore";
 import postMessage from "@src/util/postMessage";
 
-import { fetchPendingRequests, setPendingRequests, usePendingRequests } from "../requests";
+import { fetchPendingRequests, finalizeRequest, setPendingRequests, usePendingRequests } from "../requests";
 
 describe("ui/ducks/requests", () => {
   const defaultPendingRequests: PendingRequest[] = [{ id: "1", windowId: 1, type: PendingRequestType.APPROVE }];
@@ -29,6 +30,26 @@ describe("ui/ducks/requests", () => {
 
     expect(requests.pendingRequests).toStrictEqual(defaultPendingRequests);
     expect(result.current).toStrictEqual(defaultPendingRequests);
+  });
+
+  test("should finalize request properly", async () => {
+    await Promise.resolve(
+      store.dispatch(
+        finalizeRequest({
+          id: "1",
+          status: RequestResolutionStatus.ACCEPT,
+        }),
+      ),
+    );
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.FINALIZE_REQUEST,
+      payload: {
+        id: "1",
+        status: RequestResolutionStatus.ACCEPT,
+      },
+    });
   });
 
   test("should set pending requests properly", async () => {

--- a/src/ui/ducks/app.ts
+++ b/src/ui/ducks/app.ts
@@ -13,25 +13,35 @@ import { useAppSelector } from "./hooks";
 export interface AppState {
   isInitialized: boolean;
   isUnlocked: boolean;
+  isDisconnectedPermanently?: boolean;
 }
 
 const initialState: AppState = {
   isInitialized: false,
   isUnlocked: false,
+  isDisconnectedPermanently: undefined,
 };
 
 const appSlice = createSlice({
   name: "app",
   initialState,
   reducers: {
-    setStatus: (state: AppState, action: PayloadAction<AppState>) => {
+    setStatus: (state: AppState, action: PayloadAction<Omit<AppState, "isDisconnectedPermanently">>) => {
       state.isInitialized = action.payload.isInitialized;
       state.isUnlocked = action.payload.isUnlocked;
+    },
+
+    setDisconnectedPermanently: (state: AppState, action: PayloadAction<boolean>) => {
+      state.isDisconnectedPermanently = action.payload;
     },
   },
 });
 
 export const { setStatus } = appSlice.actions;
+
+export const lock = () => async (): Promise<void> => {
+  await postMessage({ method: RPCAction.LOCK });
+};
 
 export const closePopup = () => async (): Promise<void> => {
   await postMessage({ method: RPCAction.CLOSE_POPUP });
@@ -47,6 +57,22 @@ export const fetchStatus = (): TypedThunk => async (dispatch) => {
   const status = await postMessage<AppState>({ method: RPCAction.GET_STATUS });
   dispatch(setStatus(status));
 };
+
+export const setWalletConnection =
+  (isDisconnectedPermanently: boolean): TypedThunk =>
+  async (dispatch): Promise<void> => {
+    await postMessage({ method: RPCAction.SET_CONNECT_WALLET, payload: { isDisconnectedPermanently } });
+    dispatch(appSlice.actions.setDisconnectedPermanently(isDisconnectedPermanently));
+  };
+
+export const getWalletConnection =
+  (): TypedThunk =>
+  async (dispatch): Promise<void> => {
+    const response = await postMessage<{ isDisconnectedPermanently: boolean }>({
+      method: RPCAction.GET_CONNECT_WALLET,
+    });
+    dispatch(appSlice.actions.setDisconnectedPermanently(Boolean(response?.isDisconnectedPermanently)));
+  };
 
 export const useAppStatus = (): AppState => useAppSelector((state) => state.app, deepEqual);
 

--- a/src/ui/ducks/permissions.ts
+++ b/src/ui/ducks/permissions.ts
@@ -1,0 +1,90 @@
+/* eslint-disable no-param-reassign */
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import deepEqual from "fast-deep-equal";
+
+import { RPCAction } from "@src/constants";
+import postMessage from "@src/util/postMessage";
+
+import type { TypedThunk } from "../store/configureAppStore";
+
+import { useAppSelector } from "./hooks";
+
+export interface PermissionsState {
+  noApprovals: Record<string, HostPermission>;
+}
+
+export interface HostPermission {
+  noApproval: boolean;
+  host: string;
+}
+
+const initialState: PermissionsState = {
+  noApprovals: {},
+};
+
+const permissionsSlice = createSlice({
+  name: "permissions",
+  initialState,
+  reducers: {
+    setPermission: (state: PermissionsState, action: PayloadAction<HostPermission>) => {
+      state.noApprovals[action.payload.host] = action.payload;
+    },
+
+    removeHostPermission: (state: PermissionsState, action: PayloadAction<string>) => {
+      delete state.noApprovals[action.payload];
+    },
+  },
+});
+
+const { setPermission, removeHostPermission } = permissionsSlice.actions;
+
+export const fetchHostPermissions =
+  (host: string): TypedThunk<Promise<void>> =>
+  async (dispatch) => {
+    const res = await postMessage<{ noApproval: boolean }>({
+      method: RPCAction.GET_HOST_PERMISSIONS,
+      payload: host,
+    });
+
+    dispatch(setPermission({ host, noApproval: res.noApproval }));
+  };
+
+export const setHostPermissions =
+  (permission: HostPermission): TypedThunk<Promise<void>> =>
+  async (dispatch) => {
+    await postMessage<{ noApproval: boolean }>({
+      method: RPCAction.SET_HOST_PERMISSIONS,
+      payload: {
+        host: permission.host,
+        noApproval: permission.noApproval,
+      },
+    });
+
+    dispatch(setPermission(permission));
+  };
+
+export const removeHost =
+  (host: string): TypedThunk<Promise<void>> =>
+  async (dispatch) => {
+    await postMessage({
+      method: RPCAction.REMOVE_HOST,
+      payload: {
+        host,
+      },
+    });
+
+    dispatch(removeHostPermission(host));
+  };
+
+export const checkHostApproval =
+  (host: string): TypedThunk<Promise<boolean>> =>
+  async () =>
+    postMessage({
+      method: RPCAction.IS_HOST_APPROVED,
+      payload: host,
+    });
+
+export const useHostPermission = (host: string): HostPermission | undefined =>
+  useAppSelector((state) => state.permissions.noApprovals[host], deepEqual);
+
+export default permissionsSlice.reducer;

--- a/src/ui/ducks/requests.ts
+++ b/src/ui/ducks/requests.ts
@@ -5,7 +5,7 @@ import deepEqual from "fast-deep-equal";
 import { RPCAction } from "@src/constants";
 import postMessage from "@src/util/postMessage";
 
-import type { PendingRequest } from "@src/types";
+import type { PendingRequest, RequestResolutionAction } from "@src/types";
 import type { TypedThunk } from "@src/ui/store/configureAppStore";
 
 import { useAppSelector } from "./hooks";
@@ -34,6 +34,14 @@ export const fetchPendingRequests = (): TypedThunk => async (dispatch) => {
   const pendingRequests = await postMessage<PendingRequest[]>({ method: RPCAction.GET_PENDING_REQUESTS });
   dispatch(setPendingRequests(pendingRequests));
 };
+
+export const finalizeRequest =
+  (request: RequestResolutionAction): TypedThunk<Promise<boolean>> =>
+  async (): Promise<boolean> =>
+    postMessage({
+      method: RPCAction.FINALIZE_REQUEST,
+      payload: request,
+    });
 
 export const usePendingRequests = (): PendingRequest[] =>
   useAppSelector((state) => state.requests.pendingRequests, deepEqual);

--- a/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
+++ b/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
@@ -6,9 +6,14 @@ import { act, render, screen } from "@testing-library/react";
 
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { IUseConnectionModalData, useConnectionModal } from "@src/ui/components/ConnectionModal/useConnectionModal";
 import { sliceAddress } from "@src/util/account";
 
 import { Info, InfoProps } from "..";
+
+jest.mock("@src/ui/components/ConnectionModal/useConnectionModal", (): unknown => ({
+  useConnectionModal: jest.fn(),
+}));
 
 describe("ui/pages/Home/components/Info", () => {
   const defaultProps: InfoProps = {
@@ -18,7 +23,17 @@ describe("ui/pages/Home/components/Info", () => {
     refreshConnectionStatus: jest.fn().mockResolvedValue(true),
   };
 
+  const defaultConnectionModalHookData: IUseConnectionModalData = {
+    url: new URL("http://localhost:3000"),
+    checked: false,
+    faviconUrl: "http://localhost:3000/favicon.ico",
+    onSetApproval: jest.fn(),
+    onRemoveHost: jest.fn(),
+  };
+
   beforeEach(() => {
+    (useConnectionModal as jest.Mock).mockReturnValue(defaultConnectionModalHookData);
+
     createModalRoot();
   });
 

--- a/src/ui/pages/Home/useHome.ts
+++ b/src/ui/pages/Home/useHome.ts
@@ -1,13 +1,12 @@
 import BigNumber from "bignumber.js";
 import { useRef, useState, useEffect, useCallback, RefObject } from "react";
-import { browser } from "webextension-polyfill-ts";
 
 import { Chain } from "@src/config/rpc";
-import { RPCAction } from "@src/constants";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchIdentities, deleteAllIdentities, useIdentities, IdentityData } from "@src/ui/ducks/identities";
+import { checkHostApproval } from "@src/ui/ducks/permissions";
 import { useWallet } from "@src/ui/hooks/wallet";
-import postMessage from "@src/util/postMessage";
+import { getLastActiveTabUrl } from "@src/util/browser";
 
 export interface IUseHomeData {
   isFixedTabsMode: boolean;
@@ -45,17 +44,14 @@ export const useHome = (): IUseHomeData => {
   }, [dispatch]);
 
   const refreshConnectionStatus = useCallback(async () => {
-    const [tab] = await browser.tabs.query({ active: true, lastFocusedWindow: true });
+    const tabUrl = await getLastActiveTabUrl();
 
-    if (!tab?.url) {
+    if (!tabUrl) {
       return false;
     }
 
-    return postMessage<boolean>({
-      method: RPCAction.IS_HOST_APPROVED,
-      payload: new URL(tab.url).origin,
-    });
-  }, []);
+    return dispatch(checkHostApproval(tabUrl.origin));
+  }, [dispatch]);
 
   useEffect(() => {
     dispatch(fetchIdentities());

--- a/src/ui/store/configureAppStore.ts
+++ b/src/ui/store/configureAppStore.ts
@@ -5,12 +5,14 @@ import thunk from "redux-thunk";
 import { isDebugMode } from "@src/config/env";
 import app from "@src/ui/ducks/app";
 import identities from "@src/ui/ducks/identities";
+import permissions from "@src/ui/ducks/permissions";
 import requests from "@src/ui/ducks/requests";
 
 const rootReducer = {
   identities,
   requests,
   app,
+  permissions,
 };
 
 const middlewares = isDebugMode() ? [thunk, createLogger({ collapsed: true })] : [thunk];

--- a/src/util/__tests__/browser.test.ts
+++ b/src/util/__tests__/browser.test.ts
@@ -1,0 +1,29 @@
+import { browser } from "webextension-polyfill-ts";
+
+import { getLastActiveTabUrl } from "../browser";
+
+describe("util/browser", () => {
+  const defaultTabs = [{ url: "http://localhost:3000" }];
+
+  beforeEach(() => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should get last active tab url properly", async () => {
+    const url = await getLastActiveTabUrl();
+
+    expect(url?.origin).toBe(defaultTabs[0].url);
+  });
+
+  test("should return undefined if there is no tab url", async () => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue([]);
+
+    const url = await getLastActiveTabUrl();
+
+    expect(url).toBeUndefined();
+  });
+});

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -1,0 +1,7 @@
+import { browser } from "webextension-polyfill-ts";
+
+export const getLastActiveTabUrl = async (): Promise<URL | undefined> => {
+  const [tab] = await browser.tabs.query({ active: true, lastFocusedWindow: true });
+
+  return tab?.url ? new URL(tab.url) : undefined;
+};


### PR DESCRIPTION
## Explanation

This PR contains refactoring for hooks logic. Extension related logic moved to utils or ducks to improve stability and ability to reuse this functionality.

Details are below:
- [x] Add permissions ducks
- [x] Refactoring for ui hooks

## More Information

N/A

## Screenshots/Screencaps

### Before

N/A

### After

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
