### PR TITLE
feat: remove history operation

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -7,6 +7,7 @@
   "moduleFileExtensions": ["ts", "js", "tsx"],
   "moduleNameMapper": {
     "^.+\\.(css|scss|svg|png)$": "<rootDir>/src/config/mock/resourceMock.js",
+    "nanoid": "<rootDir>/src/config/mock/nanoidMock.js",
     "@src/(.*)$": "<rootDir>/src/$1"
   },
   "coveragePathIgnorePatterns": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "fast-deep-equal": "^3.1.3",
         "link-preview-js": "^3.0.4",
         "loglevel": "^1.8.1",
+        "nanoid": "^4.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.9",
@@ -23917,14 +23918,20 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/napi-build-utils": {
@@ -25440,6 +25447,24 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/preact": {
       "version": "10.4.1",
@@ -50701,8 +50726,9 @@
       "version": "2.0.0"
     },
     "nanoid": {
-      "version": "3.3.4",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -51693,6 +51719,14 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
+        }
       }
     },
     "postcss-modules-extract-imports": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "fast-deep-equal": "^3.1.3",
     "link-preview-js": "^3.0.4",
     "loglevel": "^1.8.1",
+    "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",

--- a/src/background/services/history/__tests__/history.test.ts
+++ b/src/background/services/history/__tests__/history.test.ts
@@ -77,9 +77,10 @@ describe("background/services/history", () => {
     historyStore.get.mockResolvedValue(serializedDefaultOperations);
     settingsStore.get.mockResolvedValueOnce(serializedDefaultSettings);
 
-    const operations = await service.loadOperations();
+    const { operations, settings } = await service.loadOperations();
 
     expect(operations).toHaveLength(3);
+    expect(settings).toStrictEqual(defaultSettings);
     expect(service.getOperations()).toStrictEqual(operations);
   });
 
@@ -88,9 +89,10 @@ describe("background/services/history", () => {
     historyStore.get.mockResolvedValue(serializedDefaultOperations);
     settingsStore.get.mockResolvedValueOnce(null);
 
-    const operations = await service.loadOperations();
+    const { operations, settings } = await service.loadOperations();
 
     expect(operations).toHaveLength(3);
+    expect(settings).toStrictEqual(defaultSettings);
     expect(service.getOperations()).toStrictEqual(operations);
     expect(service.getSettings()).toStrictEqual(defaultSettings);
   });
@@ -102,9 +104,10 @@ describe("background/services/history", () => {
     historyStore.get.mockResolvedValue(serializedDefaultOperations);
     settingsStore.get.mockResolvedValueOnce(serializedDefaultSettings);
 
-    const operations = await service.loadOperations();
+    const { operations, settings } = await service.loadOperations();
 
     expect(operations).toHaveLength(2);
+    expect(settings).toStrictEqual(defaultSettings);
     expect(service.getOperations()).toStrictEqual(operations);
   });
 
@@ -112,9 +115,10 @@ describe("background/services/history", () => {
     const [, settingsStore] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage, MockStorage];
     settingsStore.get.mockResolvedValueOnce(JSON.stringify({ ...defaultSettings, isEnabled: false }));
 
-    const operations = await service.loadOperations();
+    const { operations, settings } = await service.loadOperations();
 
     expect(operations).toHaveLength(0);
+    expect(settings).toStrictEqual({ isEnabled: false });
     expect(service.getOperations()).toHaveLength(0);
   });
 
@@ -123,9 +127,10 @@ describe("background/services/history", () => {
     historyStore.get.mockResolvedValue(null);
     settingsStore.get.mockResolvedValueOnce(serializedDefaultSettings);
 
-    const operations = await service.loadOperations();
+    const { operations, settings } = await service.loadOperations();
 
     expect(operations).toHaveLength(0);
+    expect(settings).toStrictEqual(defaultSettings);
     expect(service.getOperations()).toHaveLength(0);
   });
 

--- a/src/background/services/history/index.ts
+++ b/src/background/services/history/index.ts
@@ -1,3 +1,5 @@
+import { nanoid } from "nanoid";
+
 import { getEnabledFeatures } from "@src/config/features";
 import { IdentityMetadata, Operation, OperationType } from "@src/types";
 
@@ -5,6 +7,7 @@ import LockService from "../lock";
 import SimpleStorage from "../simpleStorage";
 
 const HISTORY_KEY = "@@HISTORY@@";
