### PR TITLE
feat: delete connected identity

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -19,8 +19,20 @@ function NotConnected({ onClick }: INotConnectedProps) {
   );
 }
 
-function NoConnectedIdentityCommitment() {
-  return <div>Please set a connected identity in the Crypt-Keeper plugin to continue.</div>;
+interface NoConnectedIdentityCommitmentProps {
+  onCreateIdentity: () => void;
+}
+
+function NoConnectedIdentityCommitment({ onCreateIdentity }: NoConnectedIdentityCommitmentProps) {
+  return (
+    <div>
+      <p>Please set a connected identity in the Crypt-Keeper plugin to continue.</p>
+
+      <button data-testid="create-new-identity" onClick={onCreateIdentity}>
+        Create identity
+      </button>
+    </div>
+  );
 }
 
 function App() {
@@ -34,8 +46,8 @@ function App() {
     return <NotConnected onClick={connect} />;
   }
 
-  if (!connectedIdentity) {
-    return <NoConnectedIdentityCommitment />;
+  if (!connectedIdentity?.commitment) {
+    return <NoConnectedIdentityCommitment onCreateIdentity={createIdentity} />;
   }
 
   return (

--- a/e2e/tests/identity.test.ts
+++ b/e2e/tests/identity.test.ts
@@ -69,15 +69,18 @@ test.describe("identity", () => {
     await expect(extension.activityTab.getByText("Identity created")).toBeVisible();
 
     await extension.identitiesTab.openTab();
+    await extension.identitiesTab.createIdentity({ walletType: "ck" });
+    await expect(extension.getByText(/Account/)).toHaveCount(2);
+
     await extension.identitiesTab.deleteIdentity(0);
-    await expect(extension.getByText(/Account/)).toHaveCount(0);
+    await expect(extension.getByText(/Account/)).toHaveCount(1);
 
     await extension.activityTab.openTab();
     await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
 
     await extension.identitiesTab.openTab();
-    await extension.identitiesTab.createIdentity({ walletType: "ck" });
-    await expect(extension.getByText(/Account/)).toHaveCount(1);
+    await extension.identitiesTab.createIdentity({ walletType: "ck", identityType: "Random" });
+    await expect(extension.getByText(/Account/)).toHaveCount(2);
 
     await extension.settingsPage.openPage();
     await extension.settingsPage.openTab("Advanced");
@@ -99,12 +102,14 @@ test.describe("identity", () => {
     await extension.activityTab.openTab();
     await expect(extension.activityTab.getByText("Identity created")).toBeVisible();
 
-    await extension.identitiesTab.openTab();
-    await extension.identitiesTab.deleteIdentity(0);
-    await expect(extension.getByText(/Account/)).toHaveCount(0);
+    await extension.settingsPage.openPage();
+    await extension.settingsPage.openTab("Advanced");
+    await extension.settingsPage.deleteAllIdentities();
+
+    await extension.goHome();
 
     await extension.activityTab.openTab();
-    await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
+    await expect(extension.activityTab.getByText("All identities removed")).toBeVisible();
 
     await extension.activityTab.deleteOperation();
     await extension.activityTab.deleteOperation();
@@ -130,11 +135,11 @@ test.describe("identity", () => {
     await extension.settingsPage.toggleHistoryTracking();
 
     await extension.goHome();
-    await extension.identitiesTab.deleteIdentity();
-    await expect(extension.getByText(/Account/)).toHaveCount(0);
+    await extension.identitiesTab.createIdentity({ walletType: "eth" });
+    await expect(extension.getByText(/Account/)).toHaveCount(2);
 
     await extension.activityTab.openTab();
-    await expect(extension.activityTab.getByText("Identity removed")).toBeVisible();
+    await expect(extension.activityTab.getByText("Identity created")).toBeVisible();
 
     await extension.settingsPage.openPage();
     await extension.settingsPage.clearHistory();

--- a/src/ui/components/IdentityList/Item/index.tsx
+++ b/src/ui/components/IdentityList/Item/index.tsx
@@ -81,6 +81,11 @@ export const IdentityItem = ({
   const identityTitle = features.INTERREP_IDENTITY ? "random" : "";
   const canShowIdentityType = Boolean(metadata.web2Provider || identityTitle);
 
+  const menuItems = [
+    { label: "Rename", isDangerItem: false, onClick: handleToggleRenaming },
+    { label: "Delete", isDangerItem: true, onClick: handleDeleteIdentity },
+  ];
+
   return (
     <div key={commitment} className="p-4 identity-row">
       <Icon
@@ -146,13 +151,7 @@ export const IdentityItem = ({
       </div>
 
       {isShowMenu && (
-        <Menuable
-          className="flex user-menu"
-          items={[
-            { label: "Rename", isDangerItem: false, onClick: handleToggleRenaming },
-            { label: "Delete", isDangerItem: true, onClick: handleDeleteIdentity },
-          ]}
-        >
+        <Menuable className="flex user-menu" items={selected !== commitment ? menuItems : [menuItems[0]]}>
           <Icon className="identity-row__menu-icon" fontAwesome="fas fa-ellipsis-h" />
         </Menuable>
       )}

--- a/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -114,7 +114,7 @@ describe("ui/components/IdentityList", () => {
   });
 
   test("should accept to delete identity properly", async () => {
-    render(<IdentityList {...defaultProps} />);
+    render(<IdentityList {...defaultProps} selectedCommitment={undefined} />);
 
     const [menuIcon] = await screen.findAllByTestId("menu");
     act(() => menuIcon.click());
@@ -136,7 +136,7 @@ describe("ui/components/IdentityList", () => {
   });
 
   test("should reject to delete identity properly", async () => {
-    render(<IdentityList {...defaultProps} />);
+    render(<IdentityList {...defaultProps} selectedCommitment={undefined} />);
 
     const [menuIcon] = await screen.findAllByTestId("menu");
     act(() => menuIcon.click());

--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -68,11 +68,7 @@ const Settings = (): JSX.Element => {
 
             {tab === SettingsTabs.ADVANCED && (
               <>
-                <Advanced
-                  isLoading={isLoading}
-                  onDeleteIdentities={onDeleteAllIdentities}
-                  onGoToBackup={onGoToBackup}
-                />
+                <Advanced isLoading={isLoading} onDeleteIdentities={onConfirmModalShow} onGoToBackup={onGoToBackup} />
 
                 <ConfirmDangerModal
                   accept={onDeleteAllIdentities}


### PR DESCRIPTION
## Explanation

This PR is a part of #445 adds support for removing identities on demo and restricts deleting connected identities.

Details are below:
- [x] Connected identity can be only renamed
- [x] Show create identity screen on demo page where there is no any identity

## More Information

Related to #445 
Blocked by #490 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/ca8215f7-071c-476c-a584-e1dfbb03c17e)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/5b176e9c-ae66-482b-adaa-4f233d5b84d2)

## Manual Testing Steps

1. Connected identity can't be removed from identity list
2. After all identity removal from advanced settings page, demo page shows no connected identity screen.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
