### PR TITLE
feat: switch account

### DIFF
--- a/demo/useCryptKeeper.ts
+++ b/demo/useCryptKeeper.ts
@@ -170,6 +170,14 @@ export const useCryptKeeper = (): IUseCryptKeeperData => {
     [setSelectedIdentity],
   );
 
+  const onAccountChanged = useCallback(
+    (address: unknown) => {
+      const newAccounts = [address as string].concat(accounts.filter((account) => account !== address));
+      setAccounts(newAccounts);
+    },
+    [accounts, setAccounts],
+  );
+
   const onLogin = useCallback(() => {
     setIsLocked(false);
     getIdentityCommitment();
@@ -193,9 +201,10 @@ export const useCryptKeeper = (): IUseCryptKeeperData => {
     client?.on("login", onLogin);
     client?.on("identityChanged", onIdentityChanged);
     client?.on("logout", onLogout);
+    client?.on("accountChanged", onAccountChanged);
 
     return () => client?.cleanListeners();
-  }, [client, setAccounts, onLogout, onIdentityChanged, onLogin]);
+  }, [client, setAccounts, onLogout, onIdentityChanged, onAccountChanged, onLogin]);
 
   return {
     accounts,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11200,15 +11200,9 @@
       }
     },
     "node_modules/dotenv": {
-<<<<<<< HEAD
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.3.tgz",
       "integrity": "sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==",
-=======
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.2.tgz",
-      "integrity": "sha512-RiNjjDF5yr9NtjqJqmWYA/XZShmt3r8FtJgAaqTiYqb99SqT0+aw5xAwOIvjMyXsH/C9/fLNafFkkZDwRi1KHA==",
->>>>>>> 5fcdd68 (feat: switch account)
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -34021,15 +34015,9 @@
       }
     },
     "dotenv": {
-<<<<<<< HEAD
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.3.tgz",
       "integrity": "sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==",
-=======
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.2.tgz",
-      "integrity": "sha512-RiNjjDF5yr9NtjqJqmWYA/XZShmt3r8FtJgAaqTiYqb99SqT0+aw5xAwOIvjMyXsH/C9/fLNafFkkZDwRi1KHA==",
->>>>>>> 5fcdd68 (feat: switch account)
       "dev": true
     },
     "dotenv-parse-variables": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11200,9 +11200,15 @@
       }
     },
     "node_modules/dotenv": {
+<<<<<<< HEAD
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.3.tgz",
       "integrity": "sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==",
+=======
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.2.tgz",
+      "integrity": "sha512-RiNjjDF5yr9NtjqJqmWYA/XZShmt3r8FtJgAaqTiYqb99SqT0+aw5xAwOIvjMyXsH/C9/fLNafFkkZDwRi1KHA==",
+>>>>>>> 5fcdd68 (feat: switch account)
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -34015,9 +34021,15 @@
       }
     },
     "dotenv": {
+<<<<<<< HEAD
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.3.tgz",
       "integrity": "sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==",
+=======
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.2.tgz",
+      "integrity": "sha512-RiNjjDF5yr9NtjqJqmWYA/XZShmt3r8FtJgAaqTiYqb99SqT0+aw5xAwOIvjMyXsH/C9/fLNafFkkZDwRi1KHA==",
+>>>>>>> 5fcdd68 (feat: switch account)
       "dev": true
     },
     "dotenv-parse-variables": {

--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -2,7 +2,7 @@ import log from "loglevel";
 import { browser } from "webextension-polyfill-ts";
 
 import { InjectedMessageData, ReduxAction, SelectedIdentity } from "@src/types";
-import { setStatus } from "@src/ui/ducks/app";
+import { setSelectedAccount, setStatus } from "@src/ui/ducks/app";
 import { setSelectedCommitment } from "@src/ui/ducks/identities";
 
 function injectScript() {
@@ -50,6 +50,17 @@ function injectScript() {
             target: "injected-injectedscript",
             payload: [null],
             nonce: !(action.payload as { isUnlocked: boolean }).isUnlocked ? "logout" : "login",
+          },
+          "*",
+        );
+        return;
+      }
+      case setSelectedAccount.type: {
+        window.postMessage(
+          {
+            target: "injected-injectedscript",
+            payload: [null, action.payload],
+            nonce: "accountChanged",
           },
           "*",
         );

--- a/src/background/cryptKeeper.ts
+++ b/src/background/cryptKeeper.ts
@@ -105,6 +105,8 @@ export default class CryptKeeperController extends Handler {
     this.add(RPCAction.GENERATE_MNEMONIC, this.lockService.ensure, this.walletService.generateMnemonic);
     this.add(RPCAction.SAVE_MNEMONIC, this.lockService.ensure, this.walletService.generateKeyPair);
     this.add(RPCAction.GET_ACCOUNTS, this.lockService.ensure, this.walletService.accounts);
+    this.add(RPCAction.SELECT_ACCOUNT, this.lockService.ensure, this.walletService.selectAccount);
+    this.add(RPCAction.GET_SELECTED_ACCOUNT, this.lockService.ensure, this.walletService.getSelectedAccount);
 
     // Protocols
     this.add(

--- a/src/background/services/event/types.ts
+++ b/src/background/services/event/types.ts
@@ -1,3 +1,3 @@
 export type EventHandler = (data: unknown) => void;
-export type EventName = "login" | "identityChanged" | "logout";
+export type EventName = "login" | "identityChanged" | "logout" | "accountChanged";
 export type Events = Record<EventName, EventHandler>;

--- a/src/constants/rpcActions.ts
+++ b/src/constants/rpcActions.ts
@@ -38,6 +38,8 @@ export enum RPCAction {
   SAVE_MNEMONIC = "rpc/mnemonic/save",
   GENERATE_MNEMONIC = "rpc/mnemonic/generate",
   GET_ACCOUNTS = "rpc/accounts/get",
+  SELECT_ACCOUNT = "rpc/accounts/select-account",
+  GET_SELECTED_ACCOUNT = "rpc/accounts/get-selected-account",
   // DEV RPCS
   CLEAR_APPROVED_HOSTS = "rpc/hosts/clear",
 }

--- a/src/providers/sdk/Base.ts
+++ b/src/providers/sdk/Base.ts
@@ -121,6 +121,12 @@ export class CryptKeeperInjectedProvider extends EventEmitter {
         return;
       }
 
+      if (data.nonce === "accountChanged") {
+        const [, res] = data.payload;
+        this.emit("accountChanged", res);
+        return;
+      }
+
       if (data.nonce === "logout") {
         const [, res] = data.payload;
         this.emit("logout", res);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -105,6 +105,7 @@ jest.mock("webextension-polyfill-ts", (): unknown => {
 
 export const events: Events = {
   identityChanged: () => false,
+  accountChanged: () => false,
   login: () => false,
   logout: () => false,
 };

--- a/src/ui/components/AccountMenu/AccountMenu.tsx
+++ b/src/ui/components/AccountMenu/AccountMenu.tsx
@@ -35,6 +35,7 @@ export const AccountMenu = ({ ethWallet, cryptKeeperWallet }: IAccountMenuProps)
     onLock,
     onGoToSettings,
     onGoToMetamaskPage,
+    onSelectAccount,
   } = useAccountMenu({
     ethWallet,
     cryptKeeperWallet,
@@ -54,7 +55,9 @@ export const AccountMenu = ({ ethWallet, cryptKeeperWallet }: IAccountMenuProps)
         {accounts.map((account) => (
           <MenuItem
             key={`${account.type}-${account.address}`}
+            data-testid={`${account.type}-${account.address}`}
             sx={{ display: "flex", alignItems: "center", width: 200 }}
+            onClick={account.type === EWallet.CRYPT_KEEPER_WALLET ? () => onSelectAccount(account.address) : undefined}
           >
             <Jazzicon diameter={16} seed={jsNumberForAddress(account.address)} />
 

--- a/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -35,6 +35,7 @@ describe("ui/components/Header", () => {
     onClose: jest.fn(),
     onGoToMetamaskPage: jest.fn(),
     onGoToSettings: jest.fn(),
+    onSelectAccount: jest.fn(),
   };
 
   beforeEach(() => {
@@ -115,5 +116,16 @@ describe("ui/components/Header", () => {
     await act(async () => Promise.resolve(disconnect.click()));
 
     expect(defaultHookData.onDisconnect).toBeCalledTimes(1);
+  });
+
+  test("should select account properly", async () => {
+    const { findByTestId } = render(<AccountMenu {...defaulltProps} />);
+
+    const [cryptKeeperAccount] = defaultHookData.accounts;
+    const account = await findByTestId(`${cryptKeeperAccount.type}-${cryptKeeperAccount.address}`);
+    await act(async () => Promise.resolve(account.click()));
+
+    expect(defaultHookData.onSelectAccount).toBeCalledTimes(1);
+    expect(defaultHookData.onSelectAccount).toBeCalledWith(cryptKeeperAccount.address);
   });
 });

--- a/src/ui/components/AccountMenu/useAccountMenu.ts
+++ b/src/ui/components/AccountMenu/useAccountMenu.ts
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { EWallet, IUseWalletData } from "@src/types";
+import { selectAccount } from "@src/ui/ducks/app";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { redirectToNewTab } from "@src/util/browser";
 
 export interface IUseAccountMenuArgs {
@@ -21,6 +23,7 @@ export interface IUseAccountMenuData {
   onClose: () => void;
   onGoToMetamaskPage: () => void;
   onGoToSettings: () => void;
+  onSelectAccount: (address: string) => void;
 }
 
 const METAMASK_INSTALL_URL = "https://metamask.io/";
@@ -29,6 +32,7 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
 
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   const onOpen = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -66,6 +70,13 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
     onClose();
   }, [ethWallet.onDisconnect, onClose]);
 
+  const onSelectAccount = useCallback(
+    (address: string) => {
+      dispatch(selectAccount(address));
+    },
+    [dispatch],
+  );
+
   const isOpen = useMemo(() => Boolean(anchorEl), [Boolean(anchorEl)]);
 
   const ethAddresses = useMemo(
@@ -101,5 +112,6 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
     onClose,
     onGoToSettings,
     onGoToMetamaskPage,
+    onSelectAccount,
   };
 };

--- a/src/ui/ducks/__tests__/app.test.tsx
+++ b/src/ui/ducks/__tests__/app.test.tsx
@@ -5,6 +5,7 @@
 import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 
+import { ZERO_ADDRESS } from "@src/config/const";
 import { RPCAction } from "@src/constants";
 import { store } from "@src/ui/store/configureAppStore";
 import postMessage from "@src/util/postMessage";
@@ -13,9 +14,11 @@ import {
   closePopup,
   fetchStatus,
   generateMnemonic,
+  getSelectedAccount,
   getWalletConnection,
   lock,
   saveMnemonic,
+  selectAccount,
   setStatus,
   setWalletConnection,
   setupPassword,
@@ -158,6 +161,42 @@ describe("ui/ducks/app", () => {
     });
     expect(postMessage).toBeCalledTimes(1);
     expect(postMessage).toBeCalledWith({ method: RPCAction.SAVE_MNEMONIC });
+  });
+
+  test("should select account properly", async () => {
+    await Promise.resolve(store.dispatch(selectAccount(ZERO_ADDRESS)));
+    const { app } = store.getState();
+
+    expect(app).toStrictEqual({
+      isInitialized: true,
+      isUnlocked: true,
+      isMnemonicGenerated: true,
+      isDisconnectedPermanently: true,
+      mnemonic: "",
+      selectedAccount: ZERO_ADDRESS,
+    });
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({ method: RPCAction.SELECT_ACCOUNT, payload: ZERO_ADDRESS });
+  });
+
+  test("should get selected account properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue(ZERO_ADDRESS);
+
+    await Promise.resolve(store.dispatch(getSelectedAccount()));
+    const { app } = store.getState();
+
+    expect(app).toStrictEqual({
+      isInitialized: true,
+      isUnlocked: true,
+      isMnemonicGenerated: true,
+      isDisconnectedPermanently: true,
+      mnemonic: "",
+      selectedAccount: ZERO_ADDRESS,
+    });
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({ method: RPCAction.GET_SELECTED_ACCOUNT });
   });
 
   test("should generate mnemonic properly", async () => {

--- a/src/ui/ducks/app.ts
+++ b/src/ui/ducks/app.ts
@@ -16,6 +16,7 @@ export interface AppState {
   isUnlocked: boolean;
   isMnemonicGenerated: boolean;
   mnemonic?: string;
+  selectedAccount?: string;
   isDisconnectedPermanently?: boolean;
 }
 
@@ -44,10 +45,14 @@ const appSlice = createSlice({
     setDisconnectedPermanently: (state: AppState, action: PayloadAction<boolean>) => {
       state.isDisconnectedPermanently = action.payload;
     },
+
+    setSelectedAccount: (state: AppState, action: PayloadAction<string>) => {
+      state.selectedAccount = action.payload;
+    },
   },
 });
 
-export const { setStatus } = appSlice.actions;
+export const { setStatus, setSelectedAccount } = appSlice.actions;
 
 export const lock = () => async (): Promise<void> => {
   await postMessage({ method: RPCAction.LOCK });
@@ -94,6 +99,18 @@ export const saveMnemonic = (): TypedThunk<Promise<void>> => async (dispatch) =>
   dispatch(setStatus({ isInitialized: true, isUnlocked: true, isMnemonicGenerated: true }));
   dispatch(appSlice.actions.setMnemonic(""));
 };
+
+export const getSelectedAccount = (): TypedThunk<Promise<void>> => async (dispatch) => {
+  const account = await postMessage<string>({ method: RPCAction.GET_SELECTED_ACCOUNT });
+  dispatch(setSelectedAccount(account));
+};
+
+export const selectAccount =
+  (address: string): TypedThunk<Promise<void>> =>
+  async (dispatch) => {
+    await postMessage({ method: RPCAction.SELECT_ACCOUNT, payload: address });
+    dispatch(setSelectedAccount(address));
+  };
 
 export const useGeneratedMnemonic = (): string | undefined => useAppSelector((state) => state.app.mnemonic, deepEqual);
 

--- a/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -68,12 +68,17 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
           web2Provider: web2Provider.value as IdentityWeb2Provider,
           nonce,
           identityStrategyType: identityStrategyType.value as IdentityStrategy,
-          account: identityStrategyType.value !== "random" ? (account as string) : ZERO_ADDRESS,
+          account: identityStrategyType.value !== "random" ? (account as string).toLowerCase() : ZERO_ADDRESS,
         });
 
         const options =
           identityStrategyType.value !== "random"
-            ? { nonce, web2Provider: web2Provider.value as IdentityWeb2Provider, account: account as string, message }
+            ? {
+                nonce,
+                web2Provider: web2Provider.value as IdentityWeb2Provider,
+                account: (account as string).toLowerCase(),
+                message,
+              }
             : { message, account: ZERO_ADDRESS };
 
         const messageSignature =

--- a/src/ui/pages/Home/Home.tsx
+++ b/src/ui/pages/Home/Home.tsx
@@ -7,14 +7,14 @@ import "./home.scss";
 import { useHome } from "./useHome";
 
 const Home = (): JSX.Element => {
-  const { chain, balance, identities, refreshConnectionStatus } = useHome();
+  const { identities, refreshConnectionStatus } = useHome();
 
   return (
     <div className="w-full h-full flex flex-col home" data-testid="home-page">
       <Header />
 
       <div className={classNames("flex flex-col flex-grow flex-shrink overflow-y-auto home__scroller")}>
-        <Info balance={balance} chain={chain} refreshConnectionStatus={refreshConnectionStatus} />
+        <Info refreshConnectionStatus={refreshConnectionStatus} />
 
         <TabList>
           <IdentityList identities={identities} />

--- a/src/ui/pages/Home/Home.tsx
+++ b/src/ui/pages/Home/Home.tsx
@@ -7,14 +7,14 @@ import "./home.scss";
 import { useHome } from "./useHome";
 
 const Home = (): JSX.Element => {
-  const { address, chain, balance, identities, refreshConnectionStatus } = useHome();
+  const { chain, balance, identities, refreshConnectionStatus } = useHome();
 
   return (
     <div className="w-full h-full flex flex-col home" data-testid="home-page">
       <Header />
 
       <div className={classNames("flex flex-col flex-grow flex-shrink overflow-y-auto home__scroller")}>
-        <Info address={address} balance={balance} chain={chain} refreshConnectionStatus={refreshConnectionStatus} />
+        <Info balance={balance} chain={chain} refreshConnectionStatus={refreshConnectionStatus} />
 
         <TabList>
           <IdentityList identities={identities} />

--- a/src/ui/pages/Home/__tests__/Home.test.tsx
+++ b/src/ui/pages/Home/__tests__/Home.test.tsx
@@ -36,8 +36,6 @@ describe("ui/pages/Home", () => {
   const defaultHookData: IUseHomeData = {
     identities: [],
     address: defaultWalletHookData.address,
-    balance: defaultWalletHookData.balance,
-    chain: defaultWalletHookData.chain,
     refreshConnectionStatus: jest.fn().mockResolvedValue(true),
   };
 

--- a/src/ui/pages/Home/__tests__/useHome.test.ts
+++ b/src/ui/pages/Home/__tests__/useHome.test.ts
@@ -89,8 +89,6 @@ describe("ui/pages/Home/useHome", () => {
     const { result } = renderHook(() => useHome());
 
     expect(result.current.address).toBe(defaultWalletHookData.address);
-    expect(result.current.balance).toStrictEqual(defaultWalletHookData.balance);
-    expect(result.current.chain).toStrictEqual(defaultWalletHookData.chain);
     expect(result.current.identities).toStrictEqual(defaultIdentities);
     expect(fetchIdentities).toBeCalledTimes(1);
     expect(fetchHistory).toBeCalledTimes(1);

--- a/src/ui/pages/Home/components/IdentityList/identityListStyles.scss
+++ b/src/ui/pages/Home/components/IdentityList/identityListStyles.scss
@@ -1,7 +1,7 @@
 @import "@src/util/variables";
 
 .identities-content {
-  height: 300px;
+  height: 355px;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/src/ui/pages/Home/components/Info/Info.tsx
+++ b/src/ui/pages/Home/components/Info/Info.tsx
@@ -4,25 +4,18 @@ import { useCallback, useEffect, useState } from "react";
 
 import { DEFAULT_ROUND } from "@src/config/const";
 import { ConnectionModal } from "@src/ui/components/ConnectionModal";
-import { sliceAddress } from "@src/util/account";
 
 import type { Chain } from "@src/types";
 
 import "./infoStyles.scss";
 
 export interface InfoProps {
-  address?: string;
   balance?: BigNumber;
   chain?: Chain;
   refreshConnectionStatus: () => Promise<boolean>;
 }
 
-export const Info = ({
-  address = "",
-  balance = undefined,
-  chain = undefined,
-  refreshConnectionStatus,
-}: InfoProps): JSX.Element => {
+export const Info = ({ balance = undefined, chain = undefined, refreshConnectionStatus }: InfoProps): JSX.Element => {
   const [isConnected, setIsConnected] = useState(false);
   const [isModalShow, setIsModalShow] = useState(false);
 
@@ -64,8 +57,6 @@ export const Info = ({
           <div className="text-xs home__info__connection-button__text">
             {isConnected ? "Connected" : "Not Connected"}
           </div>
-
-          {address && <div className="text-sm home__info__account-button">{sliceAddress(address)}</div>}
         </button>
 
         <div>

--- a/src/ui/pages/Home/components/Info/Info.tsx
+++ b/src/ui/pages/Home/components/Info/Info.tsx
@@ -1,21 +1,15 @@
-import BigNumber from "bignumber.js";
 import classNames from "classnames";
 import { useCallback, useEffect, useState } from "react";
 
-import { DEFAULT_ROUND } from "@src/config/const";
 import { ConnectionModal } from "@src/ui/components/ConnectionModal";
-
-import type { Chain } from "@src/types";
 
 import "./infoStyles.scss";
 
 export interface InfoProps {
-  balance?: BigNumber;
-  chain?: Chain;
   refreshConnectionStatus: () => Promise<boolean>;
 }
 
-export const Info = ({ balance = undefined, chain = undefined, refreshConnectionStatus }: InfoProps): JSX.Element => {
+export const Info = ({ refreshConnectionStatus }: InfoProps): JSX.Element => {
   const [isConnected, setIsConnected] = useState(false);
   const [isModalShow, setIsModalShow] = useState(false);
 
@@ -58,12 +52,6 @@ export const Info = ({ balance = undefined, chain = undefined, refreshConnection
             {isConnected ? "Connected" : "Not Connected"}
           </div>
         </button>
-
-        <div>
-          <div className="text-3xl font-semibold">
-            {chain && balance ? `${balance.toFormat(DEFAULT_ROUND)} ${chain.nativeCurrency.symbol}` : "-"}
-          </div>
-        </div>
       </div>
     </>
   );

--- a/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
+++ b/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
@@ -5,7 +5,6 @@
 import { act, render, screen } from "@testing-library/react";
 
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
-import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { IUseConnectionModalData, useConnectionModal } from "@src/ui/components/ConnectionModal/useConnectionModal";
 
 import { Info, InfoProps } from "..";
@@ -16,8 +15,6 @@ jest.mock("@src/ui/components/ConnectionModal/useConnectionModal", (): unknown =
 
 describe("ui/pages/Home/components/Info", () => {
   const defaultProps: InfoProps = {
-    balance: defaultWalletHookData.balance,
-    chain: defaultWalletHookData.chain,
     refreshConnectionStatus: jest.fn().mockResolvedValue(true),
   };
 
@@ -45,27 +42,16 @@ describe("ui/pages/Home/components/Info", () => {
     render(<Info {...defaultProps} />);
 
     const component = await screen.findByTestId("home-info");
-    const balance = await screen.findByText("1,000.0000 ETH");
 
     expect(component).toBeInTheDocument();
-    expect(balance).toBeInTheDocument();
   });
 
   test("should render properly without wallet data", async () => {
     const mockRefreshConnectionStatus = jest.fn().mockRejectedValue(false);
-    render(
-      <Info
-        {...defaultProps}
-        balance={undefined}
-        chain={undefined}
-        refreshConnectionStatus={mockRefreshConnectionStatus}
-      />,
-    );
+    render(<Info {...defaultProps} refreshConnectionStatus={mockRefreshConnectionStatus} />);
 
-    const balance = await screen.findByText("-");
     const connectedTitle = await screen.findByText("Not Connected");
 
-    expect(balance).toBeInTheDocument();
     expect(connectedTitle).toBeInTheDocument();
   });
 

--- a/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
+++ b/src/ui/pages/Home/components/Info/__tests__/Info.test.tsx
@@ -7,7 +7,6 @@ import { act, render, screen } from "@testing-library/react";
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { IUseConnectionModalData, useConnectionModal } from "@src/ui/components/ConnectionModal/useConnectionModal";
-import { sliceAddress } from "@src/util/account";
 
 import { Info, InfoProps } from "..";
 
@@ -17,7 +16,6 @@ jest.mock("@src/ui/components/ConnectionModal/useConnectionModal", (): unknown =
 
 describe("ui/pages/Home/components/Info", () => {
   const defaultProps: InfoProps = {
-    address: defaultWalletHookData.address,
     balance: defaultWalletHookData.balance,
     chain: defaultWalletHookData.chain,
     refreshConnectionStatus: jest.fn().mockResolvedValue(true),
@@ -48,11 +46,9 @@ describe("ui/pages/Home/components/Info", () => {
 
     const component = await screen.findByTestId("home-info");
     const balance = await screen.findByText("1,000.0000 ETH");
-    const address = await screen.findByText(sliceAddress(defaultWalletHookData.address as string));
 
     expect(component).toBeInTheDocument();
     expect(balance).toBeInTheDocument();
-    expect(address).toBeInTheDocument();
   });
 
   test("should render properly without wallet data", async () => {
@@ -60,7 +56,6 @@ describe("ui/pages/Home/components/Info", () => {
     render(
       <Info
         {...defaultProps}
-        address={undefined}
         balance={undefined}
         chain={undefined}
         refreshConnectionStatus={mockRefreshConnectionStatus}

--- a/src/ui/pages/Home/useHome.ts
+++ b/src/ui/pages/Home/useHome.ts
@@ -1,4 +1,3 @@
-import BigNumber from "bignumber.js";
 import { useEffect, useCallback } from "react";
 
 import { useAppDispatch } from "@src/ui/ducks/hooks";
@@ -7,13 +6,11 @@ import { checkHostApproval } from "@src/ui/ducks/permissions";
 import { useEthWallet } from "@src/ui/hooks/wallet";
 import { getLastActiveTabUrl } from "@src/util/browser";
 
-import type { Chain, IdentityData } from "@src/types";
+import type { IdentityData } from "@src/types";
 
 export interface IUseHomeData {
   identities: IdentityData[];
   address?: string;
-  balance?: BigNumber;
-  chain?: Chain;
   refreshConnectionStatus: () => Promise<boolean>;
 }
 
@@ -21,7 +18,7 @@ export const useHome = (): IUseHomeData => {
   const dispatch = useAppDispatch();
   const identities = useIdentities();
 
-  const { address, chain, balance } = useEthWallet();
+  const { address } = useEthWallet();
 
   const refreshConnectionStatus = useCallback(async () => {
     const tabUrl = await getLastActiveTabUrl();
@@ -40,8 +37,6 @@ export const useHome = (): IUseHomeData => {
 
   return {
     address,
-    chain,
-    balance,
     identities,
     refreshConnectionStatus,
   };

--- a/src/ui/pages/Popup/__tests__/usePopup.test.ts
+++ b/src/ui/pages/Popup/__tests__/usePopup.test.ts
@@ -52,7 +52,7 @@ describe("ui/pages/Popup/usePopup", () => {
 
   const waitForData = async (current: IUsePopupData) => {
     await waitFor(() => current.isLoading === true);
-    await waitFor(() => expect(mockDispatch).toBeCalledTimes(3));
+    await waitFor(() => expect(mockDispatch).toBeCalledTimes(2));
     await waitFor(() => current.isLoading === false);
   };
 
@@ -95,11 +95,26 @@ describe("ui/pages/Popup/usePopup", () => {
     await waitForData(result.current);
 
     expect(result.current.isLoading).toBe(false);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchStatus).toBeCalledTimes(1);
+    expect(fetchPendingRequests).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnectEagerly).toBeCalledTimes(2);
+  });
+
+  test("should get selected account properly when mnemonic generated", async () => {
+    (useAppStatus as jest.Mock).mockReturnValue({ isInitialized: true, isUnlocked: true, isMnemonicGenerated: true });
+
+    const { result } = renderHook(() => usePopup());
+
+    await waitFor(() => result.current.isLoading === true);
+    await waitFor(() => expect(mockDispatch).toBeCalledTimes(3));
+    await waitFor(() => result.current.isLoading === false);
+
+    expect(result.current.isLoading).toBe(false);
     expect(mockDispatch).toBeCalledTimes(3);
     expect(fetchStatus).toBeCalledTimes(1);
     expect(fetchPendingRequests).toBeCalledTimes(1);
     expect(getSelectedAccount).toBeCalledTimes(1);
-    expect(defaultWalletHookData.onConnectEagerly).toBeCalledTimes(2);
   });
 
   test("should handle load data error", async () => {

--- a/src/ui/pages/Popup/__tests__/usePopup.test.ts
+++ b/src/ui/pages/Popup/__tests__/usePopup.test.ts
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 
 import { defaultWalletHookData } from "@src/config/mock/wallet";
 import { Paths } from "@src/constants";
-import { fetchStatus, useAppStatus } from "@src/ui/ducks/app";
+import { fetchStatus, getSelectedAccount, useAppStatus } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchPendingRequests, usePendingRequests } from "@src/ui/ducks/requests";
 import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
@@ -21,6 +21,7 @@ jest.mock("react-router-dom", (): unknown => ({
 
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   fetchStatus: jest.fn(),
+  getSelectedAccount: jest.fn(),
   useAppStatus: jest.fn(),
 }));
 
@@ -51,7 +52,7 @@ describe("ui/pages/Popup/usePopup", () => {
 
   const waitForData = async (current: IUsePopupData) => {
     await waitFor(() => current.isLoading === true);
-    await waitFor(() => expect(mockDispatch).toBeCalledTimes(2));
+    await waitFor(() => expect(mockDispatch).toBeCalledTimes(3));
     await waitFor(() => current.isLoading === false);
   };
 
@@ -94,9 +95,10 @@ describe("ui/pages/Popup/usePopup", () => {
     await waitForData(result.current);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(2);
+    expect(mockDispatch).toBeCalledTimes(3);
     expect(fetchStatus).toBeCalledTimes(1);
     expect(fetchPendingRequests).toBeCalledTimes(1);
+    expect(getSelectedAccount).toBeCalledTimes(1);
     expect(defaultWalletHookData.onConnectEagerly).toBeCalledTimes(2);
   });
 

--- a/src/ui/pages/Popup/usePopup.ts
+++ b/src/ui/pages/Popup/usePopup.ts
@@ -32,8 +32,12 @@ export const usePopup = (): IUsePopupData => {
   const redirect = useMemo(() => redirectParam && REDIRECT_PATHS[redirectParam], [redirectParam, window.location.href]);
 
   const fetchData = useCallback(async () => {
-    await Promise.all([dispatch(fetchStatus()), dispatch(fetchPendingRequests()), dispatch(getSelectedAccount())]);
-  }, [dispatch]);
+    await Promise.all([dispatch(fetchStatus()), dispatch(fetchPendingRequests())]);
+
+    if (isUnlocked && isMnemonicGenerated) {
+      await dispatch(getSelectedAccount());
+    }
+  }, [isUnlocked, isMnemonicGenerated, dispatch]);
 
   useEffect(() => {
     if (isLoading) {

--- a/src/ui/pages/Popup/usePopup.ts
+++ b/src/ui/pages/Popup/usePopup.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
-import { fetchStatus, useAppStatus } from "@src/ui/ducks/app";
+import { fetchStatus, getSelectedAccount, useAppStatus } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchPendingRequests, usePendingRequests } from "@src/ui/ducks/requests";
 import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
@@ -32,7 +32,7 @@ export const usePopup = (): IUsePopupData => {
   const redirect = useMemo(() => redirectParam && REDIRECT_PATHS[redirectParam], [redirectParam, window.location.href]);
 
   const fetchData = useCallback(async () => {
-    await Promise.all([dispatch(fetchStatus()), dispatch(fetchPendingRequests())]);
+    await Promise.all([dispatch(fetchStatus()), dispatch(fetchPendingRequests()), dispatch(getSelectedAccount())]);
   }, [dispatch]);
 
   useEffect(() => {


### PR DESCRIPTION
## Explanation

This PR adds support for switching cryptkeeper addresses.

Details are below:
- [x] Support wallet service for account changing
- [x] Support ui to change cryptkeeper account

## More Information

Closes #377 
Closes #333
Blocked by #418

## Screenshots/Screencaps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