+const HISTORY_SETTINGS_KEY = "@@HISTORY-SETTINGS@@";
 
 export interface OperationOptions {
   identity: {
@@ -17,19 +20,29 @@ export interface OperationFilter {
   type: OperationType;
 }
 
+export interface HistorySettings {
+  isEnabled: boolean;
+}
+
 export default class HistoryService {
   private static INSTANCE: HistoryService;
 
   private historyStore: SimpleStorage;
 
+  private historySettingsStore: SimpleStorage;
+
   private lockService: LockService;
 
   private operations: Operation[];
 
+  private settings?: HistorySettings;
+
   private constructor() {
     this.historyStore = new SimpleStorage(HISTORY_KEY);
+    this.historySettingsStore = new SimpleStorage(HISTORY_SETTINGS_KEY);
     this.lockService = LockService.getInstance();
     this.operations = [];
+    this.settings = undefined;
   }
 
   public static getInstance(): HistoryService {
@@ -40,7 +53,18 @@ export default class HistoryService {
     return HistoryService.INSTANCE;
   }
 
+  public enableHistory = async (isEnabled: boolean): Promise<void> => {
+    this.settings = { isEnabled };
+    await this.writeSettings(this.settings);
+  };
+
   public loadOperations = async (): Promise<Operation[]> => {
+    await this.loadSettings();
+
+    if (!this.settings?.isEnabled) {
+      return [];
+    }
+
     const features = getEnabledFeatures();
     const serializedOperations = await this.historyStore
       .get<string>()
@@ -56,18 +80,53 @@ export default class HistoryService {
   public getOperations = (filter?: Partial<OperationFilter>): Operation[] =>
     this.operations.filter((operation) => (filter?.type ? operation.type === filter.type : true));
 
+  public getSettings = (): HistorySettings | undefined => this.settings;
+
   public trackOperation = async (type: OperationType, { identity }: OperationOptions): Promise<void> => {
+    if (!this.settings?.isEnabled) {
+      return;
+    }
+
     this.operations.push({
+      id: nanoid(),
       type,
       identity,
       createdAt: new Date().toISOString(),
     });
-    const cipherText = this.lockService.encrypt(JSON.stringify(this.operations));
-    await this.historyStore.set(cipherText);
+
+    await this.writeOperations(this.operations);
+  };
+
+  public removeOperation = async (id: string): Promise<void> => {
+    this.operations = this.operations.filter((operation) => operation.id !== id);
+
+    await this.writeOperations(this.operations);
   };
 
   public clear = async (): Promise<void> => {
-    await this.historyStore.clear();
     this.operations = [];
+    await this.historyStore.clear();
+  };
+
+  private loadSettings = async (): Promise<HistorySettings> => {
+    this.settings = await this.historySettingsStore
+      .get<string>()
+      .then((settings) => (settings ? (JSON.parse(settings) as HistorySettings) : undefined));
+
+    if (!this.settings) {
+      this.settings = { isEnabled: true };
+      await this.writeSettings(this.settings);
+    }
+
+    return this.settings;
+  };
+
+  private writeOperations = async (operations: Operation[]) => {
+    const cipherText = this.lockService.encrypt(JSON.stringify(operations));
+    await this.historyStore.set(cipherText);
+  };
+
+  private writeSettings = async (settings: HistorySettings) => {
+    await this.historySettingsStore.set(JSON.stringify(settings));
   };
 }

--- a/src/background/zkKeeper.ts
+++ b/src/background/zkKeeper.ts
@@ -125,6 +125,10 @@ export default class ZkKeeperController extends Handler {
 
     this.add(RPCAction.GET_IDENTITY_HISTORY, this.lockService.ensure, this.historyService.getOperations);
 
+    this.add(RPCAction.DELETE_HISTORY_OPERATION, this.lockService.ensure, this.historyService.removeOperation);
+
+    this.add(RPCAction.DELETE_HISTORY_OPERATION, this.lockService.ensure, this.historyService.clear);
+
     // Protocols
     this.add(
       RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST,

--- a/src/config/mock/nanoidMock.js
+++ b/src/config/mock/nanoidMock.js
@@ -1,0 +1,3 @@
+module.exports = {
+  nanoid: () => (Math.random() % 100).toString(),
+};

--- a/src/constants/rpcActions.ts
+++ b/src/constants/rpcActions.ts
@@ -30,6 +30,8 @@ export enum RPCAction {
   SET_CONNECT_WALLET = "rpc/wallet/connect",
   LOAD_IDENTITY_HISTORY = "rpc/identity/load-history",
   GET_IDENTITY_HISTORY = "rpc/identity/get-history",
+  DELETE_HISTORY_OPERATION = "rpc/identity/delete-history-operation",
+  DELETE_ALL_HISTORY_OPERATIONS = "rpc/identity/delete-history",
   // DEV RPCS
   CLEAR_APPROVED_HOSTS = "rpc/hosts/clear",
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,3 +149,7 @@ export interface Operation {
   };
   createdAt: string;
 }
+
+export interface HistorySettings {
+  isEnabled: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,7 @@ export enum OperationType {
 }
 
 export interface Operation {
+  id: string;
   type: OperationType;
   identity: {
     commitment: string;

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -44,7 +44,12 @@ describe("ui/ducks/identities", () => {
   ];
 
   const defaultOperations: IdentitiesState["operations"] = [
-    { type: OperationType.CREATE_IDENTITY, createdAt: new Date().toISOString(), identity: defaultIdentities[0] },
+    {
+      id: "1",
+      type: OperationType.CREATE_IDENTITY,
+      createdAt: new Date().toISOString(),
+      identity: defaultIdentities[0],
+    },
   ];
 
   const defaultSelectedIdentity: SelectedIdentity = {

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -7,7 +7,7 @@ import { Provider } from "react-redux";
 
 import { ZERO_ADDRESS } from "@src/config/const";
 import { RPCAction } from "@src/constants";
-import { OperationType } from "@src/types";
+import { HistorySettings, OperationType } from "@src/types";
 import { store } from "@src/ui/store/configureAppStore";
 import postMessage from "@src/util/postMessage";
 
@@ -31,6 +31,9 @@ import {
   useIdentityOperations,
   getHistory,
   setOperations,
+  deleteHistoryOperation,
+  clearHistory,
+  useHistorySettings,
 } from "../identities";
 
 jest.unmock("@src/ui/ducks/hooks");
@@ -51,6 +54,8 @@ describe("ui/ducks/identities", () => {
       identity: defaultIdentities[0],
     },
   ];
+
+  const defaultSettings: HistorySettings = { isEnabled: true };
 
   const defaultSelectedIdentity: SelectedIdentity = {
     commitment: defaultIdentities[0].commitment,
@@ -79,16 +84,21 @@ describe("ui/ducks/identities", () => {
   });
 
   test("should fetch history properly", async () => {
-    (postMessage as jest.Mock).mockResolvedValue(defaultOperations);
+    (postMessage as jest.Mock).mockResolvedValue({ operations: defaultOperations, settings: defaultSettings });
 
     await Promise.resolve(store.dispatch(fetchHistory()));
     const { identities } = store.getState();
     const operationsHookData = renderHook(() => useIdentityOperations(), {
       wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
     });
+    const settingsHookData = renderHook(() => useHistorySettings(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
 
     expect(identities.operations).toStrictEqual(defaultOperations);
+    expect(identities.settings).toStrictEqual(defaultSettings);
     expect(operationsHookData.result.current).toStrictEqual(defaultOperations);
+    expect(settingsHookData.result.current).toStrictEqual(defaultSettings);
   });
 
   test("should get history properly", async () => {
@@ -102,6 +112,33 @@ describe("ui/ducks/identities", () => {
 
     expect(identities.operations).toStrictEqual(defaultOperations);
     expect(operationsHookData.result.current).toStrictEqual(defaultOperations);
+  });
+
+  test("should delete history operation properly", async () => {
+    const expectedOperations = defaultOperations.slice(1);
+    (postMessage as jest.Mock).mockResolvedValue(expectedOperations);
+
+    await Promise.resolve(store.dispatch(deleteHistoryOperation(defaultOperations[0].id)));
+    const { identities } = store.getState();
+    const operationsHookData = renderHook(() => useIdentityOperations(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    expect(identities.operations).toStrictEqual(expectedOperations);
+    expect(operationsHookData.result.current).toStrictEqual(expectedOperations);
+  });
+
+  test("should clear history properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue(undefined);
+
+    await Promise.resolve(store.dispatch(clearHistory()));
+    const { identities } = store.getState();
+    const operationsHookData = renderHook(() => useIdentityOperations(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    expect(identities.operations).toHaveLength(0);
+    expect(operationsHookData.result.current).toHaveLength(0);
   });
 
   test("should set operations properly", async () => {


### PR DESCRIPTION
## Explanation

This PR adds support for removing operation and history incognito mode.

Details are below:
- [x] Add nanoid for operation id field
- [x] Add remove operation method for history service
- [x] Support incognito mode for history service

## More Information

Blocked by #252 
Related to #30

## Screenshots/Screencaps

### Before

N/A

### After

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
