### PR TITLE
feat: add download backup file

### DIFF
--- a/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
+++ b/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
@@ -50,6 +50,7 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
   });
 
   test("should submit form properly", async () => {
+    const spyCreateElement = jest.spyOn(document, "createElement");
     const { result } = renderHook(() => useDownloadBackup());
 
     await act(async () =>
@@ -68,6 +69,9 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
     expect(result.current.isLoading).toBe(false);
     expect(mockDispatch).toBeCalledTimes(1);
     expect(downloadBackup).toBeCalledTimes(1);
+    expect(spyCreateElement).toBeCalledTimes(2);
+    expect(spyCreateElement).toHaveBeenNthCalledWith(1, "div");
+    expect(spyCreateElement).toHaveBeenNthCalledWith(2, "a");
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(-1);
   });

--- a/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
+++ b/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 
 import { downloadBackup } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { downloadFile } from "@src/util/browser";
 
 import type { ChangeEvent, FormEvent } from "react";
 
@@ -24,6 +25,10 @@ jest.mock("@src/ui/ducks/backup", (): unknown => ({
   downloadBackup: jest.fn(),
 }));
 
+jest.mock("@src/util/browser", (): unknown => ({
+  downloadFile: jest.fn(),
+}));
+
 describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
 
@@ -35,6 +40,8 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (downloadBackup as jest.Mock).mockReturnValue("content");
+
+    (downloadFile as jest.Mock).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -50,7 +57,6 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
   });
 
   test("should submit form properly", async () => {
-    const spyCreateElement = jest.spyOn(document, "createElement");
     const { result } = renderHook(() => useDownloadBackup());
 
     await act(async () =>
@@ -69,9 +75,7 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
     expect(result.current.isLoading).toBe(false);
     expect(mockDispatch).toBeCalledTimes(1);
     expect(downloadBackup).toBeCalledTimes(1);
-    expect(spyCreateElement).toBeCalledTimes(2);
-    expect(spyCreateElement).toHaveBeenNthCalledWith(1, "div");
-    expect(spyCreateElement).toHaveBeenNthCalledWith(2, "a");
+    expect(downloadFile).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(-1);
   });

--- a/src/ui/pages/DownloadBackup/useDownloadBackup.ts
+++ b/src/ui/pages/DownloadBackup/useDownloadBackup.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { PasswordFormFields } from "@src/types";
 import { downloadBackup } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { formatDate } from "@src/util/date";
 
 export interface IUseDownloadBackupData {
   isLoading: boolean;
@@ -44,7 +45,7 @@ export const useDownloadBackup = (): IUseDownloadBackupData => {
     const element = document.createElement("a");
     element.style.display = "none";
     element.setAttribute("href", content);
-    element.setAttribute("download", "ck-backup.json");
+    element.setAttribute("download", `ck-backup-${formatDate(new Date())}.json`);
     document.body.appendChild(element);
     element.click();
     document.body.removeChild(element);

--- a/src/ui/pages/DownloadBackup/useDownloadBackup.ts
+++ b/src/ui/pages/DownloadBackup/useDownloadBackup.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { PasswordFormFields } from "@src/types";
 import { downloadBackup } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { downloadFile } from "@src/util/browser";
 import { formatDate } from "@src/util/date";
 
 export interface IUseDownloadBackupData {
@@ -41,22 +42,10 @@ export const useDownloadBackup = (): IUseDownloadBackupData => {
     navigate(-1);
   }, [navigate]);
 
-  const downloadFile = useCallback((content: string) => {
-    const element = document.createElement("a");
-    element.style.display = "none";
-    element.setAttribute("href", content);
-    element.setAttribute("download", `ck-backup-${formatDate(new Date())}.json`);
-    document.body.appendChild(element);
-    element.click();
-    document.body.removeChild(element);
-
-    return Promise.resolve();
-  }, []);
-
   const onSubmit = useCallback(
     (data: DownloadBackupFields) => {
       dispatch(downloadBackup(data.password))
-        .then((content: string) => downloadFile(content))
+        .then((content: string) => downloadFile(content, `ck-backup-${formatDate(new Date())}.json`))
         .then(() => onGoBack())
         .catch((error: Error) => setError("password", { type: "submit", message: error.message }));
     },

--- a/src/ui/pages/DownloadBackup/useDownloadBackup.ts
+++ b/src/ui/pages/DownloadBackup/useDownloadBackup.ts
@@ -40,10 +40,22 @@ export const useDownloadBackup = (): IUseDownloadBackupData => {
     navigate(-1);
   }, [navigate]);
 
+  const downloadFile = useCallback((content: string) => {
+    const element = document.createElement("a");
+    element.style.display = "none";
+    element.setAttribute("href", content);
+    element.setAttribute("download", "ck-backup.json");
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+
+    return Promise.resolve();
+  }, []);
+
   const onSubmit = useCallback(
     (data: DownloadBackupFields) => {
-      // TODO: implement file download
       dispatch(downloadBackup(data.password))
+        .then((content: string) => downloadFile(content))
         .then(() => onGoBack())
         .catch((error: Error) => setError("password", { type: "submit", message: error.message }));
     },

--- a/src/util/__tests__/browser.test.ts
+++ b/src/util/__tests__/browser.test.ts
@@ -1,7 +1,11 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/unbound-method */
 import { browser } from "webextension-polyfill-ts";
 
-import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl } from "../browser";
+import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl, downloadFile } from "../browser";
 
 describe("util/browser", () => {
   const defaultTabs = [{ url: "http://localhost:3000" }];
@@ -40,5 +44,17 @@ describe("util/browser", () => {
 
     expect(browser.runtime.getURL).toBeCalledTimes(1);
     expect(browser.runtime.getURL).toBeCalledWith("url");
+  });
+
+  test("should download file properly", async () => {
+    const element = document.createElement("a");
+    element.click = jest.fn();
+
+    const spyCreateElement = jest.spyOn(document, "createElement").mockReturnValue(element);
+
+    await downloadFile("content", "filename");
+
+    expect(spyCreateElement).toBeCalledTimes(1);
+    expect(element.click).toBeCalledTimes(1);
   });
 });

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -11,3 +11,15 @@ export const redirectToNewTab = async (url: string): Promise<void> => {
 };
 
 export const getExtensionUrl = (path: string): string => browser.runtime.getURL(path);
+
+export const downloadFile = (content: string, filename: string): Promise<void> => {
+  const element = document.createElement("a");
+  element.style.display = "none";
+  element.setAttribute("href", content);
+  element.setAttribute("download", filename);
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+
+  return Promise.resolve();
+};


### PR DESCRIPTION
## Explanation

This PR adds support for dowloading backup json file.

## More Information

Related to #257 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

1. Enable `BACKUP` flag
2. Go to advanced settings and click download backup
3. Enter password and dowload
4. See backup file is downloaded

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
