### PR TITLE
feat: account menu

### DIFF
--- a/e2e/pages/cryptKeeper/CryptKeeper.ts
+++ b/e2e/pages/cryptKeeper/CryptKeeper.ts
@@ -33,7 +33,7 @@ export default class CryptKeeper extends BasePage {
 
   async connectWallet(): Promise<void> {
     await this.page.getByTestId("menu").click();
-    await this.page.getByText("Connect wallet", { exact: true }).click();
+    await this.page.getByText("Connect Metamask", { exact: true }).click();
 
     await metamaskCommands.acceptAccess();
   }

--- a/src/config/mock/wallet.ts
+++ b/src/config/mock/wallet.ts
@@ -13,6 +13,7 @@ export const defaultWalletHookData: IUseWalletData = {
   isActivating: false,
   isInjectedWallet: true,
   address: ZERO_ADDRESS,
+  addresses: [ZERO_ADDRESS],
   balance: new BigNumber(1000),
   chain: getChains()[1],
   connectorName: ConnectorNames.MOCK,

--- a/src/types/hooks/index.ts
+++ b/src/types/hooks/index.ts
@@ -14,6 +14,7 @@ export interface IUseWalletData {
   isActive: boolean;
   isActivating: boolean;
   isInjectedWallet: boolean;
+  addresses?: string[];
   address?: string;
   balance?: BigNumber;
   chain?: Chain;

--- a/src/ui/components/AccountMenu/AccountMenu.tsx
+++ b/src/ui/components/AccountMenu/AccountMenu.tsx
@@ -1,0 +1,102 @@
+import Badge from "@mui/material/Badge";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Skeleton from "@mui/material/Skeleton";
+import Typography from "@mui/material/Typography";
+import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+
+import { EWallet, IUseWalletData } from "@src/types";
+import { ellipsify } from "@src/util/account";
+
+import { useAccountMenu } from "./useAccountMenu";
+
+export interface IAccountMenuProps {
+  ethWallet: IUseWalletData;
+  cryptKeeperWallet: IUseWalletData;
+}
+
+const WALLET_LABEL_BY_TYPE = {
+  [EWallet.ETH_WALLET]: "Metamask",
+  [EWallet.CRYPT_KEEPER_WALLET]: "Cryptkeeper",
+};
+
+export const AccountMenu = ({ ethWallet, cryptKeeperWallet }: IAccountMenuProps): JSX.Element => {
+  const {
+    isOpen,
+    accounts,
+    anchorEl,
+    onOpen,
+    onClose,
+    onConnect,
+    onDisconnect,
+    onLock,
+    onGoToSettings,
+    onGoToMetamaskPage,
+  } = useAccountMenu({
+    ethWallet,
+    cryptKeeperWallet,
+  });
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center" }}>
+      <IconButton data-testid="menu" disabled={!cryptKeeperWallet.address} onClick={onOpen}>
+        {cryptKeeperWallet.address ? (
+          <Jazzicon diameter={32} seed={jsNumberForAddress(cryptKeeperWallet.address)} />
+        ) : (
+          <Skeleton data-testid="address-loading" height={32} variant="circular" width={32} />
+        )}
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={isOpen} onClose={onClose}>
+        {accounts.map((account) => (
+          <MenuItem
+            key={`${account.type}-${account.address}`}
+            sx={{ display: "flex", alignItems: "center", width: 200 }}
+          >
+            <Jazzicon diameter={16} seed={jsNumberForAddress(account.address)} />
+
+            <Box sx={{ ml: 1 }}>
+              <Typography sx={{ fontSize: "0.7rem" }} variant="body2">
+                {WALLET_LABEL_BY_TYPE[account.type]}
+              </Typography>
+
+              <Typography variant="body2">{ellipsify(account.address)}</Typography>
+
+              {account.active && (
+                <Badge
+                  color="success"
+                  sx={{
+                    backgroundColor: "success.main",
+                    borderRadius: "50%",
+                    position: "absolute",
+                    top: 20,
+                    right: 16,
+                    height: 8,
+                    width: 8,
+                  }}
+                />
+              )}
+            </Box>
+          </MenuItem>
+        ))}
+
+        <Divider sx={{ backgroundColor: "background.paper" }} />
+
+        {ethWallet.isActive && <MenuItem onClick={onDisconnect}>Disconnect Metamask</MenuItem>}
+
+        {ethWallet.isInjectedWallet ? (
+          !ethWallet.isActive && <MenuItem onClick={onConnect}>Connect Metamask</MenuItem>
+        ) : (
+          <MenuItem onClick={onGoToMetamaskPage}>Install Metamask</MenuItem>
+        )}
+
+        <MenuItem onClick={onGoToSettings}>Settings</MenuItem>
+
+        <MenuItem onClick={onLock}>Lock</MenuItem>
+      </Menu>
+    </Box>
+  );
+};

--- a/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render } from "@testing-library/react";
+
+import { ZERO_ADDRESS } from "@src/config/const";
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { EWallet } from "@src/types";
+
+import { AccountMenu, IAccountMenuProps } from "..";
+import { IUseAccountMenuData, useAccountMenu } from "../useAccountMenu";
+
+jest.mock("../useAccountMenu", (): unknown => ({
+  useAccountMenu: jest.fn(),
+}));
+
+describe("ui/components/Header", () => {
+  const defaulltProps: IAccountMenuProps = {
+    ethWallet: defaultWalletHookData,
+    cryptKeeperWallet: defaultWalletHookData,
+  };
+
+  const defaultHookData: IUseAccountMenuData = {
+    isOpen: true,
+    accounts: [
+      { type: EWallet.CRYPT_KEEPER_WALLET, address: ZERO_ADDRESS, active: true },
+      { type: EWallet.ETH_WALLET, address: ZERO_ADDRESS, active: true },
+    ],
+    anchorEl: document.body,
+    onConnect: jest.fn(),
+    onDisconnect: jest.fn(),
+    onLock: jest.fn(),
+    onOpen: jest.fn(),
+    onClose: jest.fn(),
+    onGoToMetamaskPage: jest.fn(),
+    onGoToSettings: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useAccountMenu as jest.Mock).mockReturnValue(defaultHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { findByTestId } = render(<AccountMenu {...defaulltProps} />);
+
+    const menu = await findByTestId("menu");
+
+    expect(menu).toBeInTheDocument();
+  });
+
+  test("should render properly without connected wallet", async () => {
+    const { findByText } = render(
+      <AccountMenu {...defaulltProps} ethWallet={{ ...defaulltProps.ethWallet, isActive: false }} />,
+    );
+
+    const item = await findByText("Connect Metamask");
+    await act(async () => Promise.resolve(item.click()));
+
+    expect(defaultHookData.onConnect).toBeCalledTimes(1);
+  });
+
+  test("should render properly activating state", async () => {
+    const { findByTestId } = render(
+      <AccountMenu {...defaulltProps} cryptKeeperWallet={{ ...defaulltProps.ethWallet, address: undefined }} />,
+    );
+
+    const loading = await findByTestId("address-loading");
+
+    expect(loading).toBeInTheDocument();
+  });
+
+  test("should render without installed wallet", async () => {
+    const { findByText } = render(
+      <AccountMenu
+        {...defaulltProps}
+        ethWallet={{ ...defaulltProps.ethWallet, isActive: false, isInjectedWallet: false }}
+      />,
+    );
+
+    const metamaskInstall = await findByText("Install Metamask");
+    await act(async () => Promise.resolve(metamaskInstall.click()));
+
+    expect(defaultHookData.onGoToMetamaskPage).toBeCalledTimes(1);
+  });
+
+  test("should go to settings page", async () => {
+    const { findByText } = render(<AccountMenu {...defaulltProps} />);
+
+    const settings = await findByText("Settings");
+    await act(async () => Promise.resolve(settings.click()));
+
+    expect(defaultHookData.onGoToSettings).toBeCalledTimes(1);
+  });
+
+  test("should lock app properly", async () => {
+    const { findByText } = render(<AccountMenu {...defaulltProps} />);
+
+    const lock = await findByText("Lock");
+    await act(async () => Promise.resolve(lock.click()));
+
+    expect(defaultHookData.onLock).toBeCalledTimes(1);
+  });
+
+  test("should disconnect metamask properly", async () => {
+    const { findByText } = render(
+      <AccountMenu {...defaulltProps} ethWallet={{ ...defaultWalletHookData, isActive: true }} />,
+    );
+
+    const disconnect = await findByText("Disconnect Metamask");
+    await act(async () => Promise.resolve(disconnect.click()));
+
+    expect(defaultHookData.onDisconnect).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
+++ b/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { MouseEvent as ReactMouseEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { Paths } from "@src/constants";
+import { EWallet } from "@src/types";
+import { getExtensionUrl, redirectToNewTab } from "@src/util/browser";
+
+import { IUseAccountMenuArgs, useAccountMenu } from "../useAccountMenu";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
+}));
+
+jest.mock("@src/util/browser", (): unknown => ({
+  redirectToNewTab: jest.fn(),
+  getExtensionUrl: jest.fn(),
+}));
+
+describe("ui/components/AccountMenu/useAccountMenu", () => {
+  const mockNavigate = jest.fn();
+
+  const defaultArgs: IUseAccountMenuArgs = {
+    ethWallet: defaultWalletHookData,
+    cryptKeeperWallet: defaultWalletHookData,
+  };
+
+  beforeEach(() => {
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    (getExtensionUrl as jest.Mock).mockReturnValue("options.html");
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should return initial data", () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    expect(result.current.accounts).toStrictEqual([
+      { type: EWallet.ETH_WALLET, address: defaultWalletHookData.address, active: true },
+      { type: EWallet.CRYPT_KEEPER_WALLET, address: defaultWalletHookData.address, active: true },
+    ]);
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.anchorEl).toBeUndefined();
+  });
+
+  test("should return empty addresses", () => {
+    const { result } = renderHook(() =>
+      useAccountMenu({
+        ethWallet: { ...defaultWalletHookData, addresses: undefined },
+        cryptKeeperWallet: { ...defaultWalletHookData, addresses: undefined },
+      }),
+    );
+
+    expect(result.current.accounts).toStrictEqual([]);
+  });
+
+  test("should go to install metamask", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(() => Promise.resolve(result.current.onGoToMetamaskPage()));
+
+    expect(redirectToNewTab).toBeCalledTimes(1);
+    expect(redirectToNewTab).toBeCalledWith("https://metamask.io/");
+  });
+
+  test("should go to settings page", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(async () => Promise.resolve(result.current.onGoToSettings()));
+
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+  });
+
+  test("should open and close menu properly", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(async () =>
+      Promise.resolve(result.current.onOpen({ currentTarget: {} } as unknown as ReactMouseEvent<HTMLButtonElement>)),
+    );
+    await waitFor(() => result.current.anchorEl !== undefined);
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.anchorEl).toBeDefined();
+
+    await act(async () => Promise.resolve(result.current.onClose()));
+    await waitFor(() => !result.current.anchorEl);
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.anchorEl).toBeUndefined();
+  });
+
+  test("should lock properly", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(async () => Promise.resolve(result.current.onLock()));
+
+    expect(defaultWalletHookData.onLock).toBeCalledTimes(1);
+  });
+
+  test("should connect properly", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(async () => Promise.resolve(result.current.onConnect()));
+
+    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+  });
+
+  test("should disconnect properly", async () => {
+    const { result } = renderHook(() => useAccountMenu(defaultArgs));
+
+    await act(async () => Promise.resolve(result.current.onDisconnect()));
+
+    expect(defaultWalletHookData.onDisconnect).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/components/AccountMenu/index.ts
+++ b/src/ui/components/AccountMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./AccountMenu";

--- a/src/ui/components/AccountMenu/useAccountMenu.ts
+++ b/src/ui/components/AccountMenu/useAccountMenu.ts
@@ -1,0 +1,105 @@
+import { useCallback, useMemo, useState, MouseEvent as ReactMouseEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+import { EWallet, IUseWalletData } from "@src/types";
+import { redirectToNewTab } from "@src/util/browser";
+
+export interface IUseAccountMenuArgs {
+  ethWallet: IUseWalletData;
+  cryptKeeperWallet: IUseWalletData;
+}
+
+export interface IUseAccountMenuData {
+  isOpen: boolean;
+  accounts: { type: EWallet; address: string; active: boolean }[];
+  anchorEl?: HTMLElement;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onLock: () => void;
+  onOpen: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onClose: () => void;
+  onGoToMetamaskPage: () => void;
+  onGoToSettings: () => void;
+}
+
+const METAMASK_INSTALL_URL = "https://metamask.io/";
+
+export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenuArgs): IUseAccountMenuData => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+
+  const navigate = useNavigate();
+
+  const onOpen = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [setAnchorEl],
+  );
+
+  const onClose = useCallback(() => {
+    setAnchorEl(undefined);
+  }, [setAnchorEl]);
+
+  const onGoToMetamaskPage = useCallback(() => {
+    redirectToNewTab(METAMASK_INSTALL_URL);
+    onClose();
+  }, [onClose]);
+
+  const onGoToSettings = useCallback(() => {
+    navigate(Paths.SETTINGS);
+    onClose();
+  }, [navigate, onClose]);
+
+  const onLock = useCallback(() => {
+    cryptKeeperWallet.onLock();
+    onClose();
+  }, [cryptKeeperWallet.onLock, onClose]);
+
+  const onConnect = useCallback(() => {
+    ethWallet.onConnect();
+    onClose();
+  }, [ethWallet.onConnect, onClose]);
+
+  const onDisconnect = useCallback(() => {
+    ethWallet.onDisconnect();
+    onClose();
+  }, [ethWallet.onDisconnect, onClose]);
+
+  const isOpen = useMemo(() => Boolean(anchorEl), [Boolean(anchorEl)]);
+
+  const ethAddresses = useMemo(
+    () =>
+      ethWallet.addresses?.map((address) => ({
+        type: EWallet.ETH_WALLET,
+        address,
+        active: ethWallet.address === address,
+      })) ?? [],
+    [ethWallet.addresses, ethWallet.address],
+  );
+
+  const cryptKeeperAddresses = useMemo(
+    () =>
+      cryptKeeperWallet.addresses?.map((address) => ({
+        type: EWallet.CRYPT_KEEPER_WALLET,
+        address,
+        active: cryptKeeperWallet.address === address,
+      })) ?? [],
+    [cryptKeeperWallet.addresses, cryptKeeperWallet.address],
+  );
+
+  const accounts = useMemo(() => ethAddresses.concat(cryptKeeperAddresses), [ethAddresses, cryptKeeperAddresses]);
+
+  return {
+    isOpen,
+    anchorEl,
+    accounts,
+    onConnect,
+    onDisconnect,
+    onLock,
+    onOpen,
+    onClose,
+    onGoToSettings,
+    onGoToMetamaskPage,
+  };
+};

