### PR TITLE
chore: get active identity data (commitment + web2provider)

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -65,7 +65,7 @@ function App() {
   const [isLocked, setIsLocked] = useState(true);
   const [selectedIdentity, setSelectedIdentity] = useState<SelectedIdentity>({
     commitment: "",
-    web2Provider: ""
+    web2Provider: "",
   });
   const mockIdentityCommitments: string[] = genMockIdentityCommitments();
 
@@ -154,13 +154,16 @@ function App() {
 
     setSelectedIdentity({
       commitment: payload.commitment,
-      web2Provider: payload.web2Provider
+      web2Provider: payload.web2Provider,
     });
 
-    toast(<div>
-      <p>Getting Identity Commitment successfully! {payload.commitment}</p>
-      <p>Identity Web2 Provider is {payload.web2Provider}</p>
-    </div>, { type: "success" });
+    toast(
+      <div>
+        <p>Getting Identity Commitment successfully! {payload.commitment}</p>
+        <p>Identity Web2 Provider is {payload.web2Provider}</p>
+      </div>,
+      { type: "success" },
+    );
   }, [client, setSelectedIdentity]);
 
   const createIdentity = useCallback(() => {
@@ -194,7 +197,7 @@ function App() {
   const onLogout = useCallback(() => {
     setSelectedIdentity({
       commitment: "",
-      web2Provider: ""
+      web2Provider: "",
     });
     setIsLocked(true);
   }, [setSelectedIdentity, setIsLocked]);

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -11,7 +11,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-toastify": "^9.1.2",
-        "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs"
+        "rlnjs": "^2.0.6"
       },
       "devDependencies": {
         "@types/react": "^18.0.32",
@@ -5796,9 +5796,9 @@
       }
     },
     "node_modules/rlnjs": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#fa4f4b8ea47f525aec7fe7efe436d089059e0cbc",
-      "license": "MIT",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-2.0.6.tgz",
+      "integrity": "sha512-fh+GNx5eCtonPrDWuVIncNz82kdVpr+LEBuxFZ0Nna+Umkkc9wEOdmtQIdU+XxC23shHIjAEfMIbDOQmep52zw==",
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/solidity": "^5.6.1",
@@ -11341,8 +11341,9 @@
       }
     },
     "rlnjs": {
-      "version": "git+ssh://git@github.com/Rate-Limiting-Nullifier/rlnjs.git#fa4f4b8ea47f525aec7fe7efe436d089059e0cbc",
-      "from": "rlnjs@github:Rate-Limiting-Nullifier/rlnjs",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/rlnjs/-/rlnjs-2.0.6.tgz",
+      "integrity": "sha512-fh+GNx5eCtonPrDWuVIncNz82kdVpr+LEBuxFZ0Nna+Umkkc9wEOdmtQIdU+XxC23shHIjAEfMIbDOQmep52zw==",
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/solidity": "^5.6.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-toastify": "^9.1.2",
-    "rlnjs": "github:Rate-Limiting-Nullifier/rlnjs"
+    "rlnjs": "^2.0.6"
   },
   "devDependencies": {
     "@types/react": "^18.0.32",

--- a/src/background/services/__tests__/identityService.test.ts
+++ b/src/background/services/__tests__/identityService.test.ts
@@ -70,14 +70,18 @@ describe("background/services/identity", () => {
 
       expect(result).toBe(true);
       expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setSelectedCommitment(defaultIdentityCommitment));
+      expect(pushMessage).toBeCalledWith(setSelectedCommitment({
+        commitment: defaultIdentityCommitment,
+      }));
       expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
 
       for (let index = 0; index < defaultTabs.length; index += 1) {
         expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(
           index + 1,
           defaultTabs[index].id,
-          setSelectedCommitment(defaultIdentityCommitment),
+          setSelectedCommitment({
+            commitment: defaultIdentityCommitment,
+          }),
         );
       }
     });
