### PR TITLE
feat: associate random identity with user address

### DIFF
--- a/e2e/pages/cryptKeeper/Identities.ts
+++ b/e2e/pages/cryptKeeper/Identities.ts
@@ -50,7 +50,7 @@ export default class Identities extends BasePage {
 
     await cryptKeeper.getByRole("button", { name: walletType === "eth" ? "Metamask" : "Cryptkeeper" }).click();
 
-    if (identityType !== "Random" && walletType === "eth") {
+    if (walletType === "eth") {
       // TODO: synpress doesn't support new data-testid for metamask
       const metamask = await this.page.context().waitForEvent("page");
 

--- a/src/background/services/zkIdentity/__test__/factory.test.ts
+++ b/src/background/services/zkIdentity/__test__/factory.test.ts
@@ -29,7 +29,7 @@ describe("background/services/zkIdentity/factory", () => {
     });
 
     expect(identity.metadata).toStrictEqual({
-      account: "",
+      account: ZERO_ADDRESS,
       identityStrategy: "random",
       name: "name",
     });

--- a/src/background/services/zkIdentity/factory/index.ts
+++ b/src/background/services/zkIdentity/factory/index.ts
@@ -27,11 +27,11 @@ function createInterrepIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphor
 }
 
 function createRandomIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphore {
-  const { identityStrategy, name } = config;
+  const { identityStrategy, name, account } = config;
   const identity = new Identity();
 
   return new ZkIdentitySemaphore(identity, {
-    account: "",
+    account,
     name,
     identityStrategy,
   });

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -257,7 +257,7 @@ export default class ZkIdentityService implements IBackupable {
     messageSignature,
     options,
   }: NewIdentityRequest): Promise<string | undefined> => {
-    if (walletType === EWallet.ETH_WALLET && !messageSignature && strategy !== "random") {
+    if (walletType === EWallet.ETH_WALLET && !messageSignature) {
       throw new Error("No signature provided");
     }
 

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -116,11 +116,11 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onCreateWithEthWallet()));
 
     expect(result.current.isLoading).toBe(false);
-    expect(signWithSigner).toBeCalledTimes(0);
+    expect(signWithSigner).toBeCalledTimes(1);
     expect(mockDispatch).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
-      messageSignature: undefined,
+      messageSignature: mockSignedMessage,
       options: { account: ZERO_ADDRESS, message: mockMessage },
       strategy: "random",
       walletType: EWallet.ETH_WALLET,

--- a/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -84,7 +84,7 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
             : { message, account: account as string };
 
         const messageSignature =
-          walletType === EWallet.ETH_WALLET && identityStrategyType.value !== "random"
+          walletType === EWallet.ETH_WALLET
             ? await signWithSigner({ signer: await ethWallet.provider?.getSigner(), message })
             : undefined;
 

--- a/src/ui/pages/Home/components/IdentityList/Item/index.tsx
+++ b/src/ui/pages/Home/components/IdentityList/Item/index.tsx
@@ -71,6 +71,7 @@ export const IdentityItem = ({
 
   const features = getEnabledFeatures();
   const identityTitle = features.INTERREP_IDENTITY ? "random" : "";
+  const canShowIdentityType = Boolean(metadata.web2Provider || identityTitle);
 
   return (
     <div key={commitment} className="p-4 identity-row">
@@ -109,21 +110,21 @@ export const IdentityItem = ({
           <div className="flex flex-row items-center text-lg font-semibold">
             {`${metadata.name}`}
 
-            <span className="text-xs py-1 px-2 ml-2 rounded-full bg-gray-500 text-gray-800">
-              {metadata.web2Provider ? (
-                <FontAwesomeIcon icon={web2ProvidersIcons[metadata.web2Provider]} title={metadata.web2Provider} />
-              ) : (
-                identityTitle
-              )}
-            </span>
+            {canShowIdentityType && (
+              <span className="text-xs py-1 px-2 ml-2 rounded-full bg-gray-500 text-gray-800">
+                {metadata.web2Provider ? (
+                  <FontAwesomeIcon icon={web2ProvidersIcons[metadata.web2Provider]} title={metadata.web2Provider} />
+                ) : (
+                  identityTitle
+                )}
+              </span>
+            )}
           </div>
         )}
 
         <div className="text-base text-gray-300">Commitment: {ellipsify(commitment)}</div>
 
-        {metadata.identityStrategy !== "random" && metadata.account && (
-          <div className="text-xs text-gray-500">Address: {ellipsify(metadata.account)}</div>
-        )}
+        {metadata.account && <div className="text-xs text-gray-500">Address: {ellipsify(metadata.account)}</div>}
       </div>
 
       <Menuable

--- a/src/ui/pages/Home/components/IdentityList/__tests__/IdentityItem.test.tsx
+++ b/src/ui/pages/Home/components/IdentityList/__tests__/IdentityItem.test.tsx
@@ -64,6 +64,25 @@ describe("ui/pages/Home/components/IdentityList/Item", () => {
     expect(name).toBeInTheDocument();
   });
 
+  test("should render random identity properly with enabled interrep identity", async () => {
+    render(
+      <IdentityItem
+        {...defaultProps}
+        metadata={{
+          ...defaultProps.metadata,
+          web2Provider: undefined,
+          identityStrategy: "random",
+        }}
+      />,
+    );
+
+    const name = await screen.findByText(defaultProps.metadata.name);
+    const random = await screen.findByText("random");
+
+    expect(name).toBeInTheDocument();
+    expect(random).toBeInTheDocument();
+  });
+
   test("should accept to delete identity properly", async () => {
     render(<IdentityItem {...defaultProps} />);
 


### PR DESCRIPTION
## Explanation

This PR adds support for adding signing account for random identities

## More Information

Related to #333 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

1. Try to create identity with metamask and cryptkeeper
2. See address is appeared for random identities 

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
