### PR TITLE
test: add e2e tests for history operations

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -48,6 +48,7 @@ export const test = base.extend<TestExtension>({
       });
 
       await use(context);
+      await context.close();
     },
     { scope: "test" },
   ],
@@ -61,6 +62,7 @@ export const test = base.extend<TestExtension>({
 
       const extensionId = background.url().split("/")[2];
       await use(extensionId);
+      await context.close();
     },
     { scope: "test" },
   ],

--- a/e2e/helpers/account.ts
+++ b/e2e/helpers/account.ts
@@ -38,10 +38,7 @@ async function connectCryptKeeper(app: Page): Promise<CryptKeeper> {
   await expect(app).toHaveTitle(/Crypt-keeper Extension demo/);
   await expect(app.getByText(/Please connect to Crypt-Keeper to continue./)).toBeVisible();
 
-  const [, popup] = await Promise.all([
-    app.getByText("Connect", { exact: true }).click(),
-    app.context().waitForEvent("page"),
-  ]);
+  const popup = await app.context().waitForEvent("page");
 
   return new CryptKeeper(popup);
 }

--- a/e2e/pages/cryptKeeper/Activity.ts
+++ b/e2e/pages/cryptKeeper/Activity.ts
@@ -1,0 +1,15 @@
+import BasePage from "../BasePage";
+
+export default class Activity extends BasePage {
+  public async openTab(): Promise<void> {
+    await this.page.getByText("Activity", { exact: true }).click();
+  }
+
+  public async deleteOperation(index = 0): Promise<void> {
+    const operations = await this.page.locator(".activity-row").all();
+    await operations[index].getByTestId("menu").click();
+
+    await this.page.getByText("Delete").click();
+    await this.page.getByText("Yes").click();
+  }
+}

--- a/e2e/pages/cryptKeeper/CryptKeeper.ts
+++ b/e2e/pages/cryptKeeper/CryptKeeper.ts
@@ -1,0 +1,50 @@
+import * as metamaskCommands from "@synthetixio/synpress/commands/metamask";
+
+import BasePage from "../BasePage";
+
+import Activity from "./Activity";
+import Identities from "./Identities";
+import Settings from "./Settings";
+
+export default class CryptKeeper extends BasePage {
+  public activityTab = new Activity(this.page);
+
+  public identitiesTab = new Identities(this.page);
+
+  public settingsPage = new Settings(this.page);
+
+  public async openPopup(extensionId: string): Promise<void> {
+    await this.page.goto(`chrome-extension://${extensionId}/popup.html`);
+  }
+
+  public async goHome(): Promise<void> {
+    await this.page.getByTestId("logo").click();
+  }
+
+  public async unlock(password: string): Promise<void> {
+    await this.page.getByLabel("Password", { exact: true }).type(password);
+    await this.page.getByText("Unlock", { exact: true }).click();
+  }
+
+  public async lock(): Promise<void> {
+    await this.page.getByTestId("menu").click();
+    await this.page.getByText("Lock", { exact: true }).click();
+  }
+
+  public async connectWallet(): Promise<void> {
+    await this.page.getByTestId("menu").click();
+    await this.page.getByText("Connect wallet", { exact: true }).click();
+
+    await metamaskCommands.acceptAccess();
+  }
+
+  public async createAccount(password: string, confirmPassword?: string): Promise<void> {
+    await this.page.getByLabel("Password", { exact: true }).type(password);
+    await this.page.getByLabel("Confirm Password", { exact: true }).type(confirmPassword ?? password);
+    await this.page.getByText("Continue", { exact: true }).click();
+  }
+
+  public async approve(): Promise<void> {
+    await this.page.getByText("Approve").click();
+  }
+}

