### PR TITLE
feat: mnemonic ui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 
 # Global:
 
-* @iskdrews @0xmad @AtHeartEngineer
+* @0xisk @0xmad @AtHeartEngineer

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -4,6 +4,7 @@ export enum Paths {
   CREATE_IDENTITY = "/create-identity",
   LOGIN = "/login",
   ONBOARDING = "/onboarding",
+  MNEMONIC = "/mnemonic",
   REQUESTS = "/requests",
   SETTINGS = "/settings",
   DOWNLOAD_BACKUP = "/download-backup",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -5,6 +5,8 @@ import "isomorphic-fetch";
 
 import type { ReactElement } from "react";
 
+jest.retryTimes(1, { logErrorsBeforeRetry: true });
+
 library.add(faTwitter, faGithub, faReddit);
 
 jest.mock("loglevel", () => ({

--- a/src/ui/components/RevealMnemonicInput/RevealMnemonicInput.tsx
+++ b/src/ui/components/RevealMnemonicInput/RevealMnemonicInput.tsx
@@ -1,0 +1,63 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import InputAdornment from "@mui/material/InputAdornment";
+import OutlinedInput from "@mui/material/OutlinedInput";
+import Tooltip from "@mui/material/Tooltip";
+
+import { useRevealMnemonic } from "./useRevealMnemonic";
+
+export interface IRevealMnemonicInputProps {
+  mnemonic: string;
+}
+
+export const RevealMnemonicInput = ({ mnemonic }: IRevealMnemonicInputProps): JSX.Element => {
+  const { isShowMnemonic, isCopied, isDownloaded, onCopy, onDownload, onShowMnemonic } = useRevealMnemonic({
+    mnemonic,
+  });
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", flexDirection: "column" }}>
+      <OutlinedInput
+        multiline
+        endAdornment={
+          <InputAdornment position="end" sx={{ width: "35px", fontSize: "1rem", color: "white" }}>
+            {isShowMnemonic ? (
+              <Tooltip key={2} title="Hide mnemonic" onClick={onShowMnemonic}>
+                <span>Hide</span>
+              </Tooltip>
+            ) : (
+              <Tooltip key={2} title="Show mnemonic" onClick={onShowMnemonic}>
+                <span>Show</span>
+              </Tooltip>
+            )}
+          </InputAdornment>
+        }
+        inputProps={{
+          sx: {
+            cursor: "pointer",
+            filter: !isShowMnemonic ? "blur(6px)" : undefined,
+          },
+        }}
+        sx={{
+          borderColor: "primary.main",
+          borderWidth: "2px",
+          color: "white",
+          cursor: "pointer",
+          fontSize: "1.5rem",
+        }}
+        type="textarea"
+        value={mnemonic}
+      />
+
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", my: 2, width: "100%" }}>
+        <Button sx={{ mr: 1, textTransform: "none", width: "100%" }} variant="outlined" onClick={onCopy}>
+          {isCopied ? "Copied!" : "Copy to clipboard"}
+        </Button>
+
+        <Button sx={{ ml: 1, textTransform: "none", width: "100%" }} variant="outlined" onClick={onDownload}>
+          {isDownloaded ? "Downloaded!" : "Download"}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/components/RevealMnemonicInput/__tests__/RevealMnemonicInput.test.tsx
+++ b/src/ui/components/RevealMnemonicInput/__tests__/RevealMnemonicInput.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render } from "@testing-library/react";
+
+import { IRevealMnemonicInputProps, RevealMnemonicInput } from "..";
+import { IUseRevealMnemonicData, useRevealMnemonic } from "../useRevealMnemonic";
+
+jest.mock("../useRevealMnemonic", (): unknown => ({
+  useRevealMnemonic: jest.fn(),
+}));
+
+describe("ui/components/RevealMnemonicInput", () => {
+  const defaultHookData: IUseRevealMnemonicData = {
+    isCopied: false,
+    isDownloaded: false,
+    isShowMnemonic: false,
+    onCopy: jest.fn(),
+    onDownload: jest.fn(),
+    onShowMnemonic: jest.fn(),
+  };
+
+  const defaultArgs: IRevealMnemonicInputProps = {
+    mnemonic: "mnemonic",
+  };
+
+  beforeEach(() => {
+    (useRevealMnemonic as jest.Mock).mockReturnValue(defaultHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { findByText } = render(<RevealMnemonicInput {...defaultArgs} />);
+
+    const copyButton = await findByText("Copy to clipboard");
+    const downloadButton = await findByText("Download");
+    const showButton = await findByText("Show");
+
+    expect(copyButton).toBeInTheDocument();
+    expect(downloadButton).toBeInTheDocument();
+    expect(showButton).toBeInTheDocument();
+  });
+
+  test("should show mnemonic properly", async () => {
+    const { findByText } = render(<RevealMnemonicInput {...defaultArgs} />);
+
+    const showButton = await findByText("Show");
+    await act(() => Promise.resolve(showButton.click()));
+
+    expect(defaultHookData.onShowMnemonic).toBeCalledTimes(1);
+  });
+
+  test("should hide mnemonic properly", async () => {
+    (useRevealMnemonic as jest.Mock).mockReturnValue({ ...defaultHookData, isShowMnemonic: true });
+
+    const { findByText } = render(<RevealMnemonicInput {...defaultArgs} />);
+
+    const hideButton = await findByText("Hide");
+    await act(() => Promise.resolve(hideButton.click()));
+
+    expect(defaultHookData.onShowMnemonic).toBeCalledTimes(1);
+  });
+
+  test("should call copy and download properly", async () => {
+    const { findByText } = render(<RevealMnemonicInput {...defaultArgs} />);
+
+    const copyButton = await findByText("Copy to clipboard");
+    const downloadButton = await findByText("Download");
+
+    await act(() => Promise.resolve(copyButton.click()));
+    await act(() => Promise.resolve(downloadButton.click()));
+
+    expect(defaultHookData.onCopy).toBeCalledTimes(1);
+    expect(defaultHookData.onDownload).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/RevealMnemonicInput/__tests__/useRevealMnemonic.test.ts
+++ b/src/ui/components/RevealMnemonicInput/__tests__/useRevealMnemonic.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+
+import { IUseTimeoutData, useTimeout } from "@src/ui/hooks/timeout";
+import { copyToClipboard, downloadFile } from "@src/util/browser";
+
+import { IUseRevealMnemonicArgs, useRevealMnemonic } from "../useRevealMnemonic";
+
+jest.mock("@src/ui/hooks/timeout", (): unknown => ({
+  useTimeout: jest.fn(),
+}));
+
+jest.mock("@src/util/browser", (): unknown => ({
+  copyToClipboard: jest.fn(),
+  downloadFile: jest.fn(),
+}));
+
+describe("ui/components/RevealMnemonicInput/useRevealMnemonic", () => {
+  const defaultTimeoutHookData: IUseTimeoutData = {
+    isActive: false,
+    setActive: jest.fn(),
+  };
+
+  const defaultHookArgs: IUseRevealMnemonicArgs = {
+    mnemonic: "mnemonic",
+  };
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    (useTimeout as jest.Mock).mockReturnValue(defaultTimeoutHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test("should return initial data", () => {
+    const { result } = renderHook(() => useRevealMnemonic(defaultHookArgs));
+
+    expect(result.current.isCopied).toBe(false);
+    expect(result.current.isDownloaded).toBe(false);
+    expect(result.current.isShowMnemonic).toBe(false);
+  });
+
+  test("should copy mnemonic properly", async () => {
+    const { result } = renderHook(() => useRevealMnemonic(defaultHookArgs));
+
+    await act(() => Promise.resolve(result.current.onCopy()));
+
+    expect(defaultTimeoutHookData.setActive).toBeCalledTimes(1);
+    expect(copyToClipboard).toBeCalledTimes(1);
+  });
+
+  test("should download mnemonic properly", async () => {
+    const { result } = renderHook(() => useRevealMnemonic(defaultHookArgs));
+
+    await act(() => Promise.resolve(result.current.onDownload()));
+
+    expect(defaultTimeoutHookData.setActive).toBeCalledTimes(1);
+    expect(downloadFile).toBeCalledTimes(1);
+  });
+
+  test("should toggle mnemonic show properly", async () => {
+    const { result } = renderHook(() => useRevealMnemonic(defaultHookArgs));
+
+    await act(() => Promise.resolve(result.current.onShowMnemonic()));
+    expect(result.current.isShowMnemonic).toBe(true);
+
+    await act(() => Promise.resolve(result.current.onShowMnemonic()));
+    expect(result.current.isShowMnemonic).toBe(false);
+  });
+});

--- a/src/ui/components/RevealMnemonicInput/index.ts
+++ b/src/ui/components/RevealMnemonicInput/index.ts
@@ -1,0 +1,1 @@
+export * from "./RevealMnemonicInput";

--- a/src/ui/components/RevealMnemonicInput/useRevealMnemonic.ts
+++ b/src/ui/components/RevealMnemonicInput/useRevealMnemonic.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+
+import { useTimeout } from "@src/ui/hooks/timeout";
+import { copyToClipboard, downloadFile } from "@src/util/browser";
+
+export interface IUseRevealMnemonicArgs {
+  mnemonic: string;
+}
+
+export interface IUseRevealMnemonicData {
+  isShowMnemonic: boolean;
+  isCopied: boolean;
+  isDownloaded: boolean;
+  onCopy: () => void;
+  onDownload: () => void;
+  onShowMnemonic: () => void;
+}
+
+const OPERATION_TIMEOUT_MS = 1_000;
+
+export const useRevealMnemonic = ({ mnemonic }: IUseRevealMnemonicArgs): IUseRevealMnemonicData => {
+  const [isShowMnemonic, setShowMnemonic] = useState(false);
+
+  const { isActive: isCopied, setActive: setCopied } = useTimeout(OPERATION_TIMEOUT_MS);
+  const { isActive: isDownloaded, setActive: setDownloaded } = useTimeout(OPERATION_TIMEOUT_MS);
+
+  const onShowMnemonic = useCallback(() => {
+    setShowMnemonic((show) => !show);
+  }, [setShowMnemonic]);
+
+  const onCopy = useCallback(() => {
+    setCopied(true);
+    copyToClipboard(mnemonic);
+  }, [mnemonic, setCopied]);
+
+  const onDownload = useCallback(() => {
+    setDownloaded(true);
+    downloadFile(`data:text/txt;charset=utf-8,${encodeURIComponent(mnemonic)}`, "ck-mnemonic.txt");
+  }, [mnemonic, setDownloaded]);
+
+  return {
+    isShowMnemonic,
+    isCopied,
+    isDownloaded,
+    onShowMnemonic,
+    onCopy,
+    onDownload,
+  };
+};

--- a/src/ui/hooks/timeout/__tests__/useTimeout.test.ts
+++ b/src/ui/hooks/timeout/__tests__/useTimeout.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { useTimeout } from "..";
+
+describe("ui/hooks/timeout", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test("should return intial data", async () => {
+    const { result } = renderHook(() => useTimeout());
+
+    await waitFor(() => result.current.isActive === false);
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  test("should wait for timeout properly", async () => {
+    const { result } = renderHook(() => useTimeout(0));
+
+    expect(result.current.isActive).toBe(false);
+
+    await act(() => Promise.resolve(result.current.setActive(true)));
+    expect(result.current.isActive).toBe(true);
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+
+      await waitFor(() => result.current.isActive === false);
+    });
+  });
+});

--- a/src/ui/hooks/timeout/index.ts
+++ b/src/ui/hooks/timeout/index.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+export interface IUseTimeoutData {
+  isActive: boolean;
+  setActive: (isActive: boolean) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+
+export const useTimeout = (timeout = DEFAULT_TIMEOUT_MS): IUseTimeoutData => {
+  const [isActive, setActive] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => setActive(false), timeout);
+
+    return () => clearTimeout(timeoutId);
+  }, [isActive, setActive]);
+
+  return {
+    isActive,
+    setActive,
+  };
+};

--- a/src/ui/pages/Mnemonic/Mnemonic.tsx
+++ b/src/ui/pages/Mnemonic/Mnemonic.tsx
@@ -1,0 +1,46 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+
+import logoSVG from "@src/static/icons/logo.svg";
+import { Icon } from "@src/ui/components/Icon";
+import { RevealMnemonicInput } from "@src/ui/components/RevealMnemonicInput";
+
+import { useMnemonic } from "./useMnemonic";
+
+const Mnemonic = (): JSX.Element => {
+  const { mnemonic, onGoHome } = useMnemonic();
+
+  return (
+    <Box
+      data-testid="mnemonic-page"
+      sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1, p: 3 }}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1 }}>
+        <Icon size={8} url={logoSVG} />
+
+        <Typography sx={{ mt: 2 }} variant="h4">
+          One step left!
+        </Typography>
+
+        <Typography sx={{ mt: 1, mb: 2 }} variant="body1">
+          Please keep your mnemonic phrase safely
+        </Typography>
+
+        <RevealMnemonicInput mnemonic={mnemonic} />
+      </Box>
+
+      <Button
+        data-testid="submit-button"
+        sx={{ textTransform: "none" }}
+        type="button"
+        variant="contained"
+        onClick={onGoHome}
+      >
+        Get started!
+      </Button>
+    </Box>
+  );
+};
+
+export default Mnemonic;

--- a/src/ui/pages/Mnemonic/__tests__/Mnemonic.test.tsx
+++ b/src/ui/pages/Mnemonic/__tests__/Mnemonic.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, waitFor } from "@testing-library/react";
+
+import Mnemonic from "..";
+import { IUseMnemonicData, useMnemonic } from "../useMnemonic";
+
+jest.mock("../useMnemonic", (): unknown => ({
+  useMnemonic: jest.fn(),
+}));
+
+describe("ui/pages/Mnemonic", () => {
+  const defaultHookData: IUseMnemonicData = {
+    mnemonic: "mnemonic",
+    onGoHome: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useMnemonic as jest.Mock).mockReturnValue(defaultHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { container, findByTestId } = render(<Mnemonic />);
+    await waitFor(() => container.firstChild !== null);
+
+    const page = await findByTestId("mnemonic-page");
+
+    expect(page).toBeInTheDocument();
+  });
+
+  test("should go home properly", async () => {
+    const { container, findByTestId } = render(<Mnemonic />);
+    await waitFor(() => container.firstChild !== null);
+
+    const button = await findByTestId("submit-button");
+    await act(() => Promise.resolve(button.click()));
+
+    expect(defaultHookData.onGoHome).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/pages/Mnemonic/__tests__/useMnemonic.test.ts
+++ b/src/ui/pages/Mnemonic/__tests__/useMnemonic.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+import { IUseTimeoutData, useTimeout } from "@src/ui/hooks/timeout";
+
+import { useMnemonic } from "../useMnemonic";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/timeout", (): unknown => ({
+  useTimeout: jest.fn(),
+}));
+
+jest.mock("@src/util/browser", (): unknown => ({
+  copyToClipboard: jest.fn(),
+  downloadFile: jest.fn(),
+}));
+
+describe("ui/pages/Mnemonic/useMnemonic", () => {
+  const mockNavigate = jest.fn();
+  const defaultTimeoutHookData: IUseTimeoutData = {
+    isActive: false,
+    setActive: jest.fn(),
+  };
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    (useTimeout as jest.Mock).mockReturnValue(defaultTimeoutHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test("should return initial data", () => {
+    const { result } = renderHook(() => useMnemonic());
+
+    expect(result.current.mnemonic).toBeDefined();
+  });
+
+  test("should go home properly", async () => {
+    const { result } = renderHook(() => useMnemonic());
+
+    await act(() => Promise.resolve(result.current.onGoHome()));
+
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+  });
+});

--- a/src/ui/pages/Mnemonic/index.ts
+++ b/src/ui/pages/Mnemonic/index.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export default lazy(() => import("./Mnemonic"));

--- a/src/ui/pages/Mnemonic/useMnemonic.ts
+++ b/src/ui/pages/Mnemonic/useMnemonic.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+
+export interface IUseMnemonicData {
+  mnemonic: string;
+  onGoHome: () => void;
+}
+
+// TODO: update app status, generate mnemonic, save root key
+export const useMnemonic = (): IUseMnemonicData => {
+  const mnemonic = "test test test test test test test test test test test junk";
+
+  const navigate = useNavigate();
+
+  const onGoHome = useCallback(() => {
+    navigate(Paths.HOME);
+  }, [navigate]);
+
+  return {
+    mnemonic,
+    onGoHome,
+  };
+};

--- a/src/ui/pages/Popup/Popup.tsx
+++ b/src/ui/pages/Popup/Popup.tsx
@@ -6,6 +6,7 @@ import CreateIdentity from "@src/ui/pages/CreateIdentity";
 import DownloadBackup from "@src/ui/pages/DownloadBackup";
 import Home from "@src/ui/pages/Home";
 import Login from "@src/ui/pages/Login";
+import Mnemonic from "@src/ui/pages/Mnemonic";
 import Onboarding from "@src/ui/pages/Onboarding";
 import Settings from "@src/ui/pages/Settings";
 
@@ -21,6 +22,7 @@ const routeConfig: RouteObject[] = [
   { path: Paths.REQUESTS, element: <ConfirmRequestModal /> },
   { path: Paths.SETTINGS, element: <Settings /> },
   { path: Paths.DOWNLOAD_BACKUP, element: <DownloadBackup /> },
+  { path: Paths.MNEMONIC, element: <Mnemonic /> },
   {
     path: "*",
     element: <Navigate to={Paths.HOME} />,

--- a/src/util/__tests__/browser.test.ts
+++ b/src/util/__tests__/browser.test.ts
@@ -5,10 +5,17 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { browser } from "webextension-polyfill-ts";
 
-import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl, downloadFile } from "../browser";
+import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl, downloadFile, copyToClipboard } from "../browser";
 
 describe("util/browser", () => {
   const defaultTabs = [{ url: "http://localhost:3000" }];
+  const oldClipboard = navigator.clipboard;
+
+  beforeAll(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn() },
+    });
+  });
 
   beforeEach(() => {
     (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
@@ -16,6 +23,12 @@ describe("util/browser", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Object.assign(navigator, {
+      clipboard: oldClipboard,
+    });
   });
 
   test("should get last active tab url properly", async () => {
@@ -56,5 +69,14 @@ describe("util/browser", () => {
 
     expect(spyCreateElement).toBeCalledTimes(1);
     expect(element.click).toBeCalledTimes(1);
+  });
+
+  test("should copy to clipboard properly", async () => {
+    const spyCopy = jest.spyOn(navigator.clipboard, "writeText");
+
+    await copyToClipboard("content");
+
+    expect(spyCopy).toBeCalledTimes(1);
+    expect(spyCopy).toBeCalledWith("content");
   });
 });

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -23,3 +23,7 @@ export const downloadFile = (content: string, filename: string): Promise<void> =
 
   return Promise.resolve();
 };
+
+export const copyToClipboard = async (content: string): Promise<void> => {
+  await navigator.clipboard.writeText(content);
+};


### PR DESCRIPTION
## Explanation

This PR adds ui page without integration as a part of BIP39 integration.

Details are below:
- [x] Add ui page for ui mnemonic
- [x] Add copy to clipboard util
- [x] Add ui component for revealing mnemonic phrase

## More Information

Closes #338 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/29e40d70-8562-4614-a33b-43ce5c9a659e)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/7c504694-40d7-46e5-8965-30d104aa0fb2)


## Manual Testing Steps

There is no integration right now so only ui can be tested.
1. Open extension in a separate window
2. Go to `/mnemonic` page
3. Check copy and download buttons
4. `Get started` button will redirect to home

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
