### PR TITLE
feat: support cryptkeeper identity creation

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { ToastContainer } from "react-toastify";
@@ -78,14 +77,17 @@ function App() {
       <hr />
       <div>
         <h2>Get Identity Commitment</h2>
-        <button onClick={() => getIdentityCommitment()}>Get</button> <br />
+        <button onClick={getIdentityCommitment}>Get</button> <br />
         <br />
       </div>
 
       <hr />
       <div>
         <h2>Create a new Identity</h2>
-        <button onClick={createIdentity}>Create</button> <br />
+        <button data-testid="create-new-identity" onClick={createIdentity}>
+          Create
+        </button>{" "}
+        <br />
         <br />
       </div>
 

--- a/e2e/pages/cryptKeeper/Identities.ts
+++ b/e2e/pages/cryptKeeper/Identities.ts
@@ -1,10 +1,13 @@
 import BasePage from "../BasePage";
 
 export interface ICreateIdentityArgs {
+  walletType: WalletType;
   identityType?: IdentityType;
   provider?: ProviderType;
   nonce?: number;
 }
+
+type WalletType = "eth" | "ck";
 
 type IdentityType = "InterRep" | "Random";
 
@@ -26,7 +29,7 @@ export default class Identities extends BasePage {
     await this.page.getByText("Identities", { exact: true }).click();
   }
 
-  async createIdentity({ identityType, provider, nonce }: ICreateIdentityArgs | undefined = {}): Promise<void> {
+  async createIdentity({ identityType, provider, nonce, walletType }: ICreateIdentityArgs): Promise<void> {
     await this.page.getByTestId("create-new-identity").click({ delay: 1000 });
 
     const cryptKeeper = await this.page.context().waitForEvent("page");
@@ -45,12 +48,14 @@ export default class Identities extends BasePage {
       await cryptKeeper.getByLabel("Nonce").fill(nonce.toString());
     }
 
-    await cryptKeeper.getByRole("button", { name: "Create" }).click();
+    await cryptKeeper.getByRole("button", { name: walletType === "eth" ? "Metamask" : "Cryptkeeper" }).click();
 
-    // TODO: synpress doesn't support new data-testid for metamask
-    const metamask = await this.page.context().waitForEvent("page");
+    if (identityType !== "Random" && walletType === "eth") {
+      // TODO: synpress doesn't support new data-testid for metamask
+      const metamask = await this.page.context().waitForEvent("page");
 
-    await metamask.getByTestId("page-container-footer-next").click();
+      await metamask.getByTestId("page-container-footer-next").click();
+    }
   }
 
   async renameIdentity(index: number, name: string): Promise<void> {

--- a/e2e/tests/backup.test.ts
+++ b/e2e/tests/backup.test.ts
@@ -17,7 +17,7 @@ test.describe("backup", () => {
     const extension = new CryptKeeper(page);
     await extension.focus();
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
     await extension.settingsPage.openPage();

--- a/e2e/tests/identity.test.ts
+++ b/e2e/tests/identity.test.ts
@@ -17,19 +17,19 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(page);
     await extension.focus();
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
-    await extension.identitiesTab.createIdentity({ provider: "Github", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ provider: "Github", nonce: 0, walletType: "eth" });
     await expect(extension.getByText("Account # 1")).toBeVisible();
 
-    await extension.identitiesTab.createIdentity({ provider: "Reddit", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ provider: "Reddit", nonce: 0, walletType: "ck" });
     await expect(extension.getByText("Account # 2")).toBeVisible();
 
-    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0, walletType: "eth" });
     await expect(extension.getByText("Account # 3")).toBeVisible();
 
-    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0 });
+    await extension.identitiesTab.createIdentity({ identityType: "Random", nonce: 0, walletType: "ck" });
     await expect(extension.getByText("Account # 4")).toBeVisible();
 
     await expect(extension.getByText(/Account/)).toHaveCount(5);
@@ -50,7 +50,7 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(page);
     await extension.focus();
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
     await extension.identitiesTab.renameIdentity(0, "My twitter identity");
@@ -62,7 +62,7 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(page);
     await extension.focus();
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText(/Account/)).toHaveCount(1);
 
     await extension.activityTab.openTab();
@@ -76,7 +76,7 @@ test.describe("identity", () => {
     await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
 
     await extension.identitiesTab.openTab();
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "ck" });
     await expect(extension.getByText(/Account/)).toHaveCount(1);
 
     await extension.settingsPage.openPage();