--- a/e2e/pages/cryptKeeper/Identities.ts
+++ b/e2e/pages/cryptKeeper/Identities.ts
@@ -27,10 +27,9 @@ export default class Identities extends BasePage {
   }
 
   public async createIdentity({ identityType, provider, nonce }: ICreateIdentityArgs | undefined = {}): Promise<void> {
-    const [cryptKeeper] = await Promise.all([
-      this.page.context().waitForEvent("page"),
-      this.page.getByText(/Add Identity/).click(),
-    ]);
+    await this.page.getByText(/Add Identity/).click();
+
+    const cryptKeeper = await this.page.context().waitForEvent("page");
 
     if (identityType) {
       await cryptKeeper.locator("#identityStrategyType").click();
@@ -45,10 +44,12 @@ export default class Identities extends BasePage {
     if (nonce && identityType !== "Random") {
       await cryptKeeper.getByLabel("Nonce").fill(nonce.toString());
     }
+
     await cryptKeeper.getByRole("button", { name: "Create" }).click();
 
     // TODO: synpress doesn't support new data-testid for metamask
     const metamask = await this.page.context().waitForEvent("page");
+
     await metamask.getByTestId("page-container-footer-next").click();
   }
 

--- a/e2e/pages/cryptKeeper/Identities.ts
+++ b/e2e/pages/cryptKeeper/Identities.ts
@@ -1,6 +1,4 @@
-import * as metamaskCommands from "@synthetixio/synpress/commands/metamask";
-
-import BasePage from "./BasePage";
+import BasePage from "../BasePage";
 
 export interface ICreateIdentityArgs {
   identityType?: IdentityType;
@@ -23,36 +21,9 @@ const PROVIDER_OPTIONS: Record<ProviderType, number> = {
   Reddit: 2,
 };
 
-export default class CryptKeeper extends BasePage {
-  public async openPopup(extensionId: string): Promise<void> {
-    await this.page.goto(`chrome-extension://${extensionId}/popup.html`);
-  }
-
-  public async unlock(password: string): Promise<void> {
-    await this.page.getByLabel("Password", { exact: true }).type(password);
-    await this.page.getByText("Unlock", { exact: true }).click();
-  }
-
-  public async lock(): Promise<void> {
-    await this.page.getByTestId("menu").click();
-    await this.page.getByText("Lock", { exact: true }).click();
-  }
-
-  public async connectWallet(): Promise<void> {
-    await this.page.getByTestId("menu").click();
-    await this.page.getByText("Connect wallet", { exact: true }).click();
-
-    await metamaskCommands.acceptAccess();
-  }
-
-  public async createAccount(password: string, confirmPassword?: string): Promise<void> {
-    await this.page.getByLabel("Password", { exact: true }).type(password);
-    await this.page.getByLabel("Confirm Password", { exact: true }).type(confirmPassword ?? password);
-    await this.page.getByText("Continue", { exact: true }).click();
-  }
-
-  public async approve(): Promise<void> {
-    await this.page.getByText("Approve").click();
+export default class Identities extends BasePage {
+  public async openTab(): Promise<void> {
+    await this.page.getByText("Identities", { exact: true }).click();
   }
 
   public async createIdentity({ identityType, provider, nonce }: ICreateIdentityArgs | undefined = {}): Promise<void> {
@@ -91,7 +62,7 @@ export default class CryptKeeper extends BasePage {
     await this.page.locator("#identityRename").press("Enter");
   }
 
-  public async deleteIdentity(index: number): Promise<void> {
+  public async deleteIdentity(index = 0): Promise<void> {
     const identities = await this.page.locator(".identity-row").all();
     await identities[index].getByTestId("menu").click();
 

--- a/e2e/pages/cryptKeeper/Settings.ts
+++ b/e2e/pages/cryptKeeper/Settings.ts
@@ -1,0 +1,17 @@
+import BasePage from "../BasePage";
+
+export default class Settings extends BasePage {
+  public async openPage(): Promise<void> {
+    await this.page.getByTestId("menu").first().click();
+    await this.page.getByText("Settings", { exact: true }).click();
+  }
+
+  public async toggleHistoryTracking(): Promise<void> {
+    await this.page.getByLabel("Keep track history").click();
+  }
+
+  public async clearHistory(): Promise<void> {
+    await this.page.getByText("Clear operation history", { exact: true }).click();
+    await this.page.getByText("Yes").click();
+  }
+}

--- a/e2e/pages/cryptKeeper/index.ts
+++ b/e2e/pages/cryptKeeper/index.ts
@@ -1,0 +1,1 @@
+export { default as CryptKeeper } from "./CryptKeeper";

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,1 +1,1 @@
-export { default as CryptKeeper } from "./CryptKeeper";
+export * from "./cryptKeeper";

--- a/e2e/tests/identity.test.ts
+++ b/e2e/tests/identity.test.ts
@@ -17,27 +17,27 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(app);
     await extension.focus();
 
-    await extension.createIdentity();
+    await extension.identitiesTab.createIdentity();
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
-    await extension.createIdentity({ provider: "Github", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ provider: "Github", nonce: 0 });
     await expect(extension.getByText("Account # 1")).toBeVisible();
 
-    await extension.createIdentity({ provider: "Reddit", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ provider: "Reddit", nonce: 0 });
     await expect(extension.getByText("Account # 2")).toBeVisible();
 
-    await extension.createIdentity({ identityType: "Random", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0 });
     await expect(extension.getByText("Account # 3")).toBeVisible();
 
-    await extension.createIdentity({ identityType: "Random", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0 });
     await expect(extension.getByText("Account # 4")).toBeVisible();
 
     await expect(extension.getByText(/Account/)).toHaveCount(5);
 
-    await extension.deleteIdentity(0);
+    await extension.identitiesTab.deleteIdentity(0);
     await expect(extension.getByText(/Account/)).toHaveCount(4);
 
-    await extension.deleteAllIdentities();
+    await extension.identitiesTab.deleteAllIdentities();
     await expect(extension.getByText(/Account/)).toHaveCount(0);
   });
 
@@ -45,11 +45,77 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(app);
     await extension.focus();
 
-    await extension.createIdentity();
+    await extension.identitiesTab.createIdentity();
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
-    await extension.renameIdentity(0, "My twitter identity");
+    await extension.identitiesTab.renameIdentity(0, "My twitter identity");
 
     await expect(extension.getByText("My twitter identity")).toBeVisible();
+  });
+
+  test("should track activity operations properly", async ({ app }) => {
+    const extension = new CryptKeeper(app);
+    await extension.focus();
+
+    await extension.identitiesTab.createIdentity();
+    await expect(extension.getByText(/Account/)).toHaveCount(1);
+
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("Identity created")).toBeVisible();
+
+    await extension.identitiesTab.openTab();
+    await extension.identitiesTab.deleteIdentity(0);
+    await expect(extension.getByText(/Account/)).toHaveCount(0);
+
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
+
+    await extension.identitiesTab.openTab();
+    await extension.identitiesTab.createIdentity();
+    await expect(extension.getByText(/Account/)).toHaveCount(1);
+
+    await extension.identitiesTab.deleteAllIdentities();
+
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("All identities removed")).toBeVisible();
+
+    await extension.activityTab.deleteOperation();
+    await extension.activityTab.deleteOperation();
+    await extension.activityTab.deleteOperation();
+    await extension.activityTab.deleteOperation();
+
+    await expect(extension.activityTab.getByText("No records found")).toBeVisible();
+  });
+
+  test("should setup settings for tracking operations", async ({ app }) => {
+    const extension = new CryptKeeper(app);
+    await extension.focus();
+
+    await extension.settingsPage.openPage();
+    await extension.settingsPage.toggleHistoryTracking();
+
+    await extension.goHome();
+    await extension.identitiesTab.createIdentity();
+    await expect(extension.getByText(/Account/)).toHaveCount(1);
+
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("No records found")).toBeVisible();
+
+    await extension.settingsPage.openPage();
+    await extension.settingsPage.toggleHistoryTracking();
+
+    await extension.goHome();
+    await extension.identitiesTab.deleteIdentity();
+    await expect(extension.getByText(/Account/)).toHaveCount(0);
+
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
+
+    await extension.settingsPage.openPage();
+    await extension.settingsPage.clearHistory();
+
+    await extension.goHome();
+    await extension.activityTab.openTab();
+    await expect(extension.activityTab.getByText("No records found")).toBeVisible();
   });
 });

--- a/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
+++ b/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
@@ -19,7 +19,7 @@ type IconWeb2Providers = Record<IdentityWeb2Provider, [IconPrefix, IconName]>;
 
 const OPERATIONS: Record<OperationType, string> = {
   [OperationType.CREATE_IDENTITY]: "Identity created",
-  [OperationType.DELETE_IDENTITY]: "Idendity removed",
+  [OperationType.DELETE_IDENTITY]: "Identity removed",
   [OperationType.DELETE_ALL_IDENTITIES]: "All identities removed",
 };
 


### PR DESCRIPTION
## Explanation

This PR adds e2e tests for activity tab and for settings page.

Details are below:
- [x] Create separate pages for identities, activity tabs and settings page
- [x] Add tests for operation history
- [x] Add tests for tracking history settings

## More Information

Related to #237 
Blocked by #265 

## Screenshots/Screencaps

### Before

N/A

### After

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
