### PR TITLE
feat: connect identity integration ui 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/fontawesome-common-types": "^6.4.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@interep/identity": "^0.3.0",
         "@metamask/providers": "^11.0.0",
@@ -3680,6 +3681,18 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
       "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
@@ -28612,6 +28625,14 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
       "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@fortawesome/fontawesome-common-types": "^6.4.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@interep/identity": "^0.3.0",
     "@metamask/providers": "^11.0.0",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,6 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
+import { faLink } from "@fortawesome/free-solid-svg-icons";
 import "@testing-library/jest-dom";
 import "isomorphic-fetch";
 
@@ -8,7 +9,7 @@ import type { ReactElement } from "react";
 
 jest.retryTimes(1, { logErrorsBeforeRetry: true });
 
-library.add(faTwitter, faGithub, faReddit);
+library.add(faTwitter, faGithub, faReddit, faLink);
 
 jest.mock("loglevel", () => ({
   info: jest.fn(),

--- a/src/ui/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/src/ui/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
 import { render, screen } from "@testing-library/react";
 import selectEvent from "react-select-event";
 
@@ -20,8 +18,6 @@ describe("ui/components/Dropdown", () => {
   };
 
   afterEach(() => {
-    library.add(faTwitter, faGithub, faReddit);
-
     jest.resetAllMocks();
   });
 

--- a/src/ui/components/IdentityList/IdentityList.tsx
+++ b/src/ui/components/IdentityList/IdentityList.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import classNames from "classnames";
 import { useCallback } from "react";
 
@@ -44,6 +45,14 @@ export const IdentityList = ({
   const onCreateIdentityRequest = useCallback(() => {
     dispatch(createIdentityRequest());
   }, [dispatch]);
+
+  if (identities.length === 0) {
+    return (
+      <Box className="identities-content" sx={{ textAlign: "center", my: 2 }}>
+        No identities available
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/src/ui/components/IdentityList/IdentityList.tsx
+++ b/src/ui/components/IdentityList/IdentityList.tsx
@@ -1,4 +1,4 @@
-import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import classNames from "classnames";
 import { useCallback } from "react";
 
@@ -46,14 +46,6 @@ export const IdentityList = ({
     dispatch(createIdentityRequest());
   }, [dispatch]);
 
-  if (identities.length === 0) {
-    return (
-      <Box className="identities-content" sx={{ textAlign: "center", my: 2 }}>
-        No identities available
-      </Box>
-    );
-  }
-
   return (
     <>
       <div className="identities-content">
@@ -69,6 +61,10 @@ export const IdentityList = ({
             onUpdateIdentityName={onUpdateIdentityName}
           />
         ))}
+
+        {identities.length === 0 && (
+          <Typography sx={{ my: 2, textAlign: "center" }}>No identities available</Typography>
+        )}
       </div>
 
       {isShowAddNew && (

--- a/src/ui/components/IdentityList/Item/index.tsx
+++ b/src/ui/components/IdentityList/Item/index.tsx
@@ -1,5 +1,6 @@
 import { IconName, IconPrefix } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Box from "@mui/material/Box";
 import classNames from "classnames";
 import { ChangeEvent, FormEvent, MouseEvent as ReactMouseEvent, useCallback, useState } from "react";
 
@@ -9,6 +10,7 @@ import { Icon } from "@src/ui/components/Icon";
 import { Input } from "@src/ui/components/Input";
 import { Menuable } from "@src/ui/components/Menuable";
 import { ellipsify } from "@src/util/account";
+import { redirectToNewTab } from "@src/util/browser";
 
 import "./identityListItemStyles.scss";
 
@@ -71,6 +73,10 @@ export const IdentityItem = ({
     [commitment, name, onUpdateIdentityName],
   );
 
+  const handleGoToHost = useCallback(() => {
+    redirectToNewTab(metadata.host as string);
+  }, [metadata.host]);
+
   const features = getEnabledFeatures();
   const identityTitle = features.INTERREP_IDENTITY ? "random" : "";
   const canShowIdentityType = Boolean(metadata.web2Provider || identityTitle);
@@ -120,6 +126,16 @@ export const IdentityItem = ({
                   identityTitle
                 )}
               </span>
+            )}
+
+            {metadata.host && (
+              <Box
+                className="text-xs py-1 px-2 ml-2 rounded-full bg-gray-500 text-gray-800"
+                data-testid="host-icon"
+                onClick={handleGoToHost}
+              >
+                <FontAwesomeIcon icon="link" title={metadata.host} />
+              </Box>
             )}
           </div>
         )}

--- a/src/ui/components/IdentityList/__tests__/IdentityItem.test.tsx
+++ b/src/ui/components/IdentityList/__tests__/IdentityItem.test.tsx
@@ -2,14 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { ZERO_ADDRESS } from "@src/config/const";
 import { getEnabledFeatures } from "@src/config/features";
+import { redirectToNewTab } from "@src/util/browser";
 
 import { IdentityItem, IdentityItemProps } from "../Item";
+
+jest.mock("@src/util/browser", (): unknown => ({
+  redirectToNewTab: jest.fn(),
+}));
 
 describe("ui/components/IdentityList/Item", () => {
   const defaultProps: IdentityItemProps = {
@@ -38,8 +41,6 @@ describe("ui/components/IdentityList/Item", () => {
   });
 
   test("should render properly", async () => {
-    library.add(faTwitter);
-
     render(<IdentityItem {...defaultProps} isShowMenu={false} />);
 
     const name = await screen.findByText(defaultProps.metadata.name);
@@ -162,5 +163,15 @@ describe("ui/components/IdentityList/Item", () => {
 
     expect(defaultProps.onUpdateIdentityName).toBeCalledTimes(1);
     expect(defaultProps.onUpdateIdentityName).toBeCalledWith(defaultProps.commitment, "Account #1");
+  });
+
+  test("should go to host properly", async () => {
+    render(<IdentityItem {...defaultProps} />);
+
+    const icon = await screen.findByTestId("host-icon");
+    await act(() => Promise.resolve(icon.click()));
+
+    expect(redirectToNewTab).toBeCalledTimes(1);
+    expect(redirectToNewTab).toBeCalledWith(defaultProps.metadata.host);
   });
 });

--- a/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { ZERO_ADDRESS } from "@src/config/const";
@@ -59,8 +57,6 @@ describe("ui/components/IdentityList", () => {
   };
 
   beforeEach(() => {
-    library.add(faTwitter, faGithub, faReddit);
-
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
     (useIdentities as jest.Mock).mockReturnValue(defaultIdentities);
@@ -78,6 +74,14 @@ describe("ui/components/IdentityList", () => {
 
     expect(identityName1).toBeInTheDocument();
     expect(identityName2).toBeInTheDocument();
+  });
+
+  test("should render without identities properly", async () => {
+    render(<IdentityList {...defaultProps} identities={[]} />);
+
+    const empty = await screen.findByText("No identities available");
+
+    expect(empty).toBeInTheDocument();
   });
 
   test("should select identity properly", async () => {

--- a/src/ui/components/IdentityList/identityListStyles.scss
+++ b/src/ui/components/IdentityList/identityListStyles.scss
@@ -3,7 +3,7 @@
 .identities-content {
   overflow-x: hidden;
   overflow-y: auto;
-  height: 330px;
+  height: 355px;
   width: 100%;
   scrollbar-width: none;
 

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -35,6 +35,8 @@ import {
   useHistorySettings,
   setSettings,
   enableHistory,
+  useLinkedIdentities,
+  useUnlinkedIdentities,
 } from "../identities";
 
 jest.unmock("@src/ui/ducks/hooks");
@@ -50,6 +52,16 @@ describe("ui/ducks/identities", () => {
         web2Provider: "twitter",
         groups: [],
         host: "http://localhost:3000",
+      },
+    },
+    {
+      commitment: "2",
+      metadata: {
+        account: ZERO_ADDRESS,
+        name: "Account #2",
+        identityStrategy: "interrep",
+        web2Provider: "twitter",
+        groups: [],
       },
     },
   ];
@@ -82,12 +94,20 @@ describe("ui/ducks/identities", () => {
     const identitiesHookData = renderHook(() => useIdentities(), {
       wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
     });
+    const linkedIdentitiesHookData = renderHook(() => useLinkedIdentities(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+    const unlinkedIdentitiesHookData = renderHook(() => useUnlinkedIdentities(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
     const selectedIdentityHookData = renderHook(() => useSelectedIdentity(), {
       wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
     });
 
     expect(identities.identities).toStrictEqual(defaultIdentities);
     expect(identitiesHookData.result.current).toStrictEqual(defaultIdentities);
+    expect(linkedIdentitiesHookData.result.current).toStrictEqual(defaultIdentities.slice(0, 1));
+    expect(unlinkedIdentitiesHookData.result.current).toStrictEqual(defaultIdentities.slice(1));
     expect(selectedIdentityHookData.result.current).toStrictEqual(defaultIdentities[0]);
   });
 

--- a/src/ui/ducks/identities.ts
+++ b/src/ui/ducks/identities.ts
@@ -156,6 +156,12 @@ export const enableHistory =
 
 export const useIdentities = (): IdentityData[] => useAppSelector((state) => state.identities.identities, deepEqual);
 
+export const useLinkedIdentities = (): IdentityData[] =>
+  useAppSelector((state) => state.identities.identities.filter((identity) => identity.metadata.host), deepEqual);
+
+export const useUnlinkedIdentities = (): IdentityData[] =>
+  useAppSelector((state) => state.identities.identities.filter((identity) => !identity.metadata.host), deepEqual);
+
 export const useSelectedIdentity = (): IdentityData | undefined =>
   useAppSelector((state) => {
     const { identities, selected } = state.identities;

--- a/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
+++ b/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
@@ -81,7 +81,7 @@ const ConnectIdentity = (): JSX.Element => {
           Reject
         </Button>
 
-        <Button sx={{ ml: 1 }} variant="contained" onClick={onConnect}>
+        <Button disabled={!selectedIdentityCommitment} sx={{ ml: 1 }} variant="contained" onClick={onConnect}>
           Connect
         </Button>
       </FullModalFooter>

--- a/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
+++ b/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
@@ -21,7 +21,7 @@ describe("ui/pages/ConnectIdentity", () => {
     host: "http://localhost:3000",
     faviconUrl: "",
     selectedTab: EConnectIdentityTabs.LINKED,
-    isShowTabs: true,
+    selectedIdentityCommitment: "1234",
     linkedIdentities: [
       {
         commitment: "1234",

--- a/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
+++ b/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
@@ -7,8 +7,10 @@ import { getLinkPreview } from "link-preview-js";
 import { SyntheticEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { ZERO_ADDRESS } from "@src/config/const";
 import { closePopup } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { fetchIdentities, useLinkedIdentities, useUnlinkedIdentities } from "@src/ui/ducks/identities";
 
 import { EConnectIdentityTabs, IUseConnectIdentityData, useConnectIdentity } from "../useConnectIdentity";
 
@@ -30,14 +32,49 @@ jest.mock("@src/ui/ducks/app", (): unknown => ({
   closePopup: jest.fn(),
 }));
 
+jest.mock("@src/ui/ducks/identities", (): unknown => ({
+  fetchIdentities: jest.fn(),
+  useLinkedIdentities: jest.fn(),
+  useUnlinkedIdentities: jest.fn(),
+}));
+
 describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
   const mockNavigate = jest.fn();
+
+  const defaultLinkedIdentities = [
+    {
+      commitment: "1234",
+      metadata: {
+        identityStrategy: "random",
+        account: ZERO_ADDRESS,
+        name: "Account #1",
+        groups: [],
+        host: "http://localhost:3000",
+      },
+    },
+  ];
+
+  const defaultUnlinkedIdentities = [
+    {
+      commitment: "4321",
+      metadata: {
+        identityStrategy: "random",
+        account: ZERO_ADDRESS,
+        name: "Account #2",
+        groups: [],
+      },
+    },
+  ];
 
   beforeEach(() => {
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useLinkedIdentities as jest.Mock).mockReturnValue(defaultLinkedIdentities);
+
+    (useUnlinkedIdentities as jest.Mock).mockReturnValue(defaultUnlinkedIdentities);
   });
 
   afterEach(() => {
@@ -46,6 +83,8 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
 
   const waitForData = async (current: IUseConnectIdentityData) => {
     await waitFor(() => current.faviconUrl !== "");
+    await waitFor(() => expect(mockDispatch).toBeCalledTimes(1));
+    await waitFor(() => expect(fetchIdentities).toBeCalledTimes(1));
   };
 
   test("should return initial data", async () => {
@@ -55,9 +94,8 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
     expect(result.current.host).toBe("http://localhost:3000");
     expect(result.current.faviconUrl).toBe("http://localhost:3000/favicon.ico");
     expect(result.current.selectedTab).toBe(EConnectIdentityTabs.LINKED);
-    expect(result.current.isShowTabs).toBe(true);
-    expect(result.current.linkedIdentities).toHaveLength(1);
-    expect(result.current.unlinkedIdentities).toHaveLength(1);
+    expect(result.current.linkedIdentities).toStrictEqual(defaultLinkedIdentities);
+    expect(result.current.unlinkedIdentities).toStrictEqual(defaultUnlinkedIdentities);
   });
 
   test("should handle empty favicon properly", () => {
@@ -74,7 +112,8 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onReject()));
 
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchIdentities).toBeCalledTimes(1);
     expect(closePopup).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(-1);
@@ -91,6 +130,26 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
     await waitFor(() => result.current.selectedTab === EConnectIdentityTabs.UNLINKED);
 
     expect(result.current.selectedTab).toBe(EConnectIdentityTabs.UNLINKED);
+  });
+
+  test("should change tab if there is no linked identities", async () => {
+    (useLinkedIdentities as jest.Mock).mockReturnValue([]);
+
+    const { result } = renderHook(() => useConnectIdentity());
+    await waitForData(result.current);
+    await waitFor(() => result.current.selectedTab === EConnectIdentityTabs.UNLINKED);
+
+    expect(result.current.selectedTab).toBe(EConnectIdentityTabs.UNLINKED);
+  });
+
+  test("should change tab if there is no unlinked identities", async () => {
+    (useUnlinkedIdentities as jest.Mock).mockReturnValue([]);
+
+    const { result } = renderHook(() => useConnectIdentity());
+    await waitForData(result.current);
+    await waitFor(() => result.current.selectedTab === EConnectIdentityTabs.LINKED);
+
+    expect(result.current.selectedTab).toBe(EConnectIdentityTabs.LINKED);
   });
 
   test("should select identity properly", async () => {

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -2,8 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useNavigate } from "react-router-dom";
 import selectEvent from "react-select-event";
@@ -54,8 +52,6 @@ describe("ui/pages/CreateIdentity", () => {
   const mockNavigate = jest.fn();
 
   beforeEach(() => {
-    library.add(faTwitter, faGithub, faReddit);
-
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
     (useCryptKeeperWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -1,5 +1,6 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTwitter, faGithub, faReddit } from "@fortawesome/free-brands-svg-icons";
+import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { ThemeProvider } from "@mui/material/styles";
 import { AnyAction } from "@reduxjs/toolkit";
 import { Web3ReactProvider } from "@web3-react/core";
@@ -40,7 +41,7 @@ browser.tabs.query({ active: true, currentWindow: true }).then(() => {
 
   const root = ReactDOM.createRoot(document.getElementById("popup") as HTMLElement);
 
-  library.add(faTwitter, faGithub, faReddit);
+  library.add(faTwitter, faGithub, faReddit, faLink);
 
   root.render(
     <Provider store={store}>

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -58,9 +58,13 @@ export const theme = createTheme({
 
     MuiButton: {
       styleOverrides: {
-        root: {
+        root: ({ ownerState }) => ({
           textTransform: "none",
-        },
+
+          "&:disabled": {
+            backgroundColor: ownerState.variant === "contained" ? grey[400] : "inherit",
+          },
+        }),
       },
     },
 


### PR DESCRIPTION
## Explanation

This PR adds support for linked and unlinked identities and is a part of #445.

Details are below:
- [x] Add host icon for identity list item
- [x] Add linked and unlinked identity selectors

## More Information

Blocked by #467
Related to #445 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