@@ -93,7 +93,7 @@ test.describe("identity", () => {
     const extension = new CryptKeeper(page);
     await extension.focus();
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText(/Account/)).toHaveCount(1);
 
     await extension.activityTab.openTab();
@@ -120,7 +120,7 @@ test.describe("identity", () => {
     await extension.settingsPage.toggleHistoryTracking();
 
     await extension.goHome();
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "ck" });
     await expect(extension.getByText(/Account/)).toHaveCount(1);
 
     await extension.activityTab.openTab();
@@ -142,5 +142,17 @@ test.describe("identity", () => {
     await extension.goHome();
     await extension.activityTab.openTab();
     await expect(extension.activityTab.getByText("No records found")).toBeVisible();
+  });
+
+  test("should create identity from demo", async ({ page, cryptKeeperExtensionId }) => {
+    await page.goto("/");
+    const extension = new CryptKeeper(page);
+    await extension.focus();
+
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
+    await extension.identitiesTab.createIdentity({ walletType: "ck" });
+
+    await page.goto(`chrome-extension://${cryptKeeperExtensionId}/popup.html`);
+    await expect(extension.getByText(/Account/)).toHaveCount(2);
   });
 });

--- a/e2e/tests/proofGeneration.test.ts
+++ b/e2e/tests/proofGeneration.test.ts
@@ -14,7 +14,7 @@ test.describe("proof generation", () => {
 
     const extension = new CryptKeeper(page);
 
-    await extension.identitiesTab.createIdentity();
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
     await expect(extension.getByText("Account # 0")).toBeVisible();
 
     await page.goto("/");

--- a/jest.config.json
+++ b/jest.config.json
@@ -20,16 +20,18 @@
     "/src/ui/popup.tsx",
     "/src/ui/theme.ts",
     "/src/background/backgroundPage.ts",
-    "/src/background/appInit.ts"
+    "/src/background/appInit.ts",
+    "/src/background/contentScript.ts",
+    "/src/background/injectedScript.ts"
   ],
   "coverageReporters": ["clover", "lcov", "json", "json-summary", "text", "text-summary"],
   "collectCoverageFrom": ["src/**/*.{ts,tsx}"],
   "coverageThreshold": {
     "global": {
-      "statements": 80,
-      "branches": 80,
-      "functions": 80,
-      "lines": 80
+      "statements": 90,
+      "branches": 90,
+      "functions": 90,
+      "lines": 90
     }
   }
 }

--- a/src/background/appInit.ts
+++ b/src/background/appInit.ts
@@ -65,8 +65,7 @@ const registerInjectedScript = async () => {
      * 2. await chrome.scripting.getRegisteredContentScripts() to check for an existing
      *    inpage script before registering - The provider is not loaded on time.
      */
-    // eslint-disable-next-line
-    log.warn(`Dropped attempt to register inpage content script. ${err}`);
+    log.warn("Dropped attempt to register inpage content script.", err);
   }
 };
 

