### PR TITLE
test: add e2e tests for identities

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CRYPTKEEPER_DEBUG: false
-  RANDOM_IDENTITY: false
+  RANDOM_IDENTITY: true
   METAMASK_EXTENSION_ID: "gopbpnbkpnnmomhlhkpljncmmoidkioi"
   METAMASK_VERSION: "10.28.1"
   INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -227,7 +227,6 @@ function App() {
   }
 
   if (!selectedIdentity) {
-    console.log("identityCommitment", selectedIdentity);
     return <NoActiveIDCommitment />;
   }
 

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -11,7 +11,6 @@ export interface TestExtension {
   context: BrowserContext;
   cryptKeeperExtensionId: string;
   app: Page;
-  cryptKeeper: Page;
 }
 
 export const test = base.extend<TestExtension>({
@@ -49,44 +48,6 @@ export const test = base.extend<TestExtension>({
       });
 
       await use(context);
-      await context.close();
-    },
-    { scope: "test" },
-  ],
-
-  app: [
-    async ({ context }, use) => {
-      const [page] = context.pages();
-      await page.goto("/");
-      await page.bringToFront();
-
-      await use(page);
-      await context.close();
-    },
-    { scope: "test" },
-  ],
-
-  cryptKeeper: [
-    async ({ context }, use) => {
-      await Promise.all(
-        context.serviceWorkers().map((sw) => {
-          if (!sw) {
-            return context.waitForEvent("serviceworker");
-          }
-
-          return undefined;
-        }),
-      );
-
-      context.on("page", async (page: Page) => {
-        await page.waitForLoadState();
-
-        const title = await page.title();
-
-        if (title.toLowerCase() === "crypt keeper") {
-          await use(page);
-        }
-      });
     },
     { scope: "test" },
   ],
@@ -100,6 +61,18 @@ export const test = base.extend<TestExtension>({
 
       const extensionId = background.url().split("/")[2];
       await use(extensionId);
+    },
+    { scope: "test" },
+  ],
+
+  app: [
+    async ({ context }, use) => {
+      const [page] = context.pages();
+      await page.goto("/");
+      await page.bringToFront();
+
+      await use(page);
+      await context.close();
     },
     { scope: "test" },
   ],

--- a/e2e/helpers/account.ts
+++ b/e2e/helpers/account.ts
@@ -34,16 +34,13 @@ export async function unlockAccount({ app, cryptKeeperExtensionId }: TestExtensi
   await cryptKeeper.unlock(CRYPT_KEEPER_PASSWORD);
 }
 
