### PR TITLE
feat: add key storage service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@zk-kit/incremental-merkle-tree": "^1.0.0",
         "bigint-conversion": "^2.4.1",
         "bignumber.js": "^9.1.1",
+        "bip39": "^3.1.0",
         "classnames": "^2.3.2",
         "copy-to-clipboard": "^3.3.2",
         "crypto-js": "^4.1.1",
@@ -50,6 +51,8 @@
         "redux-thunk": "^2.4.2",
         "rlnjs": "^2.0.8",
         "subworkers": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1",
         "webextension-polyfill-ts": "^0.26.0",
         "yup": "^1.1.1"
       },
@@ -11103,6 +11106,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "devOptional": true,
@@ -11174,6 +11182,25 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/bip66": {
       "version": "1.1.5",
@@ -16715,12 +16742,6 @@
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "node_modules/eth-sig-util/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
     },
     "node_modules/eth-tx-summary": {
       "version": "3.2.4",
@@ -29320,6 +29341,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "dev": true,
@@ -31587,14 +31613,14 @@
       }
     },
     "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -42147,6 +42173,13 @@
       "version": "1.0.2",
       "requires": {
         "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+        }
       }
     },
     "bech32": {
@@ -42199,6 +42232,21 @@
       "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "requires": {
+        "@noble/hashes": "^1.2.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+          "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+        }
       }
     },
     "bip66": {
@@ -46274,12 +46322,6 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
           }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-          "dev": true
         }
       }
     },
@@ -55148,6 +55190,13 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+        }
       }
     },
     "stable": {
@@ -56844,13 +56893,14 @@
       }
     },
     "tweetnacl": {
-      "version": "0.14.5"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@zk-kit/incremental-merkle-tree": "^1.0.0",
     "bigint-conversion": "^2.4.1",
     "bignumber.js": "^9.1.1",
+    "bip39": "^3.1.0",
     "classnames": "^2.3.2",
     "copy-to-clipboard": "^3.3.2",
     "crypto-js": "^4.1.1",
@@ -159,6 +160,8 @@
     "redux-thunk": "^2.4.2",
     "rlnjs": "^2.0.8",
     "subworkers": "^1.0.1",
+    "tweetnacl": "^1.0.3",
+    "tweetnacl-util": "^0.15.1",
     "webextension-polyfill-ts": "^0.26.0",
     "yup": "^1.1.1"
   },