--- a/src/ui/components/AccountMenu/useAccountMenu.ts
+++ b/src/ui/components/AccountMenu/useAccountMenu.ts
@@ -72,7 +72,7 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
     () =>
       ethWallet.addresses?.map((address) => ({
         type: EWallet.ETH_WALLET,
-        address,
+        address: address.toLowerCase(),
         active: ethWallet.address === address,
       })) ?? [],
     [ethWallet.addresses, ethWallet.address],
@@ -82,7 +82,7 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
     () =>
       cryptKeeperWallet.addresses?.map((address) => ({
         type: EWallet.CRYPT_KEEPER_WALLET,
-        address,
+        address: address.toLowerCase(),
         active: cryptKeeperWallet.address === address,
       })) ?? [],
     [cryptKeeperWallet.addresses, cryptKeeperWallet.address],

--- a/src/ui/components/Header/__tests__/Header.test.tsx
+++ b/src/ui/components/Header/__tests__/Header.test.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { Paths } from "@src/constants";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 import { getExtensionUrl, redirectToNewTab } from "@src/util/browser";
 
 import { Header } from "..";
@@ -18,6 +18,7 @@ jest.mock("react-router-dom", () => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 jest.mock("@src/util/browser", (): unknown => ({
@@ -30,6 +31,8 @@ describe("ui/components/Header", () => {
 
   beforeEach(() => {
     (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
@@ -64,9 +67,9 @@ describe("ui/components/Header", () => {
 
     const { findByTestId } = render(<Header />);
 
-    const icon = await findByTestId("inactive-wallet-icon");
+    const menu = await findByTestId("menu");
 
-    expect(icon).toBeInTheDocument();
+    expect(menu).toBeInTheDocument();
   });
 
   test("should render properly activating state", async () => {
@@ -80,9 +83,9 @@ describe("ui/components/Header", () => {
 
     const { findByTestId } = render(<Header />);
 
-    const icon = await findByTestId("inactive-wallet-icon-activating");
+    const menu = await findByTestId("menu");
 
-    expect(icon).toBeInTheDocument();
+    expect(menu).toBeInTheDocument();
   });
 
   test("should render without installed wallet", async () => {
@@ -96,7 +99,7 @@ describe("ui/components/Header", () => {
     const menu = await findByTestId("menu");
     await act(async () => Promise.resolve(menu.click()));
 
-    const metamaskInstall = await findByText("Install metamask");
+    const metamaskInstall = await findByText("Install Metamask");
     await act(async () => Promise.resolve(metamaskInstall.click()));
 
     expect(redirectToNewTab).toBeCalledTimes(1);

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -1,35 +1,22 @@
-import classNames from "classnames";
 import { useCallback } from "react";
-import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
-import loaderSvg from "@src/static/icons/loader.svg";
 import logoSvg from "@src/static/icons/logo.svg";
 import { Icon } from "@src/ui/components/Icon";
-import { Menuable } from "@src/ui/components/Menuable";
-import { useEthWallet } from "@src/ui/hooks/wallet";
-import { redirectToNewTab } from "@src/util/browser";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
+
+import { AccountMenu } from "../AccountMenu";
 
 import "./header.scss";
 
-const METAMASK_INSTALL_URL = "https://metamask.io/";
-
 export const Header = (): JSX.Element => {
-  const { address, isActivating, isActive, isInjectedWallet, chain, onConnect, onDisconnect, onLock } = useEthWallet();
+  const ethWallet = useEthWallet();
+  const cryptKeeperWallet = useCryptKeeperWallet();
   const navigate = useNavigate();
-  const isLoading = isActivating && isInjectedWallet;
-
-  const onGoToMetamaskPage = useCallback(() => {
-    redirectToNewTab(METAMASK_INSTALL_URL);
-  }, []);
 
   const onGoToHome = useCallback(() => {
     navigate(Paths.HOME);
-  }, [navigate]);
-
-  const onGoToSettings = useCallback(() => {
-    navigate(Paths.SETTINGS);
   }, [navigate]);
 
   return (
@@ -37,48 +24,10 @@ export const Header = (): JSX.Element => {
       <Icon data-testid="logo" size={3} url={logoSvg} onClick={onGoToHome} />
 
       <div className="flex-grow flex flex-row items-center justify-end header__content">
-        {chain && <div className="text-sm rounded-full header__network-type">{chain.name}</div>}
+        {ethWallet.chain && <div className="text-sm rounded-full header__network-type">{ethWallet.chain.name}</div>}
 
         <div className="header__account-icon">
-          <Menuable
-            className="flex user-menu"
-            items={[
-              isActive
-                ? {
-                    label: "Disconnect wallet",
-                    isDangerItem: false,
-                    onClick: onDisconnect,
-                  }
-                : {
-                    label: isInjectedWallet ? "Connect wallet" : "Install metamask",
-                    isDangerItem: false,
-                    onClick: isInjectedWallet ? onConnect : onGoToMetamaskPage,
-                  },
-              {
-                label: "Settings",
-                isDangerItem: false,
-                onClick: onGoToSettings,
-              },
-              {
-                label: "Lock",
-                isDangerItem: false,
-                onClick: onLock,
-              },
-            ]}
-          >
-            {!address ? (
-              <Icon
-                data-testid={`inactive-wallet-icon${isLoading ? "-activating" : ""}`}
-                fontAwesome={classNames({
-                  "fas fa-plug": !isLoading,
-                })}
-                size={1.25}
-                url={isLoading ? loaderSvg : undefined}
-              />
-            ) : (
-              <Jazzicon diameter={32} seed={jsNumberForAddress(address)} />
-            )}
-          </Menuable>
+          <AccountMenu cryptKeeperWallet={cryptKeeperWallet} ethWallet={ethWallet} />
         </div>
       </div>
     </div>

--- a/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
+++ b/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
@@ -37,6 +37,7 @@ jest.mock("@src/connectors", (): unknown => ({
   cryptKeeperHooks: {
     useChainId: jest.fn(),
     useAccount: jest.fn(),
+    useAccounts: jest.fn(),
   },
 }));
 
@@ -53,6 +54,8 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
     (cryptKeeperHooks.useAccount as jest.Mock).mockReturnValue(defaultWalletHookData.address);
+
+    (cryptKeeperHooks.useAccounts as jest.Mock).mockReturnValue(defaultWalletHookData.addresses);
   });
 
   afterEach(() => {

--- a/src/ui/hooks/wallet/__tests__/useEthWallet.test.ts
+++ b/src/ui/hooks/wallet/__tests__/useEthWallet.test.ts
@@ -40,6 +40,7 @@ jest.mock("@src/connectors", (): unknown => ({
   metamaskHooks: {
     useChainId: jest.fn(),
     useAccount: jest.fn(),
+    useAccounts: jest.fn(),
   },
 }));
 
@@ -62,6 +63,8 @@ describe("ui/hooks/useEthWallet", () => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
     (metamaskHooks.useAccount as jest.Mock).mockReturnValue(defaultWalletHookData.address);
+
+    (metamaskHooks.useAccounts as jest.Mock).mockReturnValue(defaultWalletHookData.addresses);
 
     (metamaskHooks.useChainId as jest.Mock).mockReturnValue(defaultWalletHookData.chain?.chainId);
   });

--- a/src/ui/hooks/wallet/useCryptKeeper.ts
+++ b/src/ui/hooks/wallet/useCryptKeeper.ts
@@ -10,7 +10,8 @@ export const useCryptKeeperWallet = (): IUseWalletData => {
   const { isActive, isActivating } = useWeb3React();
   const dispatch = useAppDispatch();
 
-  const address = cryptKeeperHooks?.useAccount();
+  const address = cryptKeeperHooks.useAccount();
+  const addresses = cryptKeeperHooks.useAccounts();
 
   const onConnect = useCallback(async () => {
     await cryptKeeper.activate();
@@ -27,13 +28,15 @@ export const useCryptKeeperWallet = (): IUseWalletData => {
 
   const onLock = useCallback(() => {
     dispatch(lock());
-  }, [dispatch]);
+    onDisconnect();
+  }, [dispatch, onDisconnect]);
 
   return {
     isActive,
     isActivating,
     isInjectedWallet: Boolean(window.cryptkeeper),
     address,
+    addresses,
     connectorName: ConnectorNames.CRYPT_KEEPER,
     connector: cryptKeeper,
     balance: undefined,

--- a/src/ui/hooks/wallet/useEthWallet.ts
+++ b/src/ui/hooks/wallet/useEthWallet.ts
@@ -30,6 +30,7 @@ export const useEthWallet = (connectorName = ConnectorNames.METAMASK): IUseWalle
 
   const chainId = connection?.hooks.useChainId();
   const address = connection?.hooks.useAccount();
+  const addresses = connection?.hooks.useAccounts();
   const chain = chainId ? chains[chainId] : undefined;
   const decimals = chain?.nativeCurrency.decimals;
 
@@ -74,6 +75,7 @@ export const useEthWallet = (connectorName = ConnectorNames.METAMASK): IUseWalle
     isActivating,
     isInjectedWallet: Boolean(window.ethereum),
     address,
+    addresses,
     balance,
     chain,
     connectorName,

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -15,7 +15,7 @@ import { IDENTITY_TYPES, WEB2_PROVIDER_OPTIONS } from "@src/constants";
 import { EWallet } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 import { signWithSigner, getMessageTemplate } from "@src/ui/services/identity";
 
 import CreateIdentity from "..";
@@ -43,6 +43,7 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 describe("ui/pages/CreateIdentity", () => {
@@ -55,6 +56,8 @@ describe("ui/pages/CreateIdentity", () => {
     library.add(faTwitter, faGithub, faReddit);
 
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -11,7 +11,7 @@ import { IDENTITY_TYPES, Paths } from "@src/constants";
 import { EWallet } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 import { signWithSigner, getMessageTemplate } from "@src/ui/services/identity";
 
 import { useCreateIdentity } from "../useCreateIdentity";
@@ -39,6 +39,7 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
@@ -59,6 +60,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     (createIdentity as jest.Mock).mockReturnValue(true);
 
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
   });
@@ -136,7 +139,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       messageSignature: undefined,
-      options: { account: "", message: mockMessage, nonce: 0, web2Provider: "twitter" },
+      options: { account: defaultWalletHookData.address, message: mockMessage, nonce: 0, web2Provider: "twitter" },
       strategy: "interrep",
       walletType: EWallet.CRYPT_KEEPER_WALLET,
     });

--- a/src/ui/pages/DownloadBackup/__tests__/DownloadBackup.test.tsx
+++ b/src/ui/pages/DownloadBackup/__tests__/DownloadBackup.test.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { downloadBackup } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 
 import DownloadBackup from "..";
 
@@ -18,6 +18,7 @@ jest.mock("react-router-dom", () => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 jest.mock("@src/ui/ducks/backup", (): unknown => ({
@@ -34,6 +35,8 @@ describe("ui/pages/DownloadBackup", () => {
 
   beforeEach(() => {
     (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 

--- a/src/ui/pages/Home/__tests__/Home.test.tsx
+++ b/src/ui/pages/Home/__tests__/Home.test.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 
 import Home from "..";
 import { IUseHomeData, useHome } from "../useHome";
@@ -18,6 +18,7 @@ jest.mock("react-router-dom", () => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
@@ -46,6 +47,8 @@ describe("ui/pages/Home", () => {
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
   });
 
   afterEach(() => {

--- a/src/ui/pages/Popup/__tests__/Popup.test.tsx
+++ b/src/ui/pages/Popup/__tests__/Popup.test.tsx
@@ -11,7 +11,7 @@ import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { Paths } from "@src/constants";
 import { useAppDispatch, useAppSelector } from "@src/ui/ducks/hooks";
 import { usePendingRequests } from "@src/ui/ducks/requests";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 
 import Popup from "..";
 import { IUsePopupData, usePopup } from "../usePopup";
@@ -27,6 +27,7 @@ jest.mock("@src/ui/ducks/requests", (): unknown => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 jest.mock("../usePopup", (): unknown => ({
@@ -42,6 +43,8 @@ describe("ui/pages/Popup", () => {
     (usePopup as jest.Mock).mockReturnValue(defaultHookData);
 
     (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
     (usePendingRequests as jest.Mock).mockReturnValue([{ type: "unknown" }]);
 

--- a/src/ui/pages/Settings/__tests__/Settings.test.tsx
+++ b/src/ui/pages/Settings/__tests__/Settings.test.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
-import { useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
 
 import Settings from "..";
 import { IUseSettingsData, SettingsTabs, useSettings } from "../useSettings";
@@ -18,6 +18,7 @@ jest.mock("react-router-dom", (): unknown => ({
 
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
 }));
 
 jest.mock("../useSettings", (): unknown => ({
@@ -44,6 +45,8 @@ describe("ui/pages/Settings", () => {
 
   beforeEach(() => {
     (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -55,5 +55,43 @@ export const theme = createTheme({
         },
       },
     },
+
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: "none",
+        },
+      },
+    },
+
+    MuiMenu: {
+      styleOverrides: {
+        paper: ({ theme: { palette } }) => ({
+          backgroundColor: palette.background.default,
+          border: `1px solid ${grey[700]}`,
+          borderRadius: "0.75rem",
+        }),
+      },
+    },
+
+    MuiMenuItem: {
+      styleOverrides: {
+        root: ({ theme: { palette } }) => ({
+          transition: "all 200ms",
+
+          "&:hover": {
+            backgroundColor: lighten(palette.background.default, 0.06),
+          },
+        }),
+
+        focusVisible: ({ theme: { palette } }) => ({
+          backgroundColor: lighten(palette.background.default, 0.06),
+        }),
+
+        selected: ({ theme: { palette } }) => ({
+          backgroundColor: lighten(palette.background.default, 0.06),
+        }),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Explanation

This PR adds ui support for multiple accounts.

Details are below:
- [x] Add account menu component
- [x] Show cryptkeeper and metamask addresses
- [x] Pass cryptkeeper address for identity creation
- [x] Refactoring for header component

## More Information

Blocked by #417
Related to #377 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/c4123d44-b083-4159-9f75-fe38e3eba11c)

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/ba6a7efe-ce06-422f-a330-32996a3169a8)


## Manual Testing Steps

1. Reinstall the extension
2. Complete onboarding
3. Create identity
4. Check identity field has the same address as in account menu

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