-const CRYPT_KEEPER_CONNECT_TIMEOUT_MS = 3000;
-
 async function connectCryptKeeper(app: Page): Promise<CryptKeeper> {
   await expect(app).toHaveTitle(/Crypt-keeper Extension demo/);
   await expect(app.getByText(/Please connect to Crypt-Keeper to continue./)).toBeVisible();
 
-  const [popup] = await Promise.all([
-    app.context().waitForEvent("page"),
+  const [, popup] = await Promise.all([
     app.getByText("Connect", { exact: true }).click(),
-    app.waitForTimeout(CRYPT_KEEPER_CONNECT_TIMEOUT_MS),
+    app.context().waitForEvent("page"),
   ]);
 
   return new CryptKeeper(popup);

--- a/e2e/pages/BasePage.ts
+++ b/e2e/pages/BasePage.ts
@@ -22,4 +22,8 @@ export default abstract class BasePage {
   public getByText(text: string | RegExp, options?: { exact: boolean }): Locator {
     return this.page.getByText(text, options);
   }
+
+  public getByTestId(testId: string | RegExp): Locator {
+    return this.page.getByTestId(testId);
+  }
 }

--- a/e2e/pages/BasePage.ts
+++ b/e2e/pages/BasePage.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from "@playwright/test";
+
+export default abstract class BasePage {
+  protected readonly page: Page;
+
+  public constructor(page: Page) {
+    this.page = page;
+  }
+
+  public async open(path = "/"): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  public async focus(): Promise<void> {
+    await this.page.bringToFront();
+  }
+
+  public async close(): Promise<void> {
+    return this.page.close();
+  }
+
+  public getByText(text: string | RegExp, options?: { exact: boolean }): Locator {
+    return this.page.getByText(text, options);
+  }
+}

--- a/e2e/pages/CryptKeeper.ts
+++ b/e2e/pages/CryptKeeper.ts
@@ -1,0 +1,106 @@
+import * as metamaskCommands from "@synthetixio/synpress/commands/metamask";
+
+import BasePage from "./BasePage";
+
+export interface ICreateIdentityArgs {
+  identityType?: IdentityType;
+  provider?: ProviderType;
+  nonce?: number;
+}
+
+type IdentityType = "InterRep" | "Random";
+
+type ProviderType = "Twitter" | "Reddit" | "Github";
+
+const IDENTITY_OPTIONS: Record<IdentityType, number> = {
+  InterRep: 0,
+  Random: 1,
+};
+
+const PROVIDER_OPTIONS: Record<ProviderType, number> = {
+  Twitter: 0,
+  Github: 1,
+  Reddit: 2,
+};
+
+export default class CryptKeeper extends BasePage {
+  public async openPopup(extensionId: string): Promise<void> {
+    await this.page.goto(`chrome-extension://${extensionId}/popup.html`);
+  }
+
+  public async unlock(password: string): Promise<void> {
+    await this.page.getByLabel("Password", { exact: true }).type(password);
+    await this.page.getByText("Unlock", { exact: true }).click();
+  }
+
+  public async lock(): Promise<void> {
+    await this.page.getByTestId("menu").click();
+    await this.page.getByText("Lock", { exact: true }).click();
+  }
+
+  public async connectWallet(): Promise<void> {
+    await this.page.getByTestId("menu").click();
+    await this.page.getByText("Connect wallet", { exact: true }).click();
+
+    await metamaskCommands.acceptAccess();
+  }
+
+  public async createAccount(password: string, confirmPassword?: string): Promise<void> {
+    await this.page.getByLabel("Password", { exact: true }).type(password);
+    await this.page.getByLabel("Confirm Password", { exact: true }).type(confirmPassword ?? password);
+    await this.page.getByText("Continue", { exact: true }).click();
+  }
+
+  public async approve(): Promise<void> {
+    await this.page.getByText("Approve").click();
+  }
+
+  public async createIdentity({ identityType, provider, nonce }: ICreateIdentityArgs | undefined = {}): Promise<void> {
+    const [cryptKeeper] = await Promise.all([
+      this.page.context().waitForEvent("page"),
+      this.page.getByText(/Add Identity/).click(),
+    ]);
+
+    if (identityType) {
+      await cryptKeeper.locator("#identityStrategyType").click();
+      await cryptKeeper.locator(`[id$="-option-${IDENTITY_OPTIONS[identityType]}"]`).click();
+    }
+
+    if (provider && identityType !== "Random") {
+      await cryptKeeper.locator("#web2Provider").click();
+      await cryptKeeper.locator(`[id$="-option-${PROVIDER_OPTIONS[provider]}"]`).click();
+    }
+
+    if (nonce && identityType !== "Random") {
+      await cryptKeeper.getByLabel("Nonce").fill(nonce.toString());
+    }
+    await cryptKeeper.getByRole("button", { name: "Create" }).click();
+
+    // TODO: synpress doesn't support new data-testid for metamask
+    const metamask = await this.page.context().waitForEvent("page");
+    await metamask.getByTestId("page-container-footer-next").click();
+  }
+
+  public async renameIdentity(index: number, name: string): Promise<void> {
+    const identities = await this.page.locator(".identity-row").all();
+    await identities[index].getByTestId("menu").click();
+
+    await this.page.getByText("Rename").click();
+
+    await this.page.locator("#identityRename").fill(name);
+    await this.page.locator("#identityRename").press("Enter");
+  }
+
+  public async deleteIdentity(index: number): Promise<void> {
+    const identities = await this.page.locator(".identity-row").all();
+    await identities[index].getByTestId("menu").click();
+
+    await this.page.getByText("Delete").click();
+    await this.page.getByText("Yes").click();
+  }
+
+  public async deleteAllIdentities(): Promise<void> {
+    await this.page.getByText("Clear all identities").click();
+    await this.page.getByText("Yes").click();
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,0 +1,1 @@
+export { default as CryptKeeper } from "./CryptKeeper";

--- a/e2e/tests/identity.test.ts
+++ b/e2e/tests/identity.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../fixtures";
+import { connectWallet, createAccount } from "../helpers/account";
+import { CryptKeeper } from "../pages";
+
+test.describe("identity", () => {
+  test.beforeEach(async ({ app, cryptKeeperExtensionId, context }) => {
+    await createAccount({ app, cryptKeeperExtensionId, context });
+
+    await app.goto(`chrome-extension://${cryptKeeperExtensionId}/popup.html`);
+    await expect(app.getByTestId("home-page")).toBeVisible();
+
+    await connectWallet({ app, cryptKeeperExtensionId, context });
+    await expect(app.getByText("Ethereum mainnet")).toBeVisible();
+  });
+
+  test("should create and delete different types of identities properly", async ({ app }) => {
+    const extension = new CryptKeeper(app);
+    await extension.focus();
+
+    await extension.createIdentity();
+    await expect(extension.getByText("Account # 0")).toBeVisible();
+
+    await extension.createIdentity({ provider: "Github", nonce: 0 });
+    await expect(extension.getByText("Account # 1")).toBeVisible();
+
+    await extension.createIdentity({ provider: "Reddit", nonce: 0 });
+    await expect(extension.getByText("Account # 2")).toBeVisible();
+
+    await extension.createIdentity({ identityType: "Random", nonce: 0 });
+    await expect(extension.getByText("Account # 3")).toBeVisible();
+
+    await extension.createIdentity({ identityType: "Random", nonce: 0 });
+    await expect(extension.getByText("Account # 4")).toBeVisible();
+
+    await expect(extension.getByText(/Account/)).toHaveCount(5);
+
+    await extension.deleteIdentity(0);
+    await expect(extension.getByText(/Account/)).toHaveCount(4);
+
+    await extension.deleteAllIdentities();
+    await expect(extension.getByText(/Account/)).toHaveCount(0);
+  });
+
+  test("should create and rename identity properly", async ({ app }) => {
+    const extension = new CryptKeeper(app);
+    await extension.focus();
+
+    await extension.createIdentity();
+    await expect(extension.getByText("Account # 0")).toBeVisible();
+
+    await extension.renameIdentity(0, "My twitter identity");
+
+    await expect(extension.getByText("My twitter identity")).toBeVisible();
+  });
+});

--- a/e2e/tests/initialization.test.ts
+++ b/e2e/tests/initialization.test.ts
@@ -2,14 +2,14 @@ import { expect, test } from "../fixtures";
 import { connectWallet, createAccount, lockAccount, unlockAccount } from "../helpers/account";
 
 test.describe("initialization", () => {
-  test("should load demo and unlock account", async ({ app, cryptKeeper, cryptKeeperExtensionId, context }) => {
-    await createAccount({ app, cryptKeeper, cryptKeeperExtensionId, context });
-    await lockAccount({ app, cryptKeeper, cryptKeeperExtensionId, context });
-    await unlockAccount({ app, cryptKeeper, cryptKeeperExtensionId, context });
+  test("should load demo and unlock account", async ({ app, cryptKeeperExtensionId, context }) => {
+    await createAccount({ app, cryptKeeperExtensionId, context });
+    await lockAccount({ app, cryptKeeperExtensionId, context });
+    await unlockAccount({ app, cryptKeeperExtensionId, context });
 
     await expect(app.getByTestId("home-page")).toBeVisible();
 
-    await connectWallet({ app, cryptKeeper, cryptKeeperExtensionId, context });
+    await connectWallet({ app, cryptKeeperExtensionId, context });
 
     await expect(app.getByText("Ethereum mainnet")).toBeVisible();
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
   workers: 1,
   reporter: [["github"], ["list"], ["html"]],
   use: {
-    actionTimeout: 0,
     baseURL: "http://localhost:1234",
     trace: "on-first-retry",
     screenshot: "only-on-failure",

--- a/src/background/services/identity.ts
+++ b/src/background/services/identity.ts
@@ -196,6 +196,7 @@ export default class IdentityService {
     identities.set(identityCommitment, newIdentity.serialize());
     await this.writeIdentities(identities);
     await this.updateActiveIdentity({ identities, identityCommitment });
+    await this.refresh();
     await this.historyService.trackOperation(OperationType.CREATE_IDENTITY, {
       identity: { commitment: identityCommitment, metadata: newIdentity.metadata },
     });

--- a/src/ui/pages/Home/components/IdentityList/Item/index.tsx
+++ b/src/ui/pages/Home/components/IdentityList/Item/index.tsx
@@ -85,6 +85,7 @@ export const IdentityItem = ({
             <Input
               autoFocus
               className="identity-row__input-field"
+              id="identityRename"
               label=""
               type="text"
               value={name}


### PR DESCRIPTION
## Explanation

This PR adds e2e tests for identity operations

Details are below:
- [x] Check creating identities
- [x] Check identity delete 
- [x] Check renaming identities
- [x] Fixes for found issues

## More Information

Related to #237 

## Screenshots/Screencaps

### Before

N/A

### After

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