--- a/src/background/controllers/requestManager.ts
+++ b/src/background/controllers/requestManager.ts
@@ -68,8 +68,8 @@ export default class RequestManager extends EventEmitter2 {
   };
 
   private addToQueue = async (type: PendingRequestType, windowId?: number, payload?: unknown): Promise<string> => {
-    // eslint-disable-next-line no-plusplus
-    const id = `${this.nonce++}`;
+    const id = this.nonce.toString();
+    this.nonce += 1;
     this.pendingRequests.push({ id, windowId, type, payload });
     await pushMessage(setPendingRequests(this.pendingRequests));
 

--- a/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
+++ b/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
@@ -379,8 +379,7 @@ describe("background/services/zkIdentity", () => {
         options: identityOptions,
       });
 
-      expect(result.status).toBe(true);
-      expect(result.identityCommitment).toBeDefined();
+      expect(result).toBeDefined();
     });
 
     test("should create a new identity with cryptkeeper properly", async () => {
@@ -398,8 +397,7 @@ describe("background/services/zkIdentity", () => {
         options: identityOptions,
       });
 
-      expect(result.status).toBe(true);
-      expect(result.identityCommitment).toBeDefined();
+      expect(result).toBeDefined();
     });
 
     test("should not create a new identity if there is no signature", async () => {
@@ -438,7 +436,7 @@ describe("background/services/zkIdentity", () => {
         options: identityOptions,
       });
 
-      expect(successResult.status).toBe(true);
+      expect(successResult).toBeDefined();
 
       (createNewIdentity as jest.Mock).mockReturnValue({
         genIdentityCommitment: () => mockDefaultIdentityCommitment,
@@ -451,7 +449,7 @@ describe("background/services/zkIdentity", () => {
         options: identityOptions,
       });
 
-      expect(failedResult.status).toBe(false);
+      expect(failedResult).toBeUndefined();
 
       const emptyResult = await zkIdentityService.createIdentity({
         strategy: identityStrategy,
@@ -460,7 +458,7 @@ describe("background/services/zkIdentity", () => {
         options: { message: "message" },
       });
 
-      expect(emptyResult.status).toBe(false);
+      expect(emptyResult).toBeUndefined();
     });
   });
 

--- a/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
+++ b/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
@@ -403,7 +403,7 @@ describe("background/services/zkIdentity", () => {
     });
 
     test("should not create a new identity if there is no signature", async () => {
-      const identityStrategy: IdentityStrategy = "random";
+      const identityStrategy: IdentityStrategy = "interrep";
       const identityOptions: CreateIdentityOptions = {
         nonce: 0,
         account: ZERO_ADDRESS,

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -7,6 +7,7 @@ import HistoryService from "@src/background/services/history";
 import LockerService from "@src/background/services/lock";
 import NotificationService from "@src/background/services/notification";
 import SimpleStorage from "@src/background/services/storage";
+import WalletService from "@src/background/services/wallet";
 import { ZkIdentitySemaphore } from "@src/background/services/zkIdentity/protocols/ZkIdentitySemaphore";
 import { getEnabledFeatures } from "@src/config/features";
 import { Paths } from "@src/constants";
@@ -23,8 +24,6 @@ import { ellipsify } from "@src/util/account";
 import pushMessage from "@src/util/pushMessage";
 
 import type { IBackupable } from "@src/background/services/backup";
-
-import WalletService from "../wallet";
 
 import { createNewIdentity } from "./factory";
 
@@ -258,7 +257,7 @@ export default class ZkIdentityService implements IBackupable {
     messageSignature,
     options,
   }: NewIdentityRequest): Promise<{ status: boolean; identityCommitment?: bigint }> => {
-    if (walletType === EWallet.ETH_WALLET && !messageSignature) {
+    if (walletType === EWallet.ETH_WALLET && !messageSignature && strategy !== "random") {
       throw new Error("No signature provided");
     }
 

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -256,7 +256,7 @@ export default class ZkIdentityService implements IBackupable {
     walletType,
     messageSignature,
     options,
-  }: NewIdentityRequest): Promise<{ status: boolean; identityCommitment?: bigint }> => {
+  }: NewIdentityRequest): Promise<string | undefined> => {
     if (walletType === EWallet.ETH_WALLET && !messageSignature && strategy !== "random") {
       throw new Error("No signature provided");
     }
@@ -279,10 +279,7 @@ export default class ZkIdentityService implements IBackupable {
     const status = await this.insertIdentity(identity);
     await this.browserController.closePopup();
 
-    return {
-      status,
-      identityCommitment: identity.genIdentityCommitment(),
-    };
+    return status ? identity.genIdentityCommitment().toString() : undefined;
   };
 
   private insertIdentity = async (newIdentity: ZkIdentitySemaphore): Promise<boolean> => {

--- a/src/config/mock/wallet.ts
+++ b/src/config/mock/wallet.ts
@@ -22,8 +22,8 @@ export const defaultWalletHookData: IUseWalletData = {
     getSigner: jest.fn(),
     getBalance: jest.fn(),
   } as unknown as BrowserProvider,
-  onConnect: jest.fn(),
-  onConnectEagerly: jest.fn(),
+  onConnect: jest.fn(() => Promise.resolve()),
+  onConnectEagerly: jest.fn(() => Promise.resolve()),
   onDisconnect: jest.fn(),
   onLock: jest.fn(),
 };

--- a/src/connectors/mock.ts
+++ b/src/connectors/mock.ts
@@ -44,7 +44,7 @@ export const createMockConnectorHooks = ({
   useENSNames: (): string[] => ensNames,
   useIsActivating: (): boolean => isActivating,
   useIsActive: (): boolean => isActive,
-  // eslint-disable-next-line
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   useProvider: (): unknown | undefined => provider,
 });

--- a/src/providers/sdk/Base.ts
+++ b/src/providers/sdk/Base.ts
@@ -69,8 +69,9 @@ export class CryptKeeperInjectedProvider extends EventEmitter {
   // TODO: (#75) enhance by moving towards long-lived conenctions #75
   private async post(message: InjectedProviderRequest): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      // eslint-disable-next-line no-plusplus
-      const messageNonce = this.nonce++;
+      const messageNonce = this.nonce;
+      this.nonce += 1;
+
       window.postMessage(
         {
           target: "injected-contentscript",
@@ -135,8 +136,8 @@ export class CryptKeeperInjectedProvider extends EventEmitter {
       const { resolve, reject } = promises[data.nonce];
 
       if (err) {
-        // eslint-disable-next-line consistent-return
-        return reject(new Error(err));
+        reject(new Error(err));
+        return;
       }
 
       resolve(res);

--- a/src/ui/components/Icon/index.tsx
+++ b/src/ui/components/Icon/index.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import classNames from "classnames";
 import { forwardRef, MouseEventHandler, Ref } from "react";
 
@@ -24,13 +25,14 @@ const IconUI = (
   }: IconProps,
   ref: Ref<HTMLDivElement>,
 ): JSX.Element => (
-  <div
+  <Box
     ref={ref}
     {...rest}
     className={classNames("icon", className, {
       "icon--disabled": disabled,
       "icon--clickable": onClick,
     })}
+    role="img"
     style={{
       backgroundImage: url ? `url(${url})` : undefined,
       width: !fontAwesome ? `${size}rem` : undefined,
@@ -40,7 +42,7 @@ const IconUI = (
     onClick={onClick}
   >
     {fontAwesome && <i className={`fas ${fontAwesome}`} />}
-  </div>
+  </Box>
 );
 
 export const Icon = forwardRef(IconUI);

--- a/src/ui/components/Menuable/MenuItem.tsx
+++ b/src/ui/components/Menuable/MenuItem.tsx
@@ -1,0 +1,61 @@
+import Box from "@mui/material/Box";
+import classNames from "classnames";
+import { useCallback, type MouseEvent as ReactMouseEvent } from "react";
+
+import { ItemProps } from "./useMenuable";
+
+export interface IMenuItemProps {
+  item: ItemProps;
+  onSetDangerItem: (event: ReactMouseEvent, item: ItemProps) => void;
+  onItemClick: (event: ReactMouseEvent, item: ItemProps) => void;
+}
+
+export const MenuItem = ({ item, onSetDangerItem, onItemClick }: IMenuItemProps): JSX.Element => {
+  const handleDangerItemClick = useCallback(
+    (event: ReactMouseEvent) => {
+      onSetDangerItem(event, item);
+    },
+    [item, onSetDangerItem],
+  );
+
+  const handleItemClick = useCallback(
+    (event: ReactMouseEvent) => {
+      onItemClick(event, item);
+    },
+    [item, onItemClick],
+  );
+
+  if (item.isDangerItem) {
+    return (
+      <Box
+        className={classNames(
+          "text-sm whitespace-nowrap",
+          "flex flex-row flex-nowrap items-center",
+          "menuable__menu__item hover:bg-gray-900 ",
+          "cursor-pointer",
+        )}
+        onClick={handleDangerItemClick}
+      >
+        <div className={classNames("flex-grow", "text-gray-500 hover:text-gray-300 hover:font-semibold")}>
+          {item.label}
+        </div>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      className={classNames(
+        "text-sm whitespace-nowrap",
+        "flex flex-row flex-nowrap items-center",
+        "menuable__menu__item hover:bg-gray-900 ",
+        "cursor-pointer",
+      )}
+      onClick={handleItemClick}
+    >
+      <div className={classNames("flex-grow", "text-gray-500 hover:text-gray-300 hover:font-semibold")}>
+        {item.label}
+      </div>
+    </Box>
+  );
+};

--- a/src/ui/components/Menuable/Menuable.tsx
+++ b/src/ui/components/Menuable/Menuable.tsx
@@ -1,181 +1,55 @@
+import Box from "@mui/material/Box";
 import classNames from "classnames";
 import { ReactNode } from "react";
 
 import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
 
-import { Icon } from "../Icon";
-
 import "./menuable.scss";
+import { MenuItem } from "./MenuItem";
 import { useMenuable, ItemProps } from "./useMenuable";
 
 export interface MenuableProps {
   items: ItemProps[];
   children: ReactNode;
-  className?: string;
+  className: string;
   menuClassName?: string;
-  opened?: boolean;
-  onOpen?: () => void;
-  onClose?: () => void;
 }
 
-export const Menuable = ({
-  items,
-  children,
-  opened = false,
-  className = "",
-  menuClassName = "",
-  onOpen = undefined,
-  onClose = undefined,
-}: MenuableProps): JSX.Element => {
+export const Menuable = ({ items, children, className, menuClassName = "" }: MenuableProps): JSX.Element => {
   const {
     menuRef,
     isShowing,
-    path,
     menuItems,
     isOpenDangerModal,
+    onShow,
     onItemClick,
-    handleClose,
-    handleGoBack,
-    handleOpen,
-    handleDangerAction,
-    handleDangerModalClose,
-    handleDangerModalOpen,
-    handleSetDangerItem,
+    onDangerAction,
+    onDangerModalShow,
+    onSetDangerItem,
   } = useMenuable({
-    opened,
     items,
-    onOpen,
-    onClose,
   });
 
   return (
-    <div
+    <Box
       ref={menuRef}
       className={classNames("menuable", { "menuable--active": isShowing }, className)}
+      component="button"
       data-testid="menu"
-      onClick={(e) => {
-        e.stopPropagation();
-
-        if (isShowing) {
-          handleClose();
-        } else {
-          handleOpen();
-        }
-      }}
+      type="button"
+      onClick={onShow}
     >
       {children}
 
-      <ConfirmDangerModal accept={handleDangerAction} isOpenModal={isOpenDangerModal} reject={handleDangerModalClose} />
+      <ConfirmDangerModal accept={onDangerAction} isOpenModal={isOpenDangerModal} reject={onDangerModalShow} />
 
       {isShowing && (
         <div className={classNames("rounded-xl border border-gray-700 menuable__menu", menuClassName)}>
-          {!!path.length && (
-            <div
-              className={classNames(
-                "text-sm whitespace-nowrap cursor-pointer",
-                "flex flex-row flex-nowrap items-center",
-                "text-gray-500 hover:text-gray-300 hover:bg-gray-900 menuable__menu__item",
-              )}
-              onClick={handleGoBack}
-            >
-              <Icon fontAwesome="fas fa-caret-left" />
-
-              <span className="ml-2">Go back</span>
-            </div>
-          )}
-
-          {menuItems.map((item, i) => (
-            <div key={i}>
-              {item.isDangerItem ? (
-                <div
-                  key={item.label}
-                  className={classNames(
-                    "text-sm whitespace-nowrap",
-                    "flex flex-row flex-nowrap items-center",
-                    "menuable__menu__item hover:bg-gray-900 ",
-                    { "cursor-pointer": !item.disabled },
-                    item.className,
-                  )}
-                  onClick={(e) => {
-                    handleSetDangerItem(item, i);
-                    handleDangerModalOpen(e);
-                  }}
-                >
-                  {item.component ? (
-                    item.component
-                  ) : (
-                    <>
-                      <div
-                        className={classNames("flex-grow", {
-                          "text-gray-500 hover:text-gray-300 hover:font-semibold": !item.disabled,
-                          "text-gray-700": item.disabled,
-                        })}
-                      >
-                        {item.label}
-                      </div>
-
-                      {(item.iconUrl || item.iconFA) && (
-                        <Icon
-                          className={classNames(
-                            "ml-4",
-                            {
-                              "opacity-50": item.disabled,
-                            },
-                            item.iconClassName,
-                          )}
-                          fontAwesome={item.iconFA}
-                          url={item.iconUrl}
-                        />
-                      )}
-                    </>
-                  )}
-                </div>
-              ) : (
-                <div
-                  key={item.label}
-                  className={classNames(
-                    "text-sm whitespace-nowrap",
-                    "flex flex-row flex-nowrap items-center",
-                    "menuable__menu__item hover:bg-gray-900 ",
-                    { "cursor-pointer": !item.disabled },
-                    item.className,
-                  )}
-                  onClick={(e) => onItemClick(e, item, i)}
-                >
-                  {item.component ? (
-                    item.component
-                  ) : (
-                    <>
-                      <div
-                        className={classNames("flex-grow", {
-                          "text-gray-500 hover:text-gray-300 hover:font-semibold": !item.disabled,
-                          "text-gray-700": item.disabled,
-                        })}
-                      >
-                        {item.label}
-                      </div>
-
-                      {(item.iconUrl || item.iconFA) && (
-                        <Icon
-                          className={classNames(
-                            "ml-4",
-                            {
-                              "opacity-50": item.disabled,
-                            },
-                            item.iconClassName,
-                          )}
-                          fontAwesome={item.iconFA}
-                          url={item.iconUrl}
-                        />
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+          {menuItems.map((item) => (
+            <MenuItem key={item.label} item={item} onItemClick={onItemClick} onSetDangerItem={onSetDangerItem} />
           ))}
         </div>
       )}
-    </div>
+    </Box>
   );
 };

--- a/src/ui/components/Menuable/menuable.scss
+++ b/src/ui/components/Menuable/menuable.scss
@@ -2,6 +2,7 @@
 
 .menuable {
   position: relative;
+  background: none;
 
   &__menu {
     position: absolute;
@@ -17,6 +18,8 @@
       @extend %row-nowrap;
       align-content: center;
       padding: 0.5rem 1rem;
+      text-align: left;
+      background: none;
     }
   }
 }

--- a/src/ui/components/Modal/index.tsx
+++ b/src/ui/components/Modal/index.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import { MouseEventHandler, ReactNode, useCallback } from "react";
 import ReactDOM from "react-dom";
 
@@ -17,11 +18,11 @@ export const Modal = ({ className, onClose, children, ...rest }: ModalProps): JS
   const onClick: MouseEventHandler = useCallback((e) => e.stopPropagation(), []);
 
   return ReactDOM.createPortal(
-    <div {...rest} className="modal__overlay" onClick={onClose}>
-      <div className={`modal__wrapper ${className as string}`} onClick={onClick}>
+    <Box {...rest} className="modal__overlay" role="none" onClick={onClose}>
+      <Box className={`modal__wrapper ${className as string}`} role="dialog" onClick={onClick}>
         {children}
-      </div>
-    </div>,
+      </Box>
+    </Box>,
     modalRoot as HTMLDivElement,
   );
 };

--- a/src/ui/ducks/identities.ts
+++ b/src/ui/ducks/identities.ts
@@ -67,7 +67,7 @@ export const createIdentityRequest = () => async (): Promise<void> => {
 
 export const createIdentity =
   ({ walletType, strategy, messageSignature, options }: ICreateIdentityUiArgs) =>
-  async (): Promise<boolean> =>
+  async (): Promise<string | undefined> =>
     postMessage({
       method: RPCAction.CREATE_IDENTITY,
       payload: {

--- a/src/ui/pages/CreateIdentity/CreateIdentity.tsx
+++ b/src/ui/pages/CreateIdentity/CreateIdentity.tsx
@@ -1,10 +1,14 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import { Controller } from "react-hook-form";
 
 import { getEnabledFeatures } from "@src/config/features";
 import { IDENTITY_TYPES, WEB2_PROVIDER_OPTIONS } from "@src/constants";
-import { Button } from "@src/ui/components/Button";
 import { Dropdown } from "@src/ui/components/Dropdown";
 import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
+import { Icon } from "@src/ui/components/Icon";
 import { Input } from "@src/ui/components/Input";
 
 import "./createIdentityStyles.scss";
@@ -12,11 +16,20 @@ import { useCreateIdentity } from "./useCreateIdentity";
 
 const CreateIdentity = (): JSX.Element => {
   const features = getEnabledFeatures();
-  const { isLoading, isProviderAvailable, errors, control, closeModal, onSubmit } = useCreateIdentity();
+  const {
+    isLoading,
+    isProviderAvailable,
+    isMetamaskConnected,
+    errors,
+    control,
+    closeModal,
+    onCreateWithCryptkeeper,
+    onCreateWithEthWallet,
+  } = useCreateIdentity();
 
   return (
     <FullModal data-testid="create-identity-page" onClose={closeModal}>
-      <form className="create-identity-form" onSubmit={onSubmit}>
+      <form className="create-identity-form">
         <FullModalHeader onClose={closeModal}>Create Identity</FullModalHeader>
 
         <FullModalContent>
@@ -72,10 +85,41 @@ const CreateIdentity = (): JSX.Element => {
 
         {errors.root && <div className="text-xs text-red-500 text-center pb-1">{errors.root}</div>}
 
+        <Box sx={{ p: "1rem", display: "flex", alignItems: "center" }}>
+          <Typography sx={{ mr: 1 }}>Choose wallet to create identity</Typography>
+
+          <Tooltip
+            followCursor
+            title="Identity creation can be done with your Cryptkeeper keys or with connected Ethereum wallet."
+          >
+            <Icon fontAwesome="fa-info" />
+          </Tooltip>
+        </Box>
+
         <FullModalFooter>
-          <Button loading={isLoading} type="submit">
-            Create
-          </Button>
+          <Box sx={{ alignItems: "center", display: "flex", justifyContent: "space-between", width: "100%" }}>
+            <Button
+              disabled={isLoading || !isMetamaskConnected}
+              name="metamask"
+              sx={{ textTransform: "none" }}
+              type="submit"
+              variant="outlined"
+              onClick={onCreateWithEthWallet}
+            >
+              Metamask
+            </Button>
+
+            <Button
+              disabled={isLoading}
+              name="cryptkeeper"
+              sx={{ textTransform: "none" }}
+              type="submit"
+              variant="contained"
+              onClick={onCreateWithCryptkeeper}
+            >
+              Cryptkeeper
+            </Button>
+          </Box>
         </FullModalFooter>
       </form>
     </FullModal>

--- a/src/ui/pages/CreateIdentity/CreateIdentity.tsx
+++ b/src/ui/pages/CreateIdentity/CreateIdentity.tsx
@@ -19,13 +19,17 @@ const CreateIdentity = (): JSX.Element => {
   const {
     isLoading,
     isProviderAvailable,
-    isMetamaskConnected,
+    isWalletInstalled,
+    isWalletConnected,
     errors,
     control,
     closeModal,
+    onConnectWallet,
     onCreateWithCryptkeeper,
     onCreateWithEthWallet,
   } = useCreateIdentity();
+
+  const ethWalletTitle = isWalletConnected ? "Metamask" : "Connect to Metamask";
 
   return (
     <FullModal data-testid="create-identity-page" onClose={closeModal}>
@@ -99,14 +103,14 @@ const CreateIdentity = (): JSX.Element => {
         <FullModalFooter>
           <Box sx={{ alignItems: "center", display: "flex", justifyContent: "space-between", width: "100%" }}>
             <Button
-              disabled={isLoading || !isMetamaskConnected}
+              disabled={isLoading || !isWalletInstalled}
               name="metamask"
               sx={{ textTransform: "none" }}
               type="submit"
               variant="outlined"
-              onClick={onCreateWithEthWallet}
+              onClick={isWalletConnected ? onCreateWithEthWallet : onConnectWallet}
             >
-              Metamask
+              {isWalletInstalled ? ethWalletTitle : "Install Metamask"}
             </Button>
 
             <Button

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -83,10 +83,12 @@ describe("ui/pages/CreateIdentity", () => {
     const select = await screen.findByLabelText("Identity type");
     await selectEvent.select(select, IDENTITY_TYPES[1].label);
 
-    const button = await screen.findByText("Create");
+    const metamaskButton = await screen.findByText("Metamask");
+    const cryptkeeperButton = await screen.findByText("Cryptkeeper");
     const identityType = await screen.findByText("Random");
 
-    expect(button).toBeInTheDocument();
+    expect(metamaskButton).toBeInTheDocument();
+    expect(cryptkeeperButton).toBeInTheDocument();
     expect(identityType).toBeInTheDocument();
   });
 
@@ -98,17 +100,17 @@ describe("ui/pages/CreateIdentity", () => {
     const select = await screen.findByLabelText("Identity type");
     await selectEvent.select(select, IDENTITY_TYPES[1].label);
 
-    const button = await screen.findByText("Create");
-    await act(async () => Promise.resolve(fireEvent.submit(button)));
+    const button = await screen.findByText("Cryptkeeper");
+    await act(async () => Promise.resolve(fireEvent.click(button)));
 
-    expect(signWithSigner).toBeCalledTimes(1);
+    expect(signWithSigner).toBeCalledTimes(0);
     expect(mockDispatch).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
-      messageSignature: mockSignedMessage,
+      messageSignature: undefined,
       options: { message: mockMessage },
       strategy: "random",
-      walletType: 0,
+      walletType: EWallet.CRYPT_KEEPER_WALLET,
     });
   });
 
@@ -117,11 +119,13 @@ describe("ui/pages/CreateIdentity", () => {
 
     await waitFor(() => container.firstChild !== null);
 
-    const button = await screen.findByText("Create");
+    const metamaskButton = await screen.findByText("Metamask");
+    const cryptkeeperButton = await screen.findByText("Cryptkeeper");
     const provider = await screen.findByText("Twitter");
     const identityType = await screen.findByText("InterRep");
 
-    expect(button).toBeInTheDocument();
+    expect(metamaskButton).toBeInTheDocument();
+    expect(cryptkeeperButton).toBeInTheDocument();
     expect(provider).toBeInTheDocument();
     expect(identityType).toBeInTheDocument();
   });
@@ -137,8 +141,8 @@ describe("ui/pages/CreateIdentity", () => {
     const nonce = await screen.findByLabelText("Nonce");
     await act(async () => Promise.resolve(fireEvent.change(nonce, { target: { value: 1 } })));
 
-    const button = await screen.findByText("Create");
-    await act(async () => Promise.resolve(fireEvent.submit(button)));
+    const button = await screen.findByText("Metamask");
+    await act(async () => Promise.resolve(fireEvent.click(button)));
 
     expect(signWithSigner).toBeCalledTimes(1);
     expect(mockDispatch).toBeCalledTimes(1);
@@ -163,8 +167,8 @@ describe("ui/pages/CreateIdentity", () => {
 
     await waitFor(() => container.firstChild !== null);
 
-    const button = await screen.findByText("Create");
-    await act(async () => Promise.resolve(fireEvent.submit(button)));
+    const button = await screen.findByText("Metamask");
+    await act(async () => Promise.resolve(fireEvent.click(button)));
 
     const error = await screen.findByText(err.message);
     expect(error).toBeInTheDocument();

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -58,7 +58,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     (createIdentity as jest.Mock).mockReturnValue(true);
 
-    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+    (useWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
   });
@@ -72,7 +72,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isProviderAvailable).toBe(true);
-    expect(result.current.isMetamaskConnected).toBe(true);
+    expect(result.current.isWalletConnected).toBe(true);
+    expect(result.current.isWalletInstalled).toBe(true);
     expect(result.current.control).toBeDefined();
     expect(result.current.errors).toStrictEqual({
       root: undefined,
@@ -99,6 +100,29 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     });
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(Paths.HOME);
+  });
+
+  test("should connect eth wallet properly", async () => {
+    const { result } = renderHook(() => useCreateIdentity());
+
+    await act(async () => Promise.resolve(result.current.onConnectWallet()));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+  });
+
+  test("should handle error when trying to connect with eth wallet", async () => {
+    (useWallet as jest.Mock).mockReturnValue({
+      ...defaultWalletHookData,
+      onConnect: jest.fn(() => Promise.reject()),
+    });
+
+    const { result } = renderHook(() => useCreateIdentity());
+
+    await act(async () => Promise.resolve(result.current.onConnectWallet()));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.errors.root).toBe("Wallet connection error");
   });
 
   test("should create identity with cryptkeeper properly", async () => {

--- a/src/ui/pages/Home/components/IdentityList/IdentityList.tsx
+++ b/src/ui/pages/Home/components/IdentityList/IdentityList.tsx
@@ -10,7 +10,6 @@ import {
   setIdentityName,
   useSelectedIdentity,
 } from "@src/ui/ducks/identities";
-import { useWallet } from "@src/ui/hooks/wallet";
 
 import type { IdentityData } from "@src/types";
 
@@ -24,7 +23,6 @@ export interface IdentityListProps {
 export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => {
   const selected = useSelectedIdentity();
   const dispatch = useAppDispatch();
-  const { address } = useWallet();
 
   const onSelectIdentity = useCallback(
     (identityCommitment: string) => {
@@ -48,10 +46,8 @@ export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => 
   );
 
   const onCreateIdentityRequest = useCallback(() => {
-    if (address) {
-      dispatch(createIdentityRequest());
-    }
-  }, [address, dispatch]);
+    dispatch(createIdentityRequest());
+  }, [dispatch]);
 
   return (
     <>
@@ -73,7 +69,7 @@ export const IdentityList = ({ identities }: IdentityListProps): JSX.Element => 
         <button
           className={classNames(
             "flex flex-row items-center justify-center cursor-pointer text-gray-600",
-            `create-identity-row__${address ? "active" : "not-active"}`,
+            "create-identity-row__active",
           )}
           data-testid="create-new-identity"
           type="button"

--- a/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/src/ui/pages/Home/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -7,7 +7,6 @@ import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icon
 import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { ZERO_ADDRESS } from "@src/config/const";
-import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { IdentityData } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import {
@@ -17,7 +16,6 @@ import {
   useIdentities,
   useSelectedIdentity,
 } from "@src/ui/ducks/identities";
-import { useWallet } from "@src/ui/hooks/wallet";
 
 import { IdentityList } from "..";
 
@@ -32,10 +30,6 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
   useIdentities: jest.fn(),
   useSelectedIdentity: jest.fn(),
   createIdentityRequest: jest.fn(),
-}));
-
-jest.mock("@src/ui/hooks/wallet", (): unknown => ({
-  useWallet: jest.fn(),
 }));
 
 describe("ui/pages/Home/components/IdentityList", () => {
@@ -69,8 +63,6 @@ describe("ui/pages/Home/components/IdentityList", () => {
     (useIdentities as jest.Mock).mockReturnValue(defaultIdentities);
 
     (useSelectedIdentity as jest.Mock).mockReturnValue(defaultIdentities[0]);
-
-    (useWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
   });
 
   afterEach(() => {
@@ -78,18 +70,6 @@ describe("ui/pages/Home/components/IdentityList", () => {
   });
 
   test("should render properly", async () => {
-    render(<IdentityList identities={defaultIdentities} />);
-
-    const identityName1 = await screen.findByText(defaultIdentities[0].metadata.name);
-    const identityName2 = await screen.findByText(defaultIdentities[1].metadata.name);
-
-    expect(identityName1).toBeInTheDocument();
-    expect(identityName2).toBeInTheDocument();
-  });
-
-  test("should render properly without connected wallet", async () => {
-    (useWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, address: undefined });
-
     render(<IdentityList identities={defaultIdentities} />);
 
     const identityName1 = await screen.findByText(defaultIdentities[0].metadata.name);

--- a/src/ui/pages/Home/components/IdentityList/identityListStyles.scss
+++ b/src/ui/pages/Home/components/IdentityList/identityListStyles.scss
@@ -18,12 +18,4 @@
       }
     }
   }
-
-  &__not-active {
-    width: 100%;
-
-    &:disabled {
-      color: $gray-600;
-    }
-  }
 }


### PR DESCRIPTION
## Explanation

This PR adds support for identity creation with cryptkeeper keys and metamask.

Details are below:
- [x] Update e2e tests to support both options for signing
- [x] Improve signing flow for random identities
- [x] Remove connected wallet requirement to create identities
- [x] Support metamask and cryptkeeper sign options on ui

## More Information

Blocked by #372
Closes #341 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/6195a399-81a9-4b63-bf3a-93672a56738b)

## Manual Testing Steps

1. Create new account which has seed phrase 
2. Go to create identity screen
3. Try to create identity with cryptkeeper or metamask

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
