### PR TITLE
fix: duplicate navigation for settings page

### DIFF
--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 
 import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
 import { Header } from "@src/ui/components/Header";
+import { Icon } from "@src/ui/components/Icon";
 
 import { General } from "./components";
 import { SettingsTabs, useSettings } from "./useSettings";
@@ -19,6 +20,7 @@ const Settings = (): JSX.Element => {
     onEnableHistory,
     onConfirmModalShow,
     onDeleteAllHistory,
+    onGoBack,
   } = useSettings();
 
   return (
@@ -26,8 +28,10 @@ const Settings = (): JSX.Element => {
       <Header />
 
       <Box p={2}>
-        <Box>
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
           <Typography variant="h4">Settings</Typography>
+
+          <Icon data-testid="close-icon" fontAwesome="fas fa-times" size={1.25} onClick={onGoBack} />
         </Box>
 
         <Box sx={{ flexGrow: 1, display: "flex", mt: 3 }}>

--- a/src/ui/pages/Settings/__tests__/Settings.test.tsx
+++ b/src/ui/pages/Settings/__tests__/Settings.test.tsx
@@ -37,6 +37,7 @@ describe("ui/pages/Settings", () => {
     onDeleteAllHistory: jest.fn(),
     onEnableHistory: jest.fn(),
     onTabChange: jest.fn(),
+    onGoBack: jest.fn(),
   };
 
   beforeEach(() => {

--- a/src/ui/pages/Settings/useSettings.ts
+++ b/src/ui/pages/Settings/useSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState, SyntheticEvent } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { HistorySettings } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -13,6 +14,7 @@ export interface IUseSettingsData {
   onDeleteAllHistory: () => void;
   onEnableHistory: () => void;
   onTabChange: (event: SyntheticEvent, value: number) => void;
+  onGoBack: () => void;
 }
 
 export enum SettingsTabs {
@@ -22,6 +24,7 @@ export enum SettingsTabs {
 
 export const useSettings = (): IUseSettingsData => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const settings = useHistorySettings();
   const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -46,6 +49,10 @@ export const useSettings = (): IUseSettingsData => {
     dispatch(clearHistory()).then(() => onConfirmModalShow());
   }, [dispatch, onConfirmModalShow]);
 
+  const onGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
   useEffect(() => {
     setIsLoading(true);
     dispatch(fetchHistory()).finally(() => setIsLoading(false));
@@ -60,5 +67,6 @@ export const useSettings = (): IUseSettingsData => {
     onDeleteAllHistory,
     onEnableHistory,
     onTabChange,
+    onGoBack,
   };
 };


### PR DESCRIPTION
## Explanation

This PR adds close icon for settings page in addition for header logo navigation.

Details are below:
- [x] Add close icon and go back

## More Information

Closes #275 

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/14254374/234072404-5ee6fe75-e8b8-4a14-81b2-56fd679974d1.png)

### After

![image](https://user-images.githubusercontent.com/14254374/234072210-87997a28-2344-4023-9958-7b2635bda5bb.png)

## Manual Testing Steps

1. Go to settings page
2. Click close icon in page header

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