--- a/src/background/services/key/__tests__/keyStorageService.test.ts
+++ b/src/background/services/key/__tests__/keyStorageService.test.ts
@@ -1,0 +1,127 @@
+import { mnemonicToSeed, generateMnemonic } from "@src/background/services/mnemonic";
+import SimpleStorage from "@src/background/services/storage";
+
+import KeyStorageService from "..";
+
+const mockSerializedKeys = JSON.stringify({
+  publicKey: "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+  secretKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7aie8zrakLWKjqNAqbw1zZTIVdx3iQ6Y6wEihi1naKQ==",
+});
+
+const mockAuthenticityCheckData = {
+  isNewOnboarding: true,
+};
+
+jest.mock("@src/background/services/lock", (): unknown => ({
+  getInstance: jest.fn(() => ({
+    encrypt: jest.fn(() => mockSerializedKeys),
+    decrypt: jest.fn(() => mockSerializedKeys),
+    isAuthentic: jest.fn(() => mockAuthenticityCheckData),
+  })),
+}));
+
+jest.mock("@src/background/services/crypto", (): unknown => ({
+  cryptoGenerateEncryptedHmac: jest.fn(() => "encrypted"),
+  cryptoGetAuthenticBackupCiphertext: jest.fn(() => "encrypted"),
+}));
+
+jest.mock("@src/background/services/storage");
+
+type MockStorage = { get: jest.Mock; set: jest.Mock; clear: jest.Mock };
+
+describe("background/services/key", () => {
+  const keyStorageService = KeyStorageService.getInstance();
+  const defaultMnemonic = generateMnemonic();
+  const defaultSignedMessage =
+    "0x24fbab0609c71311cd0f5c28a30f6707bc554232a47471acd739d06e0bf4b6d6703b3d7a3a53820c37ef5df284f1ed3151fb36bbbc229dabfc203c28eddd44056d657373616765";
+
+  beforeEach(() => {
+    (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+      instance.get.mockReturnValue(mockSerializedKeys);
+      instance.set.mockReturnValue(undefined);
+      instance.clear.mockReturnValue(undefined);
+    });
+  });
+
+  afterEach(async () => {
+    await keyStorageService.clear();
+
+    (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+      instance.get.mockClear();
+      instance.set.mockClear();
+      instance.clear.mockClear();
+    });
+  });
+
+  describe("keys", () => {
+    test("should generate key pair properly", async () => {
+      const seed = await mnemonicToSeed(defaultMnemonic);
+      await keyStorageService.generateKeyPair(seed);
+
+      const [keyStorage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
+
+      expect(keyStorage.set).toBeCalledTimes(1);
+    });
+
+    test("should sign message properly", async () => {
+      const seed = await mnemonicToSeed(defaultMnemonic);
+      await keyStorageService.generateKeyPair(seed);
+
+      const result = await keyStorageService.signMessage("message");
+
+      expect(result).toBe(defaultSignedMessage);
+    });
+
+    test("should sign message with nonce properly", async () => {
+      const seed = await mnemonicToSeed(defaultMnemonic);
+      await keyStorageService.generateKeyPair(seed);
+
+      const result = await keyStorageService.signMessage("message nonce: 1");
+
+      expect(result).not.toBe(defaultSignedMessage);
+    });
+
+    test("should not sign message if there is no key pair", async () => {
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        instance.get.mockReturnValue(undefined);
+      });
+
+      await expect(keyStorageService.signMessage("message")).rejects.toThrowError("No key pair available");
+    });
+  });
+
+  describe("backup", () => {
+    test("should download encrypted keys", async () => {
+      const result = await keyStorageService.downloadEncryptedStorage("password");
+
+      expect(result).toBeDefined();
+    });
+
+    test("should not download encrypted keys if storage is empty", async () => {
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        instance.get.mockReturnValue(undefined);
+      });
+
+      const result = await keyStorageService.downloadEncryptedStorage("password");
+
+      expect(result).toBeNull();
+    });
+
+    test("should upload encrypted keys", async () => {
+      await keyStorageService.uploadEncryptedStorage("encrypted", "password");
+
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        expect(instance.set).toBeCalledTimes(1);
+        expect(instance.set).toBeCalledWith("encrypted");
+      });
+    });
+
+    test("should not upload encrypted keys if there is no data", async () => {
+      await keyStorageService.uploadEncryptedStorage("", "");
+
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        expect(instance.set).toBeCalledTimes(0);
+      });
+    });
+  });
+});

