### PR TITLE
feat: create identity from connect screen

### DIFF
--- a/src/background/services/zkIdentity/factory/index.ts
+++ b/src/background/services/zkIdentity/factory/index.ts
@@ -29,8 +29,9 @@ function createInterrepIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphor
 }
 
 function createRandomIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphore {
-  const { identityStrategy, name, account, groups, host } = config;
-  const identity = new Identity();
+  const { identityStrategy, name, messageSignature, account, groups, host } = config;
+
+  const identity = new Identity(messageSignature);
 
   return new ZkIdentitySemaphore(identity, {
     account,

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -312,8 +312,6 @@ export default class ZkIdentityService implements IBackupable {
       throw new Error("Identity is already exist. Try to change nonce or identity data.");
     }
 
-    await this.browserController.closePopup();
-
     return identity.genIdentityCommitment().toString();
   };
 

--- a/src/ui/components/IdentityList/IdentityList.tsx
+++ b/src/ui/components/IdentityList/IdentityList.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import classNames from "classnames";
 import { useCallback } from "react";
@@ -45,6 +46,14 @@ export const IdentityList = ({
   const onCreateIdentityRequest = useCallback(() => {
     dispatch(createIdentityRequest());
   }, [dispatch]);
+
+  if (identities.length === 0) {
+    return (
+      <Box className="identities-content" sx={{ textAlign: "center", my: 2 }}>
+        No identities available
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/src/ui/components/IdentityList/IdentityList.tsx
+++ b/src/ui/components/IdentityList/IdentityList.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import classNames from "classnames";
 import { useCallback } from "react";
@@ -46,14 +45,6 @@ export const IdentityList = ({
   const onCreateIdentityRequest = useCallback(() => {
     dispatch(createIdentityRequest());
   }, [dispatch]);
-
-  if (identities.length === 0) {
-    return (
-      <Box className="identities-content" sx={{ textAlign: "center", my: 2 }}>
-        No identities available
-      </Box>
-    );
-  }
 
   return (
     <>

--- a/src/ui/ducks/__tests__/identities.test.tsx
+++ b/src/ui/ducks/__tests__/identities.test.tsx
@@ -230,6 +230,8 @@ describe("ui/ducks/identities", () => {
         strategy: "interrep",
         messageSignature: "signature",
         walletType: EWallet.ETH_WALLET,
+        groups: [],
+        host: "http://localhost:3000",
         options: { message: "message", account: ZERO_ADDRESS },
       },
     });

--- a/src/ui/ducks/identities.ts
+++ b/src/ui/ducks/identities.ts
@@ -73,7 +73,7 @@ export const createIdentityRequest = () => async (): Promise<void> => {
 };
 
 export const createIdentity =
-  ({ walletType, strategy, messageSignature, options }: ICreateIdentityUiArgs) =>
+  ({ walletType, strategy, messageSignature, groups, host, options }: ICreateIdentityUiArgs) =>
   async (): Promise<string | undefined> =>
     postMessage({
       method: RPCAction.CREATE_IDENTITY,
@@ -81,6 +81,8 @@ export const createIdentity =
         strategy,
         walletType,
         messageSignature,
+        groups,
+        host,
         options,
       },
     });

--- a/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
+++ b/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
@@ -3,7 +3,9 @@ import Button from "@mui/material/Button";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
+import { NavLink } from "react-router-dom";
 
+import { Paths } from "@src/constants";
 import { FullModal, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
 import { IdentityList } from "@src/ui/components/IdentityList";
 import { SiteFavicon } from "@src/ui/components/SiteFavicon/SiteFavicon";
@@ -36,10 +38,13 @@ const ConnectIdentity = (): JSX.Element => {
             {`${host} would like to connect to your identity`}
           </Typography>
 
-          <Typography sx={{ color: "text.secondary", mb: 2, textAlign: "center" }}>
-            {/* add identity creation support */}
-            Please choose one to connect with or choose to create a new identity
-          </Typography>
+          <Box sx={{ mb: 2, mx: 2, textAlign: "center" }}>
+            <Typography sx={{ color: "text.secondary", mr: 1, display: "inline" }}>
+              Please choose one to connect with or choose to
+            </Typography>
+
+            <NavLink to={`${Paths.CREATE_IDENTITY}?back=true`}>create a new identity</NavLink>
+          </Box>
         </Box>
 
         <Tabs

--- a/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
+++ b/src/ui/pages/ConnectIdentity/ConnectIdentity.tsx
@@ -43,7 +43,7 @@ const ConnectIdentity = (): JSX.Element => {
               Please choose one to connect with or choose to
             </Typography>
 
-            <NavLink to={`${Paths.CREATE_IDENTITY}?back=true`}>create a new identity</NavLink>
+            <NavLink to={`${Paths.CREATE_IDENTITY}?back=true&host=${host}`}>create a new identity</NavLink>
           </Box>
         </Box>
 

--- a/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
+++ b/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
@@ -73,6 +73,15 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
     },
   ];
 
+  const oldHref = window.location.href;
+
+  Object.defineProperty(window, "location", {
+    value: {
+      href: oldHref,
+    },
+    writable: true,
+  });
+
   beforeEach(() => {
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
@@ -81,10 +90,14 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
     (useLinkedIdentities as jest.Mock).mockReturnValue(defaultLinkedIdentities);
 
     (useUnlinkedIdentities as jest.Mock).mockReturnValue(defaultUnlinkedIdentities);
+
+    window.location.href = `${oldHref}?host=http://localhost:3000`;
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+
+    window.location.href = oldHref;
   });
 
   const waitForData = async (current: IUseConnectIdentityData) => {

--- a/src/ui/pages/ConnectIdentity/useConnectIdentity.ts
+++ b/src/ui/pages/ConnectIdentity/useConnectIdentity.ts
@@ -1,5 +1,5 @@
 import { getLinkPreview } from "link-preview-js";
-import { type SyntheticEvent, useState, useCallback, useEffect } from "react";
+import { type SyntheticEvent, useState, useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { closePopup } from "@src/ui/ducks/app";
@@ -32,8 +32,9 @@ export enum EConnectIdentityTabs {
 }
 
 export const useConnectIdentity = (): IUseConnectIdentityData => {
-  // get data
-  const host = "http://localhost:3000";
+  const { searchParams } = new URL(window.location.href.replace("#", ""));
+  const host = useMemo(() => searchParams.get("host") as string, [searchParams.toString()]);
+
   const linkedIdentities = useLinkedIdentities(host);
   const unlinkedIdentities = useUnlinkedIdentities();
 

--- a/src/ui/pages/CreateIdentity/CreateIdentity.tsx
+++ b/src/ui/pages/CreateIdentity/CreateIdentity.tsx
@@ -34,7 +34,7 @@ const CreateIdentity = (): JSX.Element => {
   return (
     <FullModal data-testid="create-identity-page" onClose={closeModal}>
       <form className="create-identity-form">
-        <FullModalHeader onClose={closeModal}>Create Identity</FullModalHeader>
+        <FullModalHeader onClose={closeModal}>Create identity</FullModalHeader>
 
         <FullModalContent>
           {features.INTERREP_IDENTITY ? (

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -52,6 +52,15 @@ describe("ui/pages/CreateIdentity", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
   const mockNavigate = jest.fn();
 
+  const oldHref = window.location.href;
+
+  Object.defineProperty(window, "location", {
+    value: {
+      href: oldHref,
+    },
+    writable: true,
+  });
+
   beforeEach(() => {
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
@@ -74,6 +83,7 @@ describe("ui/pages/CreateIdentity", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    window.location.href = oldHref;
 
     deleteModalRoot();
   });

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -10,8 +10,9 @@ import { ZERO_ADDRESS } from "@src/config/const";
 import { getEnabledFeatures } from "@src/config/features";
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
 import { defaultWalletHookData } from "@src/config/mock/wallet";
-import { IDENTITY_TYPES, WEB2_PROVIDER_OPTIONS } from "@src/constants";
+import { IDENTITY_TYPES, Paths, WEB2_PROVIDER_OPTIONS } from "@src/constants";
 import { EWallet } from "@src/types";
+import { closePopup } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";
 import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
@@ -142,7 +143,10 @@ describe("ui/pages/CreateIdentity", () => {
     await act(async () => Promise.resolve(fireEvent.click(button)));
 
     expect(signWithSigner).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(closePopup).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       groups: [],
@@ -164,7 +168,10 @@ describe("ui/pages/CreateIdentity", () => {
     await act(async () => Promise.resolve(fireEvent.click(button)));
 
     expect(signWithSigner).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(closePopup).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       groups: [],
@@ -206,7 +213,10 @@ describe("ui/pages/CreateIdentity", () => {
     await act(async () => Promise.resolve(fireEvent.click(button)));
 
     expect(signWithSigner).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(closePopup).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       strategy: "interrep",

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -144,7 +144,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
   test("should create identity properly and go back", async () => {
     (getEnabledFeatures as jest.Mock).mockReturnValue({ INTERREP_IDENTITY: false });
-    window.location.href = `${oldHref}?back=true`;
+    window.location.href = `${oldHref}?back=true&host=http://localhost:3000`;
 
     const { result } = renderHook(() => useCreateIdentity());
 
@@ -156,6 +156,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       groups: [],
+      host: "http://localhost:3000",
       messageSignature: mockSignedMessage,
       options: { account: ZERO_ADDRESS, message: mockMessage },
       strategy: "random",

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -152,8 +152,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(signWithSigner).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(mockDispatch).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledTimes(1);
     expect(createIdentity).toBeCalledWith({
       groups: [],
@@ -164,8 +163,6 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     });
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(-1);
-
-    window.location.href = oldHref;
   });
 
   test("should connect eth wallet properly", async () => {
@@ -218,6 +215,15 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(() => Promise.resolve(result.current.closeModal()));
 
     expect(mockDispatch).toBeCalledTimes(1);
+  });
+
+  test("should go back properly", async () => {
+    window.location.href = `${oldHref}?back=true`;
+
+    const { result } = renderHook(() => useCreateIdentity());
+
+    await act(() => Promise.resolve(result.current.closeModal()));
+
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(-1);
   });

--- a/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -102,13 +102,11 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
           }),
         );
 
-        await dispatch(closePopup()).then(() => {
-          if (isBackParam) {
-            navigate(-1);
-          } else {
-            navigate(Paths.HOME);
-          }
-        });
+        if (isBackParam) {
+          navigate(-1);
+        } else {
+          dispatch(closePopup()).then(() => navigate(Paths.HOME));
+        }
       } catch (err) {
         setError("root", { type: "submit", message: (err as Error).message });
       }
@@ -131,7 +129,11 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
   }, [setError, ethWallet.onConnect]);
 
   const closeModal = useCallback(() => {
-    dispatch(closePopup()).then(() => navigate(-1));
+    if (isBackParam) {
+      navigate(-1);
+    } else {
+      dispatch(closePopup());
+    }
   }, [isBackParam, navigate, dispatch]);
 
   return {


### PR DESCRIPTION
## Explanation

This PR is a part of #445 adds support for creating identities from connect screen.

Details are below:
- [x] Add message signature for random identity create process
- [x] Close popup on ui side for create identity screen
- [x] Add redirect which depends on url param for create identity page 

## More Information

Blocked by #450
Blocked by #474
Related to #445 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
