### PR TITLE
feat: add options page

### DIFF
--- a/src/background/services/history/__tests__/history.test.ts
+++ b/src/background/services/history/__tests__/history.test.ts
@@ -39,6 +39,15 @@ const mockSerializedDefaultOperations = JSON.stringify(mockDefaultOperations);
 const mockDefaultSettings = { isEnabled: true };
 const mockSerializedDefaultSettings = JSON.stringify(mockDefaultSettings);
 
+jest.mock("../../notification", (): unknown => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      create: jest.fn(),
+    })),
+  },
+}));
+
 jest.mock("../../lock", (): unknown => ({
   __esModule: true,
   default: {

--- a/src/background/services/history/index.ts
+++ b/src/background/services/history/index.ts
@@ -1,9 +1,11 @@
 import { nanoid } from "nanoid";
+import { browser } from "webextension-polyfill-ts";
 
 import { getEnabledFeatures } from "@src/config/features";
 import { HistorySettings, IdentityData, Operation, OperationType } from "@src/types";
 
 import LockService from "../lock";
+import NotificationService from "../notification";
 import SimpleStorage from "../simpleStorage";
 
 const HISTORY_KEY = "@@HISTORY@@";
@@ -31,6 +33,8 @@ export default class HistoryService {
 
   private lockService: LockService;
 
+  private notificationService: NotificationService;
+
   private operations: Operation[];
 
   private settings?: HistorySettings;
@@ -39,6 +43,7 @@ export default class HistoryService {
     this.historyStore = new SimpleStorage(HISTORY_KEY);
     this.historySettingsStore = new SimpleStorage(HISTORY_SETTINGS_KEY);
     this.lockService = LockService.getInstance();
+    this.notificationService = NotificationService.getInstance();
     this.operations = [];
     this.settings = undefined;
   }
@@ -103,6 +108,15 @@ export default class HistoryService {
   public clear = async (): Promise<void> => {
     this.operations = [];
     await this.historyStore.clear();
+
+    await this.notificationService.create({
+      options: {
+        title: "History clear",
+        message: "History operations has been cleared",
+        iconUrl: browser.runtime.getURL("/logo.png"),
+        type: "basic",
+      },
+    });
   };
 
   private loadSettings = async (): Promise<HistorySettings> => {

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -5,4 +5,5 @@ export enum Paths {
   LOGIN = "/login",
   ONBOARDING = "/onboarding",
   REQUESTS = "/requests",
+  SETTINGS = "/settings",
 }

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -1,7 +1,9 @@
 import classNames from "classnames";
 import { useCallback } from "react";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+import { useNavigate } from "react-router-dom";
 
+import { Paths } from "@src/constants";
 import loaderSvg from "@src/static/icons/loader.svg";
 import logoSvg from "@src/static/icons/logo.svg";
 import { Icon } from "@src/ui/components/Icon";
@@ -15,15 +17,24 @@ const METAMASK_INSTALL_URL = "https://metamask.io/";
 
 export const Header = (): JSX.Element => {
   const { address, isActivating, isActive, isInjectedWallet, chain, onConnect, onDisconnect, onLock } = useWallet();
+  const navigate = useNavigate();
   const isLoading = isActivating && isInjectedWallet;
 
   const onGoToMetamaskPage = useCallback(() => {
     redirectToNewTab(METAMASK_INSTALL_URL);
   }, []);
 
+  const onGoToHome = useCallback(() => {
+    navigate(Paths.HOME);
+  }, [navigate]);
+
+  const onGoToSettings = useCallback(() => {
+    navigate(Paths.SETTINGS);
+  }, [navigate]);
+
   return (
     <div className="header h-16 flex flex-row items-center px-4">
-      <Icon size={3} url={logoSvg} />
+      <Icon data-testid="logo" size={3} url={logoSvg} onClick={onGoToHome} />
 
       <div className="flex-grow flex flex-row items-center justify-end header__content">
         {chain && <div className="text-sm rounded-full header__network-type">{chain.name}</div>}
@@ -43,6 +54,11 @@ export const Header = (): JSX.Element => {
                     isDangerItem: false,
                     onClick: isInjectedWallet ? onConnect : onGoToMetamaskPage,
                   },
+              {
+                label: "Settings",
+                isDangerItem: false,
+                onClick: onGoToSettings,
+              },
               {
                 label: "Lock",
                 isDangerItem: false,

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -5,6 +5,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 import selectEvent from "react-select-event";
 
 import { ZERO_ADDRESS } from "@src/config/const";
@@ -17,6 +18,10 @@ import { useWallet } from "@src/ui/hooks/wallet";
 import { signIdentityMessage } from "@src/ui/services/identity";
 
 import CreateIdentity from "..";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
@@ -41,6 +46,7 @@ jest.mock("@src/ui/hooks/wallet", (): unknown => ({
 describe("ui/pages/CreateIdentity", () => {
   const mockSignedMessage = "signed-message";
   const mockDispatch = jest.fn(() => Promise.resolve());
+  const mockNavigate = jest.fn();
 
   beforeEach(() => {
     library.add(faTwitter, faGithub, faReddit);
@@ -48,6 +54,8 @@ describe("ui/pages/CreateIdentity", () => {
     (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (signIdentityMessage as jest.Mock).mockResolvedValue(mockSignedMessage);
 

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -3,16 +3,21 @@
  */
 
 import { act, renderHook } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
 import { ZERO_ADDRESS } from "@src/config/const";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
-import { IDENTITY_TYPES } from "@src/constants";
+import { IDENTITY_TYPES, Paths } from "@src/constants";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";
 import { useWallet } from "@src/ui/hooks/wallet";
 import { signIdentityMessage } from "@src/ui/services/identity";
 
 import { useCreateIdentity } from "../useCreateIdentity";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
@@ -39,6 +44,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
   const mockDispatch = jest.fn();
 
+  const mockNavigate = jest.fn();
+
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
@@ -47,6 +54,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     (createIdentity as jest.Mock).mockReturnValue(true);
 
     (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
   });
 
   afterEach(() => {
@@ -81,6 +90,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
       nonce: 0,
       web2Provider: "twitter",
     });
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });
 
   test("should close modal properly", () => {

--- a/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -1,8 +1,9 @@
 import { BaseSyntheticEvent, useCallback } from "react";
 import { Control, useForm, UseFormRegister } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 
 import { getEnabledFeatures } from "@src/config/features";
-import { WEB2_PROVIDER_OPTIONS, IDENTITY_TYPES } from "@src/constants";
+import { WEB2_PROVIDER_OPTIONS, IDENTITY_TYPES, Paths } from "@src/constants";
 import { IdentityStrategy, IdentityWeb2Provider, SelectOption } from "@src/types";
 import { closePopup } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -47,6 +48,7 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
       nonce: 0,
     },
   });
+  const navigate = useNavigate();
 
   const { address, provider } = useWallet();
   const dispatch = useAppDispatch();
@@ -71,7 +73,8 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
         });
 
         if (messageSignature) {
-          dispatch(createIdentity(identityStrategyType.value as IdentityStrategy, messageSignature, options));
+          await dispatch(createIdentity(identityStrategyType.value as IdentityStrategy, messageSignature, options));
+          navigate(Paths.HOME);
         }
       } catch (err) {
         setError("root", { type: "submit", message: (err as Error).message });

--- a/src/ui/pages/Home/__tests__/Home.test.tsx
+++ b/src/ui/pages/Home/__tests__/Home.test.tsx
@@ -4,12 +4,17 @@
 
 import { render, waitFor } from "@testing-library/react";
 import { Suspense } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { useWallet } from "@src/ui/hooks/wallet";
 
 import Home from "..";
 import { IUseHomeData, useHome } from "../useHome";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useWallet: jest.fn(),
@@ -25,6 +30,8 @@ jest.mock("../useHome", (): unknown => ({
 }));
 
 describe("ui/pages/Home", () => {
+  const mockNavigate = jest.fn();
+
   const defaultHookData: IUseHomeData = {
     identities: [],
     address: defaultWalletHookData.address,
@@ -35,6 +42,8 @@ describe("ui/pages/Home", () => {
 
   beforeEach(() => {
     (useHome as jest.Mock).mockReturnValue(defaultHookData);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
   });

--- a/src/ui/pages/Home/components/ActivityList/ActivityList.tsx
+++ b/src/ui/pages/Home/components/ActivityList/ActivityList.tsx
@@ -1,24 +1,9 @@
-import classNames from "classnames";
-
-import { Checkbox } from "@src/ui/components/Checkbox";
-import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
-import { Icon } from "@src/ui/components/Icon";
-
 import "./activityListStyles.scss";
 import { ActivityItem } from "./Item";
 import { useActivityList } from "./useActivityList";
 
 export const ActivityList = (): JSX.Element => {
-  const {
-    isLoading,
-    isConfirmModalOpen,
-    operations,
-    settings,
-    onConfirmModalShow,
-    onDeleteAllHistory,
-    onDeleteHistoryOperation,
-    onEnableHistory,
-  } = useActivityList();
+  const { isLoading, operations, onDeleteHistoryOperation } = useActivityList();
 
   if (isLoading) {
     return <div className="flex flex-row items-center justify-center p-4">Loading...</div>;
@@ -29,40 +14,10 @@ export const ActivityList = (): JSX.Element => {
   }
 
   return (
-    <>
-      <div className="flex justify-end mb-3 mt-3 mr-2">
-        <Checkbox
-          checked={Boolean(settings?.isEnabled)}
-          className="mr-2"
-          id="enabledHistory"
-          onChange={onEnableHistory}
-        />
-
-        <label className="text-sm" htmlFor="enabledHistory">
-          Keep track history
-        </label>
-      </div>
-
-      <div className="activity-content">
-        {operations.map((operation) => (
-          <ActivityItem key={operation.id} operation={operation} onDelete={onDeleteHistoryOperation} />
-        ))}
-      </div>
-
-      <ConfirmDangerModal accept={onDeleteAllHistory} isOpenModal={isConfirmModalOpen} reject={onConfirmModalShow} />
-
-      <div className="flex flex-row items-center justify-center p-4">
-        <button
-          className={classNames("flex flex-row items-center justify-center cursor-pointer text-gray-600")}
-          data-testid="create-new-identity"
-          type="button"
-          onClick={onConfirmModalShow}
-        >
-          <Icon className="mr-2" fontAwesome="fas fa-trash" size={1} />
-
-          <div>Clear history</div>
-        </button>
-      </div>
-    </>
+    <div className="activity-content">
+      {operations.map((operation) => (
+        <ActivityItem key={operation.id} operation={operation} onDelete={onDeleteHistoryOperation} />
+      ))}
+    </div>
   );
 };

--- a/src/ui/pages/Home/components/ActivityList/__tests__/ActivityList.test.tsx
+++ b/src/ui/pages/Home/components/ActivityList/__tests__/ActivityList.test.tsx
@@ -47,12 +47,8 @@ describe("ui/pages/Home/components/ActivityList", () => {
 
   const defaultHookData: IUseActivityListData = {
     isLoading: false,
-    isConfirmModalOpen: false,
     operations: defaultIdentityOperations,
-    onConfirmModalShow: jest.fn(),
-    onDeleteAllHistory: jest.fn(),
     onDeleteHistoryOperation: jest.fn(),
-    onEnableHistory: jest.fn(),
   };
 
   beforeEach(() => {
@@ -91,15 +87,6 @@ describe("ui/pages/Home/components/ActivityList", () => {
     const noRecords = await screen.findByText("No records found");
 
     expect(noRecords).toBeInTheDocument();
-  });
-
-  test("should delete all history properly", async () => {
-    render(<ActivityList />);
-
-    const clearHistoryButton = await screen.findByText("Clear history");
-    await act(async () => Promise.resolve(clearHistoryButton.click()));
-
-    expect(defaultHookData.onConfirmModalShow).toBeCalledTimes(1);
   });
 
   test("should delete activity operation properly", async () => {

--- a/src/ui/pages/Home/components/ActivityList/__tests__/useActivityList.test.ts
+++ b/src/ui/pages/Home/components/ActivityList/__tests__/useActivityList.test.ts
@@ -8,9 +8,7 @@ import { ZERO_ADDRESS } from "@src/config/const";
 import { HistorySettings, Operation, OperationType } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import {
-  clearHistory,
   deleteHistoryOperation,
-  enableHistory,
   fetchHistory,
   useHistorySettings,
   useIdentityOperations,
@@ -19,10 +17,8 @@ import {
 import { useActivityList } from "../useActivityList";
 
 jest.mock("@src/ui/ducks/identities", (): unknown => ({
-  clearHistory: jest.fn(),
   deleteHistoryOperation: jest.fn(),
   fetchHistory: jest.fn(),
-  enableHistory: jest.fn(),
   useHistorySettings: jest.fn(),
   useIdentityOperations: jest.fn(),
 }));
@@ -85,39 +81,8 @@ describe("ui/pages/Home/components/ActivityList/useActivityList", () => {
 
     await waitFor(() => result.current.isLoading === false);
 
-    expect(result.current.isConfirmModalOpen).toBe(false);
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.settings).toStrictEqual(defaultHistorySettings);
     expect(result.current.operations).toStrictEqual(defaultIdentityOperations);
-  });
-
-  test("should show confirm modal", async () => {
-    const { result } = renderHook(() => useActivityList());
-
-    await waitFor(() => result.current.isLoading === false);
-
-    await act(async () => Promise.resolve(result.current.onConfirmModalShow()));
-    await waitFor(() => result.current.isConfirmModalOpen === true);
-
-    await act(async () => Promise.resolve(result.current.onDeleteAllHistory()));
-
-    await waitFor(() => result.current.isConfirmModalOpen === false);
-
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(clearHistory).toBeCalledTimes(1);
-  });
-
-  test("should delete all history properly", async () => {
-    const { result } = renderHook(() => useActivityList());
-
-    await waitFor(() => result.current.isLoading === false);
-
-    await act(async () => Promise.resolve(result.current.onDeleteAllHistory()));
-
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(clearHistory).toBeCalledTimes(1);
   });
 
   test("should delete history operation properly", async () => {
@@ -131,18 +96,5 @@ describe("ui/pages/Home/components/ActivityList/useActivityList", () => {
     expect(fetchHistory).toBeCalledTimes(1);
     expect(deleteHistoryOperation).toBeCalledTimes(1);
     expect(deleteHistoryOperation).toBeCalledWith("1");
-  });
-
-  test("should delete history operation properly", async () => {
-    const { result } = renderHook(() => useActivityList());
-
-    await waitFor(() => result.current.isLoading === false);
-
-    await act(async () => Promise.resolve(result.current.onEnableHistory()));
-
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(enableHistory).toBeCalledTimes(1);
-    expect(enableHistory).toBeCalledWith(!defaultHistorySettings.isEnabled);
   });
 });

--- a/src/ui/pages/Home/components/ActivityList/activityListStyles.scss
+++ b/src/ui/pages/Home/components/ActivityList/activityListStyles.scss
@@ -1,7 +1,7 @@
 @import "@src/util/variables";
 
 .activity-content {
-  height: 275px;
+  height: 375px;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/src/ui/pages/Home/components/ActivityList/useActivityList.ts
+++ b/src/ui/pages/Home/components/ActivityList/useActivityList.ts
@@ -1,37 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { HistorySettings, Operation } from "@src/types";
+import { Operation } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import {
-  clearHistory,
-  deleteHistoryOperation,
-  enableHistory,
-  fetchHistory,
-  useHistorySettings,
-  useIdentityOperations,
-} from "@src/ui/ducks/identities";
+import { deleteHistoryOperation, fetchHistory, useIdentityOperations } from "@src/ui/ducks/identities";
 
 export interface IUseActivityListData {
   isLoading: boolean;
-  isConfirmModalOpen: boolean;
   operations: Operation[];
-  settings?: HistorySettings;
-  onConfirmModalShow: () => void;
   onDeleteHistoryOperation: (id: string) => void;
-  onDeleteAllHistory: () => void;
-  onEnableHistory: () => void;
 }
 
 export const useActivityList = (): IUseActivityListData => {
   const dispatch = useAppDispatch();
   const operations = useIdentityOperations();
-  const settings = useHistorySettings();
-  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  const onConfirmModalShow = useCallback(() => {
-    setConfirmModalOpen((value) => !value);
-  }, [setConfirmModalOpen]);
 
   const onDeleteHistoryOperation = useCallback(
     (id: string) => {
@@ -40,14 +22,6 @@ export const useActivityList = (): IUseActivityListData => {
     [dispatch],
   );
 
-  const onEnableHistory = useCallback(() => {
-    dispatch(enableHistory(!settings?.isEnabled));
-  }, [dispatch, settings?.isEnabled]);
-
-  const onDeleteAllHistory = useCallback(() => {
-    dispatch(clearHistory()).then(() => onConfirmModalShow());
-  }, [dispatch, onConfirmModalShow]);
-
   useEffect(() => {
     setIsLoading(true);
     dispatch(fetchHistory()).finally(() => setIsLoading(false));
@@ -55,12 +29,7 @@ export const useActivityList = (): IUseActivityListData => {
 
   return {
     isLoading,
-    isConfirmModalOpen,
     operations,
-    settings,
-    onConfirmModalShow,
     onDeleteHistoryOperation,
-    onDeleteAllHistory,
-    onEnableHistory,
   };
 };

--- a/src/ui/pages/Login/__tests__/Login.test.tsx
+++ b/src/ui/pages/Login/__tests__/Login.test.tsx
@@ -3,11 +3,16 @@
  */
 
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
 import { unlock } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 
 import Login from "..";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   unlock: jest.fn(),
@@ -19,9 +24,12 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
 
 describe("ui/pages/Login", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
+  const mockNavigate = jest.fn();
 
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (unlock as jest.Mock).mockResolvedValue({});
   });

--- a/src/ui/pages/Login/__tests__/useLogin.test.ts
+++ b/src/ui/pages/Login/__tests__/useLogin.test.ts
@@ -3,12 +3,18 @@
  */
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
+import { Paths } from "@src/constants";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 
 import type { ChangeEvent, FormEvent } from "react";
 
 import { useLogin } from "../useLogin";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
@@ -17,8 +23,12 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
 describe("ui/pages/Login/useLogin", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
 
+  const mockNavigate = jest.fn();
+
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
   });
 
   afterEach(() => {
@@ -50,6 +60,8 @@ describe("ui/pages/Login/useLogin", () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });
 
   test("should handle submit error", async () => {

--- a/src/ui/pages/Login/useLogin.ts
+++ b/src/ui/pages/Login/useLogin.ts
@@ -1,6 +1,8 @@
 import { BaseSyntheticEvent, useCallback, useState } from "react";
 import { UseFormRegister, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 
+import { Paths } from "@src/constants";
 import { PasswordFormFields } from "@src/types";
 import { unlock } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -28,13 +30,15 @@ export const useLogin = (): IUseLoginData => {
     },
   });
 
+  const navigate = useNavigate();
+
   const dispatch = useAppDispatch();
 
   const onSubmit = useCallback(
     (data: PasswordFormFields) => {
-      dispatch(unlock(data.password)).catch((error: Error) =>
-        setError("password", { type: "submit", message: error.message }),
-      );
+      dispatch(unlock(data.password))
+        .then(() => navigate(Paths.HOME))
+        .catch((error: Error) => setError("password", { type: "submit", message: error.message }));
     },
     [dispatch, setError],
   );

--- a/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
+++ b/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
@@ -3,11 +3,16 @@
  */
 
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
 import { setupPassword } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 
 import Onboarding from "..";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   setupPassword: jest.fn(),
@@ -19,9 +24,12 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
 
 describe("ui/pages/Onboarding", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
+  const mockNavigate = jest.fn();
 
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (setupPassword as jest.Mock).mockResolvedValue({});
   });

--- a/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
+++ b/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
@@ -3,13 +3,19 @@
  */
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
+import { Paths } from "@src/constants";
 import { setupPassword } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 
 import type { ChangeEvent, FormEvent } from "react";
 
 import { useOnboarding } from "../useOnboarding";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   setupPassword: jest.fn(),
@@ -26,8 +32,12 @@ jest.mock("@src/ui/hooks/validation", (): unknown => ({
 describe("ui/pages/Onboarding/useOnboarding", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
 
+  const mockNavigate = jest.fn();
+
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (setupPassword as jest.Mock).mockResolvedValue({});
   });
@@ -59,6 +69,8 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });
 
   test("should handle submit error", async () => {

--- a/src/ui/pages/Onboarding/useOnboarding.ts
+++ b/src/ui/pages/Onboarding/useOnboarding.ts
@@ -1,7 +1,9 @@
 import { BaseSyntheticEvent, useCallback, useState } from "react";
 import { useForm, UseFormRegister } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import { object, ref, string } from "yup";
 
+import { Paths } from "@src/constants";
 import { PasswordFormFields } from "@src/types";
 import { setupPassword } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -45,16 +47,17 @@ export const useOnboarding = (): IUseOnboardingData => {
       confirmPassword: "",
     },
   });
+  const navigate = useNavigate();
 
   const dispatch = useAppDispatch();
 
   const onSubmit = useCallback(
     (data: PasswordFormFields) => {
-      dispatch(setupPassword(data.password)).catch((err: Error) =>
-        setError("root", { type: "submit", message: err.message }),
-      );
+      dispatch(setupPassword(data.password))
+        .then(() => navigate(Paths.HOME))
+        .catch((err: Error) => setError("root", { type: "submit", message: err.message }));
     },
-    [dispatch, setError],
+    [dispatch, navigate, setError],
   );
 
   const onShowPassword = useCallback(() => {

--- a/src/ui/pages/Popup/Popup.tsx
+++ b/src/ui/pages/Popup/Popup.tsx
@@ -6,17 +6,19 @@ import CreateIdentity from "@src/ui/pages/CreateIdentity";
 import Home from "@src/ui/pages/Home";
 import Login from "@src/ui/pages/Login";
 import Onboarding from "@src/ui/pages/Onboarding";
+import Settings from "@src/ui/pages/Settings";
 
-import "./popup.scss";
+import "../../styles.scss";
+
 import { usePopup } from "./usePopup";
 
 const routeConfig: RouteObject[] = [
-  { path: Paths.ROOT, element: null },
   { path: Paths.HOME, element: <Home /> },
   { path: Paths.CREATE_IDENTITY, element: <CreateIdentity /> },
   { path: Paths.LOGIN, element: <Login /> },
   { path: Paths.ONBOARDING, element: <Onboarding /> },
   { path: Paths.REQUESTS, element: <ConfirmRequestModal /> },
+  { path: Paths.SETTINGS, element: <Settings /> },
   {
     path: "*",
     element: <Navigate to={Paths.HOME} />,

--- a/src/ui/pages/Popup/__tests__/Popup.test.tsx
+++ b/src/ui/pages/Popup/__tests__/Popup.test.tsx
@@ -45,7 +45,7 @@ describe("ui/pages/Popup", () => {
 
     (usePendingRequests as jest.Mock).mockReturnValue([{ type: "unknown" }]);
 
-    (useAppDispatch as jest.Mock).mockReturnValue(jest.fn());
+    (useAppDispatch as jest.Mock).mockReturnValue(jest.fn(() => Promise.resolve()));
 
     (useAppSelector as jest.Mock).mockReturnValue([]);
 
@@ -133,5 +133,20 @@ describe("ui/pages/Popup", () => {
 
     const home = await findByTestId("home-page");
     expect(home).toBeInTheDocument();
+  });
+
+  test("should render settings page properly", async () => {
+    const { container, findByTestId } = render(
+      <MemoryRouter initialEntries={[Paths.SETTINGS]}>
+        <Suspense>
+          <Popup />
+        </Suspense>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const settings = await findByTestId("settings");
+    expect(settings).toBeInTheDocument();
   });
 });

--- a/src/ui/pages/Popup/__tests__/usePopup.test.ts
+++ b/src/ui/pages/Popup/__tests__/usePopup.test.ts
@@ -144,7 +144,7 @@ describe("ui/pages/Popup/usePopup", () => {
     expect(mockNavigate).toBeCalledWith(Paths.ONBOARDING);
   });
 
-  test("should redirect to onboarding page", async () => {
+  test("should redirect to pending requests page", async () => {
     (useAppStatus as jest.Mock).mockReturnValue({ isInitialized: true, isUnlocked: true });
     (usePendingRequests as jest.Mock).mockReturnValue([{}]);
 
@@ -153,16 +153,5 @@ describe("ui/pages/Popup/usePopup", () => {
 
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(Paths.REQUESTS);
-  });
-
-  test("should redirect to home page", async () => {
-    (useAppStatus as jest.Mock).mockReturnValue({ isInitialized: true, isUnlocked: true });
-    (usePendingRequests as jest.Mock).mockReturnValue([]);
-
-    const { result } = renderHook(() => usePopup());
-    await waitForData(result.current);
-
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });
 });

--- a/src/ui/pages/Popup/usePopup.ts
+++ b/src/ui/pages/Popup/usePopup.ts
@@ -47,8 +47,6 @@ export const usePopup = (): IUsePopupData => {
       navigate(Paths.REQUESTS);
     } else if (redirect) {
       navigate(redirect);
-    } else {
-      navigate(Paths.HOME);
     }
   }, [isLoading, isInitialized, isUnlocked, isShowRequestModal, redirect, navigate]);
 

--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -1,0 +1,69 @@
+import Box from "@mui/material/Box";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
+
+import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
+import { Header } from "@src/ui/components/Header";
+
+import { General } from "./components";
+import { SettingsTabs, useSettings } from "./useSettings";
+
+const Settings = (): JSX.Element => {
+  const {
+    isLoading,
+    isConfirmModalOpen,
+    tab,
+    settings,
+    onTabChange,
+    onEnableHistory,
+    onConfirmModalShow,
+    onDeleteAllHistory,
+  } = useSettings();
+
+  return (
+    <Box data-testid="settings">
+      <Header />
+
+      <Box p={2}>
+        <Box>
+          <Typography variant="h4">Settings</Typography>
+        </Box>
+
+        <Box sx={{ flexGrow: 1, display: "flex", mt: 3 }}>
+          <Tabs
+            orientation="vertical"
+            sx={{ borderRight: 1, borderColor: "divider", width: 200 }}
+            value={tab}
+            onChange={onTabChange}
+          >
+            <Tab label={<Typography>General</Typography>} sx={{ alignItems: "flex-start" }} />
+
+            {/* <Tab label={<Typography>Advanced</Typography>} sx={{ alignItems: "flex-start" }} /> */}
+          </Tabs>
+
+          <Box sx={{ width: "100%", px: 2 }}>
+            {tab === SettingsTabs.GENERAL && (
+              <>
+                <General
+                  isLoading={isLoading}
+                  settings={settings}
+                  onDeleteHistory={onConfirmModalShow}
+                  onEnableHistory={onEnableHistory}
+                />
+
+                <ConfirmDangerModal
+                  accept={onDeleteAllHistory}
+                  isOpenModal={isConfirmModalOpen}
+                  reject={onConfirmModalShow}
+                />
+              </>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default Settings;

--- a/src/ui/pages/Settings/__tests__/Settings.test.tsx
+++ b/src/ui/pages/Settings/__tests__/Settings.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { useWallet } from "@src/ui/hooks/wallet";
+
+import Settings from "..";
+import { IUseSettingsData, SettingsTabs, useSettings } from "../useSettings";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("../useSettings", (): unknown => ({
+  ...jest.requireActual("../useSettings"),
+  useSettings: jest.fn(),
+}));
+
+describe("ui/pages/Settings", () => {
+  const mockNavigate = jest.fn();
+
+  const defaultHookData: IUseSettingsData = {
+    isLoading: false,
+    isConfirmModalOpen: false,
+    tab: SettingsTabs.GENERAL,
+    settings: { isEnabled: true },
+    onConfirmModalShow: jest.fn(),
+    onDeleteAllHistory: jest.fn(),
+    onEnableHistory: jest.fn(),
+    onTabChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    (useSettings as jest.Mock).mockReturnValue(defaultHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render general settings properly", async () => {
+    const { container, findByTestId } = render(
+      <Suspense>
+        <Settings />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const section = await findByTestId("general-settings");
+
+    expect(section).toBeInTheDocument();
+  });
+});

--- a/src/ui/pages/Settings/__tests__/useSettings.test.ts
+++ b/src/ui/pages/Settings/__tests__/useSettings.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { HistorySettings } from "@src/types";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { clearHistory, enableHistory, fetchHistory, useHistorySettings } from "@src/ui/ducks/identities";
+
+import type { SyntheticEvent } from "react";
+
+import { useSettings, SettingsTabs } from "../useSettings";
+
+jest.mock("@src/ui/ducks/identities", (): unknown => ({
+  clearHistory: jest.fn(),
+  fetchHistory: jest.fn(),
+  enableHistory: jest.fn(),
+  useHistorySettings: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
+
+describe("ui/pages/Settings/useSettings", () => {
+  const mockDispatch = jest.fn(() => Promise.resolve());
+
+  const defaultHistorySettings: HistorySettings = {
+    isEnabled: true,
+  };
+
+  beforeEach(() => {
+    (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useHistorySettings as jest.Mock).mockReturnValue(defaultHistorySettings);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return intitial data", async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => result.current.isLoading === false);
+
+    expect(result.current.isConfirmModalOpen).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.tab).toBe(SettingsTabs.GENERAL);
+    expect(result.current.settings).toStrictEqual(defaultHistorySettings);
+  });
+
+  test("should show confirm modal", async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => result.current.isLoading === false);
+
+    await act(async () => Promise.resolve(result.current.onConfirmModalShow()));
+    await waitFor(() => result.current.isConfirmModalOpen === true);
+
+    await act(async () => Promise.resolve(result.current.onDeleteAllHistory()));
+
+    await waitFor(() => result.current.isConfirmModalOpen === false);
+
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchHistory).toBeCalledTimes(1);
+    expect(clearHistory).toBeCalledTimes(1);
+  });
+
+  test("should delete all history properly", async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => result.current.isLoading === false);
+
+    await act(async () => Promise.resolve(result.current.onDeleteAllHistory()));
+
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchHistory).toBeCalledTimes(1);
+    expect(clearHistory).toBeCalledTimes(1);
+  });
+
+  test("should delete history operation properly", async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => result.current.isLoading === false);
+
+    await act(async () => Promise.resolve(result.current.onEnableHistory()));
+
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchHistory).toBeCalledTimes(1);
+    expect(enableHistory).toBeCalledTimes(1);
+    expect(enableHistory).toBeCalledWith(!defaultHistorySettings.isEnabled);
+  });
+
+  test("should change tab properly", async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => result.current.isLoading === false);
+
+    await act(async () => Promise.resolve(result.current.onTabChange({} as SyntheticEvent, SettingsTabs.ADVANCED)));
+
+    expect(result.current.tab).toBe(SettingsTabs.ADVANCED);
+  });
+});

--- a/src/ui/pages/Settings/components/General/General.tsx
+++ b/src/ui/pages/Settings/components/General/General.tsx
@@ -1,0 +1,64 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Typography from "@mui/material/Typography";
+
+import type { HistorySettings } from "@src/types";
+
+export interface IGeneralProps {
+  isLoading: boolean;
+  settings?: HistorySettings;
+  onEnableHistory: () => void;
+  onDeleteHistory: () => void;
+}
+
+const General = ({ isLoading, settings = undefined, onEnableHistory, onDeleteHistory }: IGeneralProps): JSX.Element => {
+  if (isLoading) {
+    return <Box>Loading...</Box>;
+  }
+
+  return (
+    <Box data-testid="general-settings">
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h6">History tracking</Typography>
+
+        <Typography color="text.secondary" variant="body2">
+          This settings is responsible for history writing. If you do not want to keep history of your actions, you can
+          disable history tracking.
+        </Typography>
+
+        <FormGroup>
+          <FormControlLabel
+            checked={Boolean(settings?.isEnabled)}
+            control={<Checkbox data-testid="keepTrackHistory" id="keepTrackHistory" />}
+            label="Keep track history"
+            onChange={onEnableHistory}
+          />
+        </FormGroup>
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h6">Clear history</Typography>
+
+        <Typography color="text.secondary" variant="body2">
+          This cleans the operation history store. Your identities will not be affected.
+        </Typography>
+
+        <FormGroup sx={{ mt: 2 }}>
+          <Button
+            color="error"
+            sx={{ textTransform: "none", width: 200 }}
+            variant="contained"
+            onClick={onDeleteHistory}
+          >
+            Clear operation history
+          </Button>
+        </FormGroup>
+      </Box>
+    </Box>
+  );
+};
+
+export default General;

--- a/src/ui/pages/Settings/components/General/index.ts
+++ b/src/ui/pages/Settings/components/General/index.ts
@@ -1,0 +1,5 @@
+import { lazy } from "react";
+
+export * from "./General";
+
+export default lazy(() => import("./General"));

--- a/src/ui/pages/Settings/components/__tests__/General.test.tsx
+++ b/src/ui/pages/Settings/components/__tests__/General.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+
+import { General, IGeneralProps } from "..";
+
+describe("ui/pages/Settings/components/General", () => {
+  const defaultProps: IGeneralProps = {
+    isLoading: false,
+    settings: { isEnabled: true },
+    onEnableHistory: jest.fn(),
+    onDeleteHistory: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should disable history properly", async () => {
+    const { container, findByTestId } = render(
+      <Suspense>
+        <General {...defaultProps} />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const checkbox = await findByTestId("keepTrackHistory");
+    await act(() => Promise.resolve(checkbox.click()));
+
+    expect(defaultProps.onEnableHistory).toBeCalledTimes(1);
+  });
+
+  test("should clear history properly", async () => {
+    const { container, findByText } = render(
+      <Suspense>
+        <General {...defaultProps} settings={undefined} />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const button = await findByText("Clear operation history");
+    await act(() => Promise.resolve(button.click()));
+
+    expect(defaultProps.onDeleteHistory).toBeCalledTimes(1);
+  });
+
+  test("should render loading state properly", async () => {
+    const { container, findByText } = render(
+      <Suspense>
+        <General {...defaultProps} isLoading />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const loading = await findByText("Loading...");
+
+    expect(loading).toBeInTheDocument();
+  });
+});

--- a/src/ui/pages/Settings/components/index.ts
+++ b/src/ui/pages/Settings/components/index.ts
@@ -1,0 +1,2 @@
+export { default as General } from "./General";
+export * from "./General";

--- a/src/ui/pages/Settings/index.ts
+++ b/src/ui/pages/Settings/index.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export default lazy(() => import("./Settings"));

--- a/src/ui/pages/Settings/useSettings.ts
+++ b/src/ui/pages/Settings/useSettings.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState, SyntheticEvent } from "react";
+
+import { HistorySettings } from "@src/types";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { clearHistory, enableHistory, fetchHistory, useHistorySettings } from "@src/ui/ducks/identities";
+
+export interface IUseSettingsData {
+  isLoading: boolean;
+  isConfirmModalOpen: boolean;
+  tab: SettingsTabs;
+  settings?: HistorySettings;
+  onConfirmModalShow: () => void;
+  onDeleteAllHistory: () => void;
+  onEnableHistory: () => void;
+  onTabChange: (event: SyntheticEvent, value: number) => void;
+}
+
+export enum SettingsTabs {
+  GENERAL = 0,
+  ADVANCED = 1,
+}
+
+export const useSettings = (): IUseSettingsData => {
+  const dispatch = useAppDispatch();
+  const settings = useHistorySettings();
+  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [tab, setTab] = useState(SettingsTabs.GENERAL);
+
+  const onTabChange = useCallback(
+    (_: React.SyntheticEvent, newValue: number) => {
+      setTab(newValue);
+    },
+    [setTab],
+  );
+
+  const onConfirmModalShow = useCallback(() => {
+    setConfirmModalOpen((value) => !value);
+  }, [setConfirmModalOpen]);
+
+  const onEnableHistory = useCallback(() => {
+    dispatch(enableHistory(!settings?.isEnabled));
+  }, [dispatch, settings?.isEnabled]);
+
+  const onDeleteAllHistory = useCallback(() => {
+    dispatch(clearHistory()).then(() => onConfirmModalShow());
+  }, [dispatch, onConfirmModalShow]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    dispatch(fetchHistory()).finally(() => setIsLoading(false));
+  }, [dispatch, setIsLoading]);
+
+  return {
+    isLoading,
+    isConfirmModalOpen,
+    settings,
+    tab,
+    onConfirmModalShow,
+    onDeleteAllHistory,
+    onEnableHistory,
+    onTabChange,
+  };
+};

--- a/src/ui/styles.scss
+++ b/src/ui/styles.scss
@@ -39,6 +39,13 @@ a {
   }
 }
 
+.options {
+  @extend %col-nowrap;
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+}
+
 @media only screen and (min-width: 768px) {
   html {
     height: 100%;
@@ -51,6 +58,14 @@ a {
   }
 
   .popup {
+    width: 36rem;
+    height: 40rem;
+    border: 1px solid $gray-700;
+    margin: 3rem auto;
+    box-shadow: 0 2px 4px 0px $header-gray;
+  }
+
+  .options {
     width: 36rem;
     height: 40rem;
     border: 1px solid $gray-700;

--- a/src/util/__tests__/browser.test.ts
+++ b/src/util/__tests__/browser.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { browser } from "webextension-polyfill-ts";
 
-import { getLastActiveTabUrl, redirectToNewTab } from "../browser";
+import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl } from "../browser";
 
 describe("util/browser", () => {
   const defaultTabs = [{ url: "http://localhost:3000" }];
@@ -33,5 +33,12 @@ describe("util/browser", () => {
 
     expect(browser.tabs.create).toBeCalledTimes(1);
     expect(browser.tabs.create).toBeCalledWith({ url: "url" });
+  });
+
+  test("should redirect to new tab properly", () => {
+    getExtensionUrl("url");
+
+    expect(browser.runtime.getURL).toBeCalledTimes(1);
+    expect(browser.runtime.getURL).toBeCalledWith("url");
   });
 });

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -9,3 +9,5 @@ export const getLastActiveTabUrl = async (): Promise<URL | undefined> => {
 export const redirectToNewTab = async (url: string): Promise<void> => {
   await browser.tabs.create({ url });
 };
+
+export const getExtensionUrl = (path: string): string => browser.runtime.getURL(path);


### PR DESCRIPTION
## Explanation

This PR adds settings page and improves current popup.

Details are below:
- [x] Fix routing redirect to support options page
- [x] Add notification for removing all the history
- [x] Move history tracking and clear to general settings
- [x] Add redirects for login and onboarding pages

## More Information

Closes #45 

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/14254374/233445817-ae83f2cf-85e0-4cd8-885c-088717129bfe.png)

### After

![image](https://user-images.githubusercontent.com/14254374/233445320-a7191719-5743-4cf6-bf2e-75bf130df08e.png)
![image](https://user-images.githubusercontent.com/14254374/233445381-597dbdae-13ce-4a32-b510-bd050396272a.png)
![image](https://user-images.githubusercontent.com/14254374/233446243-8b974bd3-b000-434c-b8db-27ab8a4d4424.png)

## Manual Testing Steps

1. Open menu from home page
2. Go to settings page
3. Clear history and toggle track history button
4. Check activity tab after removing or creating identities

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