--- a/src/background/services/key/index.ts
+++ b/src/background/services/key/index.ts
@@ -1,0 +1,83 @@
+import { hexlify, toUtf8Bytes } from "ethers";
+import nacl from "tweetnacl";
+import util from "tweetnacl-util";
+
+import { cryptoGenerateEncryptedHmac, cryptoGetAuthenticBackupCiphertext } from "@src/background/services/crypto";
+import LockerService from "@src/background/services/lock";
+import SimpleStorage from "@src/background/services/storage";
+
+import type { KeyPair } from "./types";
+import type { IBackupable } from "../backup";
+
+const KEY_STORAGE_DB_KEY = "@KEY-STORAGE@";
+
+export default class KeyStorageService implements IBackupable {
+  private static INSTANCE: KeyStorageService;
+
+  private keyStorage: SimpleStorage;
+
+  private lockService: LockerService;
+
+  private constructor() {
+    this.keyStorage = new SimpleStorage(KEY_STORAGE_DB_KEY);
+    this.lockService = LockerService.getInstance();
+  }
+
+  static getInstance = (): KeyStorageService => {
+    if (!KeyStorageService.INSTANCE) {
+      KeyStorageService.INSTANCE = new KeyStorageService();
+    }
+
+    return KeyStorageService.INSTANCE;
+  };
+
+  generateKeyPair = async (seed: string): Promise<void> => {
+    nacl.setPRNG(() => toUtf8Bytes(seed));
+
+    const randomBytes = nacl.randomBytes(32);
+    const { publicKey, secretKey } = nacl.sign.keyPair.fromSeed(randomBytes);
+
+    const serializedKeys = JSON.stringify({
+      publicKey: util.encodeBase64(publicKey),
+      secretKey: util.encodeBase64(secretKey),
+    });
+    const encrypted = this.lockService.encrypt(serializedKeys);
+    await this.keyStorage.set(encrypted);
+  };
+
+  signMessage = async (messageHex: string): Promise<string> => {
+    const encrypted = await this.keyStorage.get<string>();
+
+    if (!encrypted) {
+      throw new Error("No key pair available");
+    }
+
+    const { secretKey } = JSON.parse(this.lockService.decrypt(encrypted)) as KeyPair;
+
+    return hexlify(nacl.sign(toUtf8Bytes(messageHex), util.decodeBase64(secretKey)));
+  };
+
+  clear = async (): Promise<void> => {
+    await this.keyStorage.clear();
+  };
+
+  downloadEncryptedStorage = async (backupPassword: string): Promise<string | null> => {
+    const backupEncryptedData = await this.keyStorage.get<string>();
+
+    if (!backupEncryptedData) {
+      return null;
+    }
+
+    await this.lockService.isAuthentic(backupPassword, true);
+    return cryptoGenerateEncryptedHmac(backupEncryptedData, backupPassword);
+  };
+
+  uploadEncryptedStorage = async (backupEncryptedData: string, backupPassword: string): Promise<void> => {
+    const { isNewOnboarding } = await this.lockService.isAuthentic(backupPassword, Boolean(backupEncryptedData));
+
+    if (isNewOnboarding && backupEncryptedData) {
+      const authenticBackupCiphertext = cryptoGetAuthenticBackupCiphertext(backupEncryptedData, backupPassword);
+      await this.keyStorage.set(authenticBackupCiphertext);
+    }
+  };
+}

--- a/src/background/services/key/types.ts
+++ b/src/background/services/key/types.ts
@@ -1,0 +1,4 @@
+export interface KeyPair {
+  publicKey: string;
+  secretKey: string;
+}

--- a/src/background/services/mnemonic/__tests__/mnemonic.test.ts
+++ b/src/background/services/mnemonic/__tests__/mnemonic.test.ts
@@ -1,0 +1,19 @@
+import { generateMnemonic, validateMnemonic, mnemonicToSeed } from "..";
+
+describe("background/services/mnemonic", () => {
+  test("should generate valid mnemonic", () => {
+    const mnemonic = generateMnemonic();
+
+    const isValid = validateMnemonic(mnemonic);
+
+    expect(isValid).toBe(true);
+  });
+
+  test("should generate seed from mnemonic", async () => {
+    const mnemonic = generateMnemonic();
+
+    const seed = await mnemonicToSeed(mnemonic);
+
+    expect(seed).toBeDefined();
+  });
+});

--- a/src/background/services/mnemonic/index.ts
+++ b/src/background/services/mnemonic/index.ts
@@ -1,0 +1,8 @@
+import * as bip39 from "bip39";
+
+export const generateMnemonic = (): string => bip39.generateMnemonic();
+
+export const validateMnemonic = (mnemonic: string): boolean => bip39.validateMnemonic(mnemonic);
+
+export const mnemonicToSeed = (mnemonic: string): Promise<string> =>
+  bip39.mnemonicToSeed(mnemonic).then((bytes) => bytes.toString("hex"));

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -55,6 +55,11 @@ module.exports = {
       chunks: ["popup"],
       minify: true,
     }),
+    new webpack.IgnorePlugin({
+      checkResource(resource) {
+        return /.*\/wordlists\/(?!english).*\.json/.test(resource);
+      },
+    }),
   ],
   module: {
     rules: [


### PR DESCRIPTION
## Explanation

This PR adds support for bip39 mnemonic phrase generation and key storage service.
This is a part of #333.

Details are below:
- [x] Add bip39 and support mnemonic phrase generation
- [x] Add service for key storage to generate key pair and sign messages
- [x] Implement backupable for key storage service  

## More Information

Closes #339 
Closes #342 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