@@ -105,14 +109,18 @@ describe("background/services/identity", () => {
 
       expect(result).toBe(true);
       expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setSelectedCommitment(defaultIdentityCommitment));
+      expect(pushMessage).toBeCalledWith(setSelectedCommitment({
+        commitment: defaultIdentityCommitment,
+      }));
       expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
 
       for (let index = 0; index < defaultTabs.length; index += 1) {
         expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(
           index + 1,
           defaultTabs[index].id,
-          setSelectedCommitment(defaultIdentityCommitment),
+          setSelectedCommitment({
+            commitment: defaultIdentityCommitment,
+          }),
         );
       }
     });

--- a/src/background/services/__tests__/identityService.test.ts
+++ b/src/background/services/__tests__/identityService.test.ts
@@ -70,9 +70,11 @@ describe("background/services/identity", () => {
 
       expect(result).toBe(true);
       expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setSelectedCommitment({
-        commitment: defaultIdentityCommitment,
-      }));
+      expect(pushMessage).toBeCalledWith(
+        setSelectedCommitment({
+          commitment: defaultIdentityCommitment,
+        }),
+      );
       expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
 
       for (let index = 0; index < defaultTabs.length; index += 1) {
@@ -109,9 +111,11 @@ describe("background/services/identity", () => {
 
       expect(result).toBe(true);
       expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setSelectedCommitment({
-        commitment: defaultIdentityCommitment,
-      }));
+      expect(pushMessage).toBeCalledWith(
+        setSelectedCommitment({
+          commitment: defaultIdentityCommitment,
+        }),
+      );
       expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
 
       for (let index = 0; index < defaultTabs.length; index += 1) {

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -148,9 +148,9 @@ export default class IdentityService {
 
     return {
       commitment: identity ? bigintToHex(identity.genIdentityCommitment()) : "",
-      web2Provider: web2Provider ? web2Provider : ""
+      web2Provider: web2Provider || "",
     };
-  }
+  };
 
   public getIdentityCommitments = async (): Promise<{ commitments: string[]; identities: Map<string, string> }> => {
     const identities = await this.getIdentitiesFromStore();
@@ -237,17 +237,24 @@ export default class IdentityService {
 
     const [tabs] = await Promise.all([
       browser.tabs.query({ active: true }),
-      pushMessage(setSelectedCommitment({
-        commitment,
-        web2Provider
-      })),
+      pushMessage(
+        setSelectedCommitment({
+          commitment,
+          web2Provider,
+        }),
+      ),
     ]);
 
     tabs.map((tab) =>
-      browser.tabs.sendMessage(tab.id as number, setSelectedCommitment({
-        commitment,
-        web2Provider
-      })).catch(() => undefined),
+      browser.tabs
+        .sendMessage(
+          tab.id as number,
+          setSelectedCommitment({
+            commitment,
+            web2Provider,
+          }),
+        )
+        .catch(() => undefined),
     );
   };
 
@@ -266,8 +273,8 @@ export default class IdentityService {
       features.RANDOM_IDENTITY
         ? iterableIdentities
         : [...iterableIdentities].filter(
-          ([, identity]) => ZkIdentityDecorater.genFromSerialized(identity).metadata.identityStrategy !== "random",
-        ),
+            ([, identity]) => ZkIdentityDecorater.genFromSerialized(identity).metadata.identityStrategy !== "random",
+          ),
     );
   };
 

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -3,7 +3,7 @@ import { browser } from "webextension-polyfill-ts";
 
 import { getEnabledFeatures } from "@src/config/features";
 import { IdentityMetadata, IdentityName } from "@src/types";
-import { setIdentities, setSelectedCommitment } from "@src/ui/ducks/identities";
+import { SelectedIdentity, setIdentities, setSelectedCommitment } from "@src/ui/ducks/identities";
 import { ellipsify } from "@src/util/account";
 import pushMessage from "@src/util/pushMessage";
 
@@ -61,7 +61,10 @@ export default class IdentityService {
     }
 
     this.activeIdentity = ZkIdentityDecorater.genFromSerialized(identity);
-    await this.writeActiveIdentity(identityCommitment);
+
+    const activeIdentityWeb2Provider = this.activeIdentity.metadata.web2Provider;
+
+    await this.writeActiveIdentity(identityCommitment, activeIdentityWeb2Provider);
 
     return true;
   };
@@ -138,6 +141,17 @@ export default class IdentityService {
     return this.activeIdentity;
   };
 
+  public getActiveIdentityData = async (): Promise<SelectedIdentity | undefined> => {
+    const identity = await this.getActiveIdentity();
+
+    const web2Provider = identity?.metadata.web2Provider;
+
+    return {
+      commitment: identity ? bigintToHex(identity.genIdentityCommitment()) : "",
+      web2Provider: web2Provider ? web2Provider : ""
+    };
+  }
+
   public getIdentityCommitments = async (): Promise<{ commitments: string[]; identities: Map<string, string> }> => {
     const identities = await this.getIdentitiesFromStore();
     const commitments = [...identities.keys()];
@@ -208,7 +222,7 @@ export default class IdentityService {
     }
 
     this.activeIdentity = undefined;
-    await this.writeActiveIdentity("");
+    await this.writeActiveIdentity("", "");
   };
 
   private writeIdentities = async (identities: Map<string, string>): Promise<void> => {
@@ -217,17 +231,23 @@ export default class IdentityService {
     await this.identitiesStore.set(cipherText);
   };
 
-  private writeActiveIdentity = async (commitment: string): Promise<void> => {
+  private writeActiveIdentity = async (commitment: string, web2Provider?: string): Promise<void> => {
     const cipherText = this.lockService.encrypt(commitment);
     await this.activeIdentityStore.set(cipherText);
 
     const [tabs] = await Promise.all([
       browser.tabs.query({ active: true }),
-      pushMessage(setSelectedCommitment(commitment)),
+      pushMessage(setSelectedCommitment({
+        commitment,
+        web2Provider
+      })),
     ]);
 
     tabs.map((tab) =>
-      browser.tabs.sendMessage(tab.id as number, setSelectedCommitment(commitment)).catch(() => undefined),
+      browser.tabs.sendMessage(tab.id as number, setSelectedCommitment({
+        commitment,
+        web2Provider
+      })).catch(() => undefined),
     );
   };
 
@@ -246,8 +266,8 @@ export default class IdentityService {
       features.RANDOM_IDENTITY
         ? iterableIdentities
         : [...iterableIdentities].filter(
-            ([, identity]) => ZkIdentityDecorater.genFromSerialized(identity).metadata.identityStrategy !== "random",
-          ),
+          ([, identity]) => ZkIdentityDecorater.genFromSerialized(identity).metadata.identityStrategy !== "random",
+        ),
     );
   };
 

--- a/src/background/zkKeeper.ts
+++ b/src/background/zkKeeper.ts
@@ -1,4 +1,3 @@
-import { bigintToHex } from "bigint-conversion";
 import log from "loglevel";
 import { browser } from "webextension-polyfill-ts";
 
@@ -117,7 +116,7 @@ export default class ZkKeeperController extends Handler {
 
       return true;
     });
