### PR TITLE
feat: return activity tab back

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -16,6 +16,7 @@
     "/e2e/",
     "/src/server/",
     "/src/ui/popup.tsx",
+    "/src/ui/theme.ts",
     "/src/background/backgroundPage.ts",
     "/src/background/appInit.ts"
   ],

--- a/src/popup.html
+++ b/src/popup.html
@@ -2,7 +2,7 @@
 <html width="357" height="600">
   <head>
     <title>Crypt keeper</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&family=Roboto+Mono:wght@400;500&display=swap"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -26,6 +26,11 @@ jest.mock("link-preview-js", (): unknown => ({
   }),
 }));
 
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(() => Promise.resolve()),
+  useAppSelector: jest.fn(),
+}));
+
 jest.mock("@src/util/postMessage");
 
 jest.mock("@src/util/pushMessage");

--- a/src/ui/components/Menuable/Menuable.tsx
+++ b/src/ui/components/Menuable/Menuable.tsx
@@ -65,13 +65,7 @@ export const Menuable = ({
     >
       {children}
 
-      {isOpenDangerModal ? (
-        <ConfirmDangerModal
-          accept={handleDangerAction}
-          isOpenModal={isOpenDangerModal}
-          reject={handleDangerModalClose}
-        />
-      ) : null}
+      <ConfirmDangerModal accept={handleDangerAction} isOpenModal={isOpenDangerModal} reject={handleDangerModalClose} />
 
       {isShowing && (
         <div className={classNames("rounded-xl border border-gray-700 menuable__menu", menuClassName)}>

--- a/src/ui/ducks/__tests__/app.test.tsx
+++ b/src/ui/ducks/__tests__/app.test.tsx
@@ -29,6 +29,8 @@ jest.mock("@src/config/env", (): unknown => ({
   isDebugMode: () => true,
 }));
 
+jest.unmock("@src/ui/ducks/hooks");
+
 describe("ui/ducks/app", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/ui/ducks/__tests__/hooks.test.ts
+++ b/src/ui/ducks/__tests__/hooks.test.ts
@@ -12,6 +12,8 @@ jest.mock("react-redux", (): unknown => ({
   useSelector: jest.fn(),
 }));
 
+jest.unmock("@src/ui/ducks/hooks");
+
 describe("ui/ducks/hooks", () => {
   beforeEach(() => {
     (useDispatch as jest.Mock).mockReturnValue(jest.fn());

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -28,6 +28,8 @@ import {
   SelectedIdentity,
 } from "../identities";
 
+jest.unmock("@src/ui/ducks/hooks");
+
 describe("ui/ducks/identities", () => {
   const defaultIdentities: IdentitiesState["identities"] = [
     {

--- a/src/ui/ducks/__tests__/permissions.test.tsx
+++ b/src/ui/ducks/__tests__/permissions.test.tsx
@@ -17,6 +17,8 @@ import {
   useHostPermission,
 } from "../permissions";
 
+jest.unmock("@src/ui/ducks/hooks");
+
 describe("ui/ducks/permissions", () => {
   const defaultHost = "http://localhost:3000";
   const defaultPermission = {

--- a/src/ui/ducks/__tests__/requests.test.tsx
+++ b/src/ui/ducks/__tests__/requests.test.tsx
@@ -12,6 +12,8 @@ import postMessage from "@src/util/postMessage";
 
 import { fetchPendingRequests, finalizeRequest, setPendingRequests, usePendingRequests } from "../requests";
 
+jest.unmock("@src/ui/ducks/hooks");
+
 describe("ui/ducks/requests", () => {
   const defaultPendingRequests: PendingRequest[] = [{ id: "1", windowId: 1, type: PendingRequestType.APPROVE }];
 

--- a/src/ui/pages/Home/Home.tsx
+++ b/src/ui/pages/Home/Home.tsx
@@ -7,32 +7,16 @@ import "./home.scss";
 import { useHome } from "./useHome";
 
 const Home = (): JSX.Element => {
-  const {
-    scrollRef,
-    isFixedTabsMode,
-    address,
-    chain,
-    balance,
-    identities,
-    refreshConnectionStatus,
-    onDeleteAllIdentities,
-    onScroll,
-  } = useHome();
+  const { address, chain, balance, identities, refreshConnectionStatus } = useHome();
 
   return (
     <div className="w-full h-full flex flex-col home" data-testid="home-page">
       <Header />
 
-      <div
-        ref={scrollRef}
-        className={classNames("flex flex-col flex-grow flex-shrink overflow-y-auto home__scroller", {
-          "home__scroller--fixed-menu": isFixedTabsMode,
-        })}
-        onScroll={onScroll}
-      >
+      <div className={classNames("flex flex-col flex-grow flex-shrink overflow-y-auto home__scroller")}>
         <Info address={address} balance={balance} chain={chain} refreshConnectionStatus={refreshConnectionStatus} />
 
-        <TabList identities={identities} onDeleteAllIdentities={onDeleteAllIdentities}>
+        <TabList>
           <IdentityList identities={identities} />
         </TabList>
       </div>

--- a/src/ui/pages/Home/__tests__/Home.test.tsx
+++ b/src/ui/pages/Home/__tests__/Home.test.tsx
@@ -26,15 +26,11 @@ jest.mock("../useHome", (): unknown => ({
 
 describe("ui/pages/Home", () => {
   const defaultHookData: IUseHomeData = {
-    isFixedTabsMode: false,
     identities: [],
-    scrollRef: { current: null },
     address: defaultWalletHookData.address,
     balance: defaultWalletHookData.balance,
     chain: defaultWalletHookData.chain,
     refreshConnectionStatus: jest.fn().mockResolvedValue(true),
-    onDeleteAllIdentities: jest.fn(),
-    onScroll: jest.fn(),
   };
 
   beforeEach(() => {

--- a/src/ui/pages/Home/__tests__/useHome.test.ts
+++ b/src/ui/pages/Home/__tests__/useHome.test.ts
@@ -7,7 +7,7 @@ import { useRef } from "react";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { IdentityData, useIdentities, fetchIdentities, deleteAllIdentities } from "@src/ui/ducks/identities";
+import { IdentityData, useIdentities, fetchIdentities } from "@src/ui/ducks/identities";
 import { checkHostApproval } from "@src/ui/ducks/permissions";
 import { useWallet } from "@src/ui/hooks/wallet";
 import { getLastActiveTabUrl } from "@src/util/browser";
@@ -29,7 +29,6 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
 
 jest.mock("@src/ui/ducks/identities", (): unknown => ({
   fetchIdentities: jest.fn(),
-  deleteAllIdentities: jest.fn(),
   useIdentities: jest.fn(),
 }));
 
@@ -90,8 +89,6 @@ describe("ui/pages/Home/useHome", () => {
     expect(result.current.address).toBe(defaultWalletHookData.address);
     expect(result.current.balance).toStrictEqual(defaultWalletHookData.balance);
     expect(result.current.chain).toStrictEqual(defaultWalletHookData.chain);
-    expect(result.current.isFixedTabsMode).toBe(false);
-    expect(result.current.scrollRef.current).toBeNull();
     expect(result.current.identities).toStrictEqual(defaultIdentities);
     expect(fetchIdentities).toBeCalledTimes(1);
     expect(mockDispatch).toBeCalledTimes(1);
@@ -114,32 +111,5 @@ describe("ui/pages/Home/useHome", () => {
     await act(async () => result.current.refreshConnectionStatus());
 
     expect(checkHostApproval).not.toBeCalled();
-  });
-
-  test("should delete all identities properly", async () => {
-    const { result } = renderHook(() => useHome());
-
-    await act(async () => Promise.resolve(result.current.onDeleteAllIdentities()));
-
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(deleteAllIdentities).toBeCalledTimes(1);
-  });
-
-  test("should set fixed tabs mode properly", async () => {
-    (useRef as jest.Mock).mockReturnValue({ current: { scrollTop: 100 } });
-
-    const { result } = renderHook(() => useHome());
-
-    await act(async () => Promise.resolve(result.current.onScroll()));
-
-    expect(result.current.isFixedTabsMode).toBe(true);
-  });
-
-  test("should not set fixed tabs mode if there is no ref", async () => {
-    const { result } = renderHook(() => useHome());
-
-    await act(async () => Promise.resolve(result.current.onScroll()));
-
-    expect(result.current.isFixedTabsMode).toBe(false);
   });
 });

--- a/src/ui/pages/Home/components/IdentityList/IdentityList.tsx
+++ b/src/ui/pages/Home/components/IdentityList/IdentityList.tsx
@@ -1,10 +1,12 @@
 import classNames from "classnames";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
+import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
 import { Icon } from "@src/ui/components/Icon";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import {
   createIdentityRequest,
+  deleteAllIdentities,
   deleteIdentity,
   IdentityData,
   setActiveIdentity,
@@ -24,6 +26,11 @@ export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => 
   const selected = useSelectedIdentity();
   const dispatch = useAppDispatch();
   const { address } = useWallet();
+  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+
+  const onConfirmModalShow = useCallback(() => {
+    setConfirmModalOpen((value) => !value);
+  }, [setConfirmModalOpen]);
 
   const onSelectIdentity = useCallback(
     (identityCommitment: string) => {
@@ -46,6 +53,10 @@ export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => 
     [dispatch],
   );
 
+  const onDeleteAllIdentities = useCallback(() => {
+    dispatch(deleteAllIdentities()).then(() => onConfirmModalShow());
+  }, [dispatch, onConfirmModalShow]);
+
   const onCreateIdentityRequest = useCallback(() => {
     if (address) {
       dispatch(createIdentityRequest());
@@ -66,19 +77,39 @@ export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => 
         />
       ))}
 
-      <button
-        className={classNames(
-          "flex flex-row items-center justify-center p-4 cursor-pointer text-gray-600",
-          `create-identity-row__${address ? "active" : "not-active"}`,
-        )}
-        data-testid="create-new-identity"
-        type="button"
-        onClick={onCreateIdentityRequest}
-      >
-        <Icon className="mr-2" fontAwesome="fas fa-plus" size={1} />
+      <ConfirmDangerModal accept={onDeleteAllIdentities} isOpenModal={isConfirmModalOpen} reject={onConfirmModalShow} />
 
-        <div>Add Identity</div>
-      </button>
+      <div className="flex flex-row items-center p-4">
+        <button
+          className={classNames(
+            "flex flex-row items-center justify-center cursor-pointer text-gray-600",
+            `create-identity-row__${address ? "active" : "not-active"}`,
+          )}
+          data-testid="create-new-identity"
+          type="button"
+          onClick={onCreateIdentityRequest}
+        >
+          <Icon className="mr-2" fontAwesome="fas fa-plus" size={1} />
+
+          <div>Add Identity</div>
+        </button>
+
+        {identities.length > 0 && (
+          <button
+            className={classNames(
+              "flex flex-row items-center justify-center cursor-pointer text-gray-600",
+              `create-identity-row__${address ? "active" : "not-active"}`,
+            )}
+            data-testid="clear-all-identities"
+            type="button"
+            onClick={onConfirmModalShow}
+          >
+            <Icon className="mr-2" fontAwesome="fas fa-trash" size={1} />
+
+            <div>Clear all identities</div>
+          </button>
+        )}
+      </div>
     </>
   );
 };

--- a/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -33,6 +33,7 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
   useIdentities: jest.fn(),
   useSelectedIdentity: jest.fn(),
   createIdentityRequest: jest.fn(),
+  deleteAllIdentities: jest.fn(),
 }));
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
@@ -40,7 +41,7 @@ jest.mock("@src/ui/hooks/wallet", (): unknown => ({
 }));
 
 describe("ui/pages/Home/components/IdentityList", () => {
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(() => Promise.resolve());
 
   const defaultIdentities: IdentityData[] = [
     {
@@ -183,6 +184,21 @@ describe("ui/pages/Home/components/IdentityList", () => {
 
     const createIdentityButton = await screen.findByTestId("create-new-identity");
     await act(async () => Promise.resolve(createIdentityButton.click()));
+
+    expect(mockDispatch).toBeCalledTimes(1);
+  });
+
+  test("should delete all the identities properly", async () => {
+    render(<IdentityList identities={defaultIdentities} />);
+
+    const clearIdentitiesButton = await screen.findByTestId("clear-all-identities");
+    await act(async () => Promise.resolve(clearIdentitiesButton.click()));
+
+    const modal = await screen.findByTestId("danger-modal");
+    expect(modal).toBeInTheDocument();
+
+    const yesButton = await screen.findByText("Yes");
+    await act(async () => Promise.resolve(yesButton.click()));
 
     expect(mockDispatch).toBeCalledTimes(1);
   });

--- a/src/ui/pages/Home/components/TabList/TabList.tsx
+++ b/src/ui/pages/Home/components/TabList/TabList.tsx
@@ -1,53 +1,37 @@
-import classNames from "classnames";
-import { ReactNode, Children, useState, useMemo } from "react";
-
-import { Icon } from "@src/ui/components/Icon";
-import { Menuable } from "@src/ui/components/Menuable";
-import { IdentityData } from "@src/ui/ducks/identities";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import { type ReactNode, type SyntheticEvent, Children, useState, useMemo, useCallback } from "react";
 
 import "./tabListStyles.scss";
 
 export interface TabListProps {
   children: ReactNode;
-  identities: IdentityData[];
-  onDeleteAllIdentities: () => void;
 }
 
-export const TabList = ({ children, identities, onDeleteAllIdentities }: TabListProps): JSX.Element => {
-  const [selectedTab] = useState(0);
+enum HomeTabs {
+  IDENTITIES = 0,
+  ACTIVITY = 1,
+}
+
+export const TabList = ({ children }: TabListProps): JSX.Element => {
+  const [selectedTab, setSelectedTab] = useState(HomeTabs.IDENTITIES);
 
   const selectedContent = useMemo(() => Children.toArray(children)[selectedTab], [children, selectedTab]);
 
+  const onTabChange = useCallback(
+    (_: SyntheticEvent, value: HomeTabs) => {
+      setSelectedTab(value);
+    },
+    [setSelectedTab],
+  );
+
   return (
     <div className="tab__list" data-testid="tab-list">
-      <div className="tab__list__header">
-        <div
-          className={classNames("tab__list__header__tab", {
-            "tab__list__header__tab--selected": selectedTab === 0,
-          })}
-        >
-          <span>Identities</span>
+      <Tabs indicatorColor="primary" textColor="primary" value={selectedTab} variant="fullWidth" onChange={onTabChange}>
+        <Tab data-testid="tab-identities" label="Identities" />
 
-          {identities.length > 0 && (
-            <Menuable
-              className="flex user-menu"
-              items={[{ label: "Delete All", isDangerItem: true, onClick: onDeleteAllIdentities }]}
-            >
-              <Icon className="tab__list__menu-icon" data-testid="menu-icon" fontAwesome="fas fa-ellipsis-h" />
-            </Menuable>
-          )}
-        </div>
-      </div>
-
-      <div className="tab__list__fix-header">
-        <div
-          className={classNames("tab__list__header__tab", {
-            "tab__list__header__tab--selected": selectedTab === 0,
-          })}
-        >
-          Identities
-        </div>
-      </div>
+        <Tab data-testid="tab-activity" label="Activity" />
+      </Tabs>
 
       <div className="tab__list__content">{selectedContent}</div>
     </div>

--- a/src/ui/pages/Home/components/TabList/__tests__/TabList.test.tsx
+++ b/src/ui/pages/Home/components/TabList/__tests__/TabList.test.tsx
@@ -4,33 +4,11 @@
 
 import { act, render, screen } from "@testing-library/react";
 
-import { ZERO_ADDRESS } from "@src/config/const";
-
 import { TabList, TabListProps } from "..";
 
 describe("ui/pages/Home/components/TabList", () => {
   const defaultProps: TabListProps = {
-    children: [],
-    identities: [
-      {
-        commitment: "0",
-        metadata: {
-          account: ZERO_ADDRESS,
-          name: "Account #0",
-          identityStrategy: "interrep",
-          web2Provider: "twitter",
-        },
-      },
-      {
-        commitment: "1",
-        metadata: {
-          account: ZERO_ADDRESS,
-          name: "Account #1",
-          identityStrategy: "random",
-        },
-      },
-    ],
-    onDeleteAllIdentities: jest.fn(),
+    children: [<div key={0}>Identities content</div>, <div key={1}>Activity content</div>],
   };
 
   afterEach(() => {
@@ -38,50 +16,26 @@ describe("ui/pages/Home/components/TabList", () => {
   });
 
   test("should render properly", async () => {
-    render(<TabList {...defaultProps} identities={[]} />);
+    render(<TabList {...defaultProps} />);
 
     const component = await screen.findByTestId("tab-list");
 
     expect(component).toBeInTheDocument();
   });
 
-  test("should accept to delete all identities properly", async () => {
+  test("should select tabs properly", async () => {
     render(<TabList {...defaultProps} />);
 
-    const icon = await screen.findByTestId("menu-icon");
-    await act(async () => Promise.resolve(icon.click()));
+    const tabIdentities = await screen.findByTestId("tab-identities");
+    act(() => tabIdentities.click());
 
-    const deleteAllButton = await screen.findByText("Delete All");
-    await act(async () => Promise.resolve(deleteAllButton.click()));
+    const identitiesContent = await screen.findByText("Identities content");
+    expect(identitiesContent).toBeInTheDocument();
 
-    const dangerModal = await screen.findByTestId("danger-modal");
+    const tabActivity = await screen.findByTestId("tab-activity");
+    act(() => tabActivity.click());
 
-    expect(dangerModal).toBeInTheDocument();
-
-    const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
-    await act(async () => Promise.resolve(dangerModalAccept.click()));
-
-    expect(defaultProps.onDeleteAllIdentities).toBeCalledTimes(1);
-    expect(dangerModal).not.toBeInTheDocument();
-  });
-
-  test("should reject to delete all identities properly", async () => {
-    render(<TabList {...defaultProps} />);
-
-    const icon = await screen.findByTestId("menu-icon");
-    await act(async () => Promise.resolve(icon.click()));
-
-    const deleteAllButton = await screen.findByText("Delete All");
-    await act(async () => Promise.resolve(deleteAllButton.click()));
-
-    const dangerModal = await screen.findByTestId("danger-modal");
-
-    expect(dangerModal).toBeInTheDocument();
-
-    const dangerModalReject = await screen.findByTestId("danger-modal-reject");
-    await act(async () => Promise.resolve(dangerModalReject.click()));
-
-    expect(defaultProps.onDeleteAllIdentities).toBeCalledTimes(0);
-    expect(dangerModal).not.toBeInTheDocument();
+    const activityContent = await screen.findByText("Activity content");
+    expect(activityContent).toBeInTheDocument();
   });
 });

--- a/src/ui/pages/Home/components/TabList/tabListStyles.scss
+++ b/src/ui/pages/Home/components/TabList/tabListStyles.scss
@@ -1,42 +1,11 @@
 @import "@src/util/variables";
 
 .tab__list {
-  @extend %col-nowrap;
-  flex: 1 1 auto;
-
-  &__fix-header {
-    display: none;
-  }
-
-  &__header {
-    @extend %row-nowrap;
-
-    &__tab {
-      @extend %row-nowrap;
-      justify-content: space-between;
-      align-items: center;
-      flex: 1 1 auto;
-      cursor: pointer;
-      padding: 1rem;
-      border-bottom: 2px solid $gray-800;
-
-      &--selected {
-        border-color: $primary-green;
-      }
-    }
-  }
-
   &__content {
-    flex: 1 1 auto;
     background-color: $black;
-  }
-
-  &__menu-icon {
-    font-size: 0.8125rem !important;
-    color: $gray-600;
-
-    &:hover {
-      color: $gray-300;
-    }
+    flex: 1;
+    height: 375px;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 }

--- a/src/ui/pages/Home/useHome.ts
+++ b/src/ui/pages/Home/useHome.ts
@@ -1,47 +1,26 @@
 import BigNumber from "bignumber.js";
-import { useRef, useState, useEffect, useCallback, RefObject } from "react";
+import { useEffect, useCallback } from "react";
 
 import { Chain } from "@src/config/rpc";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { fetchIdentities, deleteAllIdentities, useIdentities, IdentityData } from "@src/ui/ducks/identities";
+import { fetchIdentities, useIdentities, IdentityData } from "@src/ui/ducks/identities";
 import { checkHostApproval } from "@src/ui/ducks/permissions";
 import { useWallet } from "@src/ui/hooks/wallet";
 import { getLastActiveTabUrl } from "@src/util/browser";
 
 export interface IUseHomeData {
-  isFixedTabsMode: boolean;
   identities: IdentityData[];
-  scrollRef: RefObject<HTMLDivElement>;
   address?: string;
   balance?: BigNumber;
   chain?: Chain;
   refreshConnectionStatus: () => Promise<boolean>;
-  onDeleteAllIdentities: () => void;
-  onScroll: () => void;
 }
-
-const SCROLL_THRESHOLD = 92;
 
 export const useHome = (): IUseHomeData => {
   const dispatch = useAppDispatch();
   const identities = useIdentities();
 
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [isFixedTabsMode, setFixTabsMode] = useState(false);
-
   const { address, chain, balance } = useWallet();
-
-  const onScroll = useCallback(() => {
-    if (!scrollRef.current) {
-      return;
-    }
-
-    setFixTabsMode(scrollRef.current.scrollTop > SCROLL_THRESHOLD);
-  }, [scrollRef, setFixTabsMode]);
-
-  const onDeleteAllIdentities = useCallback(() => {
-    dispatch(deleteAllIdentities());
-  }, [dispatch]);
 
   const refreshConnectionStatus = useCallback(async () => {
     const tabUrl = await getLastActiveTabUrl();
@@ -58,14 +37,10 @@ export const useHome = (): IUseHomeData => {
   }, [dispatch]);
 
   return {
-    scrollRef,
-    isFixedTabsMode,
     address,
     chain,
     balance,
     identities,
     refreshConnectionStatus,
-    onDeleteAllIdentities,
-    onScroll,
   };
 };

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -1,5 +1,6 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
+import { ThemeProvider } from "@mui/material/styles";
 import { AnyAction } from "@reduxjs/toolkit";
 import { Web3ReactProvider } from "@web3-react/core";
 import log from "loglevel";
@@ -15,6 +16,7 @@ import Popup from "@src/ui/pages/Popup";
 import { store } from "@src/ui/store/configureAppStore";
 
 import { createMetamaskProvider } from "./services/provider";
+import { theme } from "./theme";
 
 log.setDefaultLevel(isDebugMode() ? "debug" : "info");
 
@@ -45,7 +47,9 @@ browser.tabs.query({ active: true, currentWindow: true }).then(() => {
       <HashRouter>
         <Web3ReactProvider connectors={connectors}>
           <Suspense>
-            <Popup />
+            <ThemeProvider theme={theme}>
+              <Popup />
+            </ThemeProvider>
           </Suspense>
         </Web3ReactProvider>
       </HashRouter>

--- a/src/ui/services/provider/index.ts
+++ b/src/ui/services/provider/index.ts
@@ -7,8 +7,6 @@ import type { Duplex } from "stream";
 
 export function createMetamaskProvider(extensionId?: string): MetaMaskInpageProvider {
   const currentMetaMaskId = extensionId || getMetaMaskId();
-  // eslint-disable-next-line no-console
-  console.error(currentMetaMaskId);
   const metamaskPort = browser.runtime.connect(currentMetaMaskId);
   const pluginStream = new PortStream(metamaskPort);
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,54 @@
+import { grey } from "@mui/material/colors";
+import { createTheme, lighten } from "@mui/material/styles";
+
+const PALETTE = {
+  background: {
+    default: "#000",
+    paper: "#fff",
+  },
+
+  common: {
+    black: "#000",
+    white: "#fff",
+  },
+
+  primary: {
+    main: "#94febf",
+  },
+
+  secondary: {
+    main: "#2580f8",
+  },
+
+  text: {
+    primary: grey[200],
+    secondary: grey[400],
+  },
+
+  error: {
+    main: "#f52525",
+    light: lighten("#f52525", 0.7),
+  },
+
+  info: {
+    main: lighten("#000", 0.75),
+  },
+
+  success: {
+    main: "#2ed272",
+  },
+};
+
+export const theme = createTheme({
+  palette: PALETTE,
+
+  components: {
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          textTransform: "none",
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Explanation

This PR adds support for material-ui theme and "Activity" tab is back again (empty yet).

Details are below:
- [x] Return activity tab back
- [x] Add mui theme
- [x] Replace fixed tabs js code with css rule
- [x] Move delete all identities to IdentityList

## More Information

Related to #30 

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/14254374/231285028-0cb99c63-6dc6-41b4-882d-e37e951f1f99.png)
![image](https://user-images.githubusercontent.com/14254374/231285055-87e504c5-508f-463c-88cf-257268ce176c.png)

### After

![image](https://user-images.githubusercontent.com/14254374/231284337-ee08ae18-c0bf-4656-b193-545b0625a68f.png)
![image](https://user-images.githubusercontent.com/14254374/231284380-35738ed6-6164-4a48-9d1b-70c73be0af5f.png)

## Manual Testing Steps

1. Go to home page
2. Try to switch tabs
3. Try to delete all the identities

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