-    
+
     // Protocols
     this.add(
       RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST,

--- a/src/background/zkKeeper.ts
+++ b/src/background/zkKeeper.ts
@@ -70,7 +70,21 @@ export default class ZkKeeperController extends Handler {
     // lock
     this.add(RPCAction.SETUP_PASSWORD, (payload: string) => this.lockService.setupPassword(payload));
 
-    // identities
+    // Identities
+    this.add(RPCAction.GET_COMMITMENTS, this.lockService.ensure, this.identityService.getIdentityCommitments);
+    this.add(RPCAction.GET_IDENTITIES, this.lockService.ensure, this.identityService.getIdentities);
+    this.add(RPCAction.GET_ACTIVE_IDENTITY_DATA, this.lockService.ensure, this.identityService.getActiveIdentityData);
+    this.add(RPCAction.SET_ACTIVE_IDENTITY, this.lockService.ensure, this.identityService.setActiveIdentity);
+    this.add(RPCAction.SET_IDENTITY_NAME, this.lockService.ensure, async (payload: IdentityName) =>
+      this.identityService.setIdentityName(payload),
+    );
+
+    this.add(RPCAction.DELETE_IDENTITY, this.lockService.ensure, async (payload: IdentityName) =>
+      this.identityService.deleteIdentity(payload),
+    );
+
+    this.add(RPCAction.DELETE_ALL_IDENTITIES, this.lockService.ensure, this.identityService.deleteAllIdentities);
+
     this.add(RPCAction.CREATE_IDENTITY_REQ, this.lockService.ensure, async () => {
       await this.browserService.openPopup({ params: { redirect: Paths.CREATE_IDENTITY } });
     });
@@ -103,27 +117,8 @@ export default class ZkKeeperController extends Handler {
 
       return true;
     });
-
-    this.add(RPCAction.GET_COMMITMENTS, this.lockService.ensure, this.identityService.getIdentityCommitments);
-    this.add(RPCAction.GET_IDENTITIES, this.lockService.ensure, this.identityService.getIdentities);
-    this.add(RPCAction.SET_ACTIVE_IDENTITY, this.lockService.ensure, this.identityService.setActiveIdentity);
-    this.add(RPCAction.SET_IDENTITY_NAME, this.lockService.ensure, async (payload: IdentityName) =>
-      this.identityService.setIdentityName(payload),
-    );
-
-    this.add(RPCAction.DELETE_IDENTITY, this.lockService.ensure, async (payload: IdentityName) =>
-      this.identityService.deleteIdentity(payload),
-    );
-
-    this.add(RPCAction.DELETE_ALL_IDENTITIES, this.lockService.ensure, this.identityService.deleteAllIdentities);
-
-    this.add(RPCAction.GET_ACTIVE_IDENTITY, this.lockService.ensure, async () => {
-      const identity = await this.identityService.getActiveIdentity();
-
-      return identity ? bigintToHex(identity.genIdentityCommitment()) : null;
-    });
-
-    // protocols
+    
+    // Protocols
     this.add(
       RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST,
       this.lockService.ensure,
@@ -211,7 +206,7 @@ export default class ZkKeeperController extends Handler {
       },
     );
 
-    // injecting
+    // Injecting
     this.add(RPCAction.TRY_INJECT, async (payload: { origin: string }) => {
       const { origin: host } = payload;
       if (!host) throw new Error("Origin not provided");

--- a/src/constants/rpcActions.ts
+++ b/src/constants/rpcActions.ts
@@ -10,7 +10,7 @@ export enum RPCAction {
   SET_IDENTITY_NAME = "rpc/identity/setIdentityName",
   DELETE_IDENTITY = "rpc/identity/deleteIdentity",
   DELETE_ALL_IDENTITIES = "rpc/identity/deleteAllIdentities",
-  GET_ACTIVE_IDENTITY = "rpc/identity/getActiveidentity",
+  GET_ACTIVE_IDENTITY_DATA = "rpc/identity/getActiveidentityData",
   GET_COMMITMENTS = "rpc/identity/getIdentityCommitments",
   GET_IDENTITIES = "rpc/identity/getIdentities",
   GET_REQUEST_PENDING_STATUS = "rpc/identity/getRequestPendingStatus",

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -3,7 +3,7 @@ import { browser } from "webextension-polyfill-ts";
 
 import { InjectedMessageData, ReduxAction } from "@src/types";
 import { setStatus } from "@src/ui/ducks/app";
-import { setSelectedCommitment } from "@src/ui/ducks/identities";
+import { SelectedIdentity, setSelectedCommitment } from "@src/ui/ducks/identities";
 
 try {
   const url = browser.runtime.getURL("js/injected.js");
@@ -36,7 +36,7 @@ try {
         window.postMessage(
           {
             target: "injected-injectedscript",
-            payload: [null, action.payload],
+            payload: [null, action.payload as SelectedIdentity],
             nonce: "identityChanged",
           },
           "*",

--- a/src/contentScripts/injected.ts
+++ b/src/contentScripts/injected.ts
@@ -5,6 +5,7 @@ import { RPCAction } from "@src/constants";
 import { InjectedMessageData, MerkleProofArtifacts } from "@src/types";
 
 import { IRlnGenerateArgs, ISemaphoreGenerateArgs, RlnProofGenerator, SemaphoreProofGenerator } from "./proof";
+import { SelectedIdentity } from "@src/ui/ducks/identities";
 
 export type IRequest = {
   method: string;
@@ -30,8 +31,8 @@ async function getIdentityCommitments() {
 
 async function getActiveIdentity() {
   return post({
-    method: RPCAction.GET_ACTIVE_IDENTITY,
-  }) as Promise<string>;
+    method: RPCAction.GET_ACTIVE_IDENTITY_DATA,
+  }) as Promise<SelectedIdentity>;
 }
 
 async function getHostPermissions(host: string) {

--- a/src/contentScripts/injected.ts
+++ b/src/contentScripts/injected.ts
@@ -3,9 +3,9 @@ import log from "loglevel";
 
 import { RPCAction } from "@src/constants";
 import { InjectedMessageData, MerkleProofArtifacts } from "@src/types";
+import { SelectedIdentity } from "@src/ui/ducks/identities";
 
 import { IRlnGenerateArgs, ISemaphoreGenerateArgs, RlnProofGenerator, SemaphoreProofGenerator } from "./proof";
-import { SelectedIdentity } from "@src/ui/ducks/identities";
 
 export type IRequest = {
   method: string;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,6 +7,8 @@ import type { ReactElement } from "react";
 
 library.add(faTwitter, faGithub, faReddit);
 
+jest.setTimeout(60000);
+
 jest.mock("loglevel", () => ({
   info: jest.fn(),
   log: jest.fn(),

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,8 +7,6 @@ import type { ReactElement } from "react";
 
 library.add(faTwitter, faGithub, faReddit);
 
-jest.setTimeout(60000);
-
 jest.mock("loglevel", () => ({
   info: jest.fn(),
   log: jest.fn(),

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -38,17 +38,15 @@ describe("ui/ducks/identities", () => {
 
   const defaultSelectedIdentity: SelectedIdentity = {
     commitment: defaultIdentities[0].commitment,
-    web2Provider: defaultIdentities[0].metadata.web2Provider      
-  }
+    web2Provider: defaultIdentities[0].metadata.web2Provider,
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("should fetch identities properly", async () => {
-    (postMessage as jest.Mock)
-      .mockResolvedValueOnce(defaultIdentities)
-      .mockResolvedValueOnce(defaultSelectedIdentity);
+    (postMessage as jest.Mock).mockResolvedValueOnce(defaultIdentities).mockResolvedValueOnce(defaultSelectedIdentity);
 
     await Promise.resolve(store.dispatch(fetchIdentities()));
     const { identities } = store.getState();

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -25,6 +25,7 @@ import {
   useIdentities,
   useIdentityRequestPending,
   useSelectedIdentity,
+  SelectedIdentity,
 } from "../identities";
 
 describe("ui/ducks/identities", () => {
@@ -35,6 +36,11 @@ describe("ui/ducks/identities", () => {
     },
   ];
 
+  const defaultSelectedIdentity: SelectedIdentity = {
+    commitment: defaultIdentities[0].commitment,
+    web2Provider: defaultIdentities[0].metadata.web2Provider      
+  }
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -42,7 +48,7 @@ describe("ui/ducks/identities", () => {
   test("should fetch identities properly", async () => {
     (postMessage as jest.Mock)
       .mockResolvedValueOnce(defaultIdentities)
-      .mockResolvedValueOnce(defaultIdentities[0].commitment);
+      .mockResolvedValueOnce(defaultSelectedIdentity);
 
     await Promise.resolve(store.dispatch(fetchIdentities()));
     const { identities } = store.getState();
@@ -59,10 +65,11 @@ describe("ui/ducks/identities", () => {
   });
 
   test("should set selected commitment properly", async () => {
-    await Promise.resolve(store.dispatch(setSelectedCommitment("1")));
+    await Promise.resolve(store.dispatch(setSelectedCommitment(defaultSelectedIdentity)));
     const { identities } = store.getState();
 
-    expect(identities.selected).toBe("1");
+    expect(identities.selected.commitment).toBe("1");
+    expect(identities.selected.web2Provider).toBe("twitter");
   });
 
   test("should set identities properly", async () => {

--- a/src/ui/ducks/identities.ts
+++ b/src/ui/ducks/identities.ts
@@ -31,8 +31,8 @@ const initialState: IdentitiesState = {
   requestPending: false,
   selected: {
     commitment: "",
-    web2Provider: ""
-  }
+    web2Provider: "",
+  },
 };
 
 const identitiesSlice = createSlice({
@@ -42,8 +42,8 @@ const identitiesSlice = createSlice({
     setSelectedCommitment: (state: IdentitiesState, action: PayloadAction<SelectedIdentity>) => {
       state.selected = {
         commitment: action.payload.commitment,
-        web2Provider: action.payload.web2Provider
-      }
+        web2Provider: action.payload.web2Provider,
+      };
     },
 
     setIdentityRequestPending: (state: IdentitiesState, action: PayloadAction<boolean>) => {
@@ -64,15 +64,15 @@ export const createIdentityRequest = () => async (): Promise<void> => {
 
 export const createIdentity =
   (strategy: IdentityStrategy, messageSignature: string, options: CreateIdentityOptions) =>
-    async (): Promise<boolean> =>
-      postMessage({
-        method: RPCAction.CREATE_IDENTITY,
-        payload: {
-          strategy,
-          messageSignature,
-          options,
-        },
-      });
+  async (): Promise<boolean> =>
+    postMessage({
+      method: RPCAction.CREATE_IDENTITY,
+      payload: {
+        strategy,
+        messageSignature,
+        options,
+      },
+    });
 
 export const setActiveIdentity = (identityCommitment: string) => async (): Promise<boolean> =>
   postMessage({
@@ -106,12 +106,16 @@ export const deleteAllIdentities = () => async (): Promise<boolean> =>
 
 export const fetchIdentities = (): TypedThunk => async (dispatch) => {
   const data = await postMessage<IdentityData[]>({ method: RPCAction.GET_IDENTITIES });
-  const { commitment, web2Provider } = await postMessage<SelectedIdentity>({ method: RPCAction.GET_ACTIVE_IDENTITY_DATA });
+  const { commitment, web2Provider } = await postMessage<SelectedIdentity>({
+    method: RPCAction.GET_ACTIVE_IDENTITY_DATA,
+  });
   dispatch(setIdentities(data));
-  dispatch(setSelectedCommitment({
-    commitment,
-    web2Provider
-  }));
+  dispatch(
+    setSelectedCommitment({
+      commitment,
+      web2Provider,
+    }),
+  );
 };
 
 export const useIdentities = (): IdentityData[] => useAppSelector((state) => state.identities.identities, deepEqual);

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -22,7 +22,7 @@ const provider = createExternalExtensionProvider();
 // @ts-ignore
 window.ethereum = provider;
 
-provider.on("error", (error) => {
+provider.on("error", (error: unknown) => {
   if ((error as string).includes(`Lost connection`)) {
     window.ethereum = undefined;
   }


### PR DESCRIPTION
## Explanation

In case of connecting to Zkitter, it needs to be able to know the Active Identity web2 proivder option. Because depending on that value, Zkitter will redirect the user to the right web2 provider the user choose before in CK, and that will allow the user easily create a Proof of Reputation using Zkitter.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

N/A

## Screenshots/Screencaps

N/A
<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

N/A
<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

N/A

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
