### PR TITLE
fix: firefox launch

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -17,6 +17,13 @@
       "js": ["js/content.js"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "js": ["js/injected.js"],
+      "run_at": "document_start",
+      "all_frames": true,
+      "world": "MAIN"
     }
   ],
   "icons": {
@@ -30,6 +37,10 @@
   "permissions": ["scripting", "clipboardWrite", "activeTab", "storage", "notifications", "unlimitedStorage"],
   "host_permissions": ["http://*/", "https://*/"],
   "web_accessible_resources": [
+    {
+      "resources": ["js/content.js"],
+      "matches": ["*://*/*"]
+    },
     {
       "resources": ["js/injected.js"],
       "matches": ["*://*/*"]

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -16,6 +16,12 @@
       "js": ["js/content.js"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "js": ["js/injected.js"],
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "icons": {
@@ -29,6 +35,10 @@
   "permissions": ["scripting", "clipboardWrite", "activeTab", "storage", "notifications", "unlimitedStorage"],
   "host_permissions": ["http://*/", "https://*/"],
   "web_accessible_resources": [
+    {
+      "resources": ["js/content.js"],
+      "matches": ["*://*/*"]
+    },
     {
       "resources": ["js/injected.js"],
       "matches": ["*://*/*"]

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "redux-thunk": "^2.4.2",
     "rlnjs": "^2.0.8",
     "subworkers": "^1.0.1",
-    "webextension-polyfill-ts": "^0.26.0",
+    "webextension-polyfill": "^0.10.0",
     "yup": "^1.2.0"
   },
   "config": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,9 @@ dependencies:
   subworkers:
     specifier: ^1.0.1
     version: 1.0.1
-  webextension-polyfill-ts:
-    specifier: ^0.26.0
-    version: 0.26.0
+  webextension-polyfill:
+    specifier: ^0.10.0
+    version: 0.10.0
   yup:
     specifier: ^1.2.0
     version: 1.2.0

--- a/src/background/appInit.ts
+++ b/src/background/appInit.ts
@@ -3,6 +3,7 @@
 
 // TODO: importing scripts better using importScritps() check MM
 import log from "loglevel";
+import browser from "webextension-polyfill";
 
 import { isDebugMode } from "@src/config/env";
 
@@ -27,46 +28,12 @@ self.addEventListener("install", () => {
  * UI sends the message periodically, in a setInterval.
  * Chrome will revive the service worker if it was shut down, whenever a new message is sent, but only if a listener was defined here.
  *
- * chrome below needs to be replaced by cross-browser object,
- * but there is issue in importing webextension-polyfill into service worker.
- * chrome does seems to work in at-least all chromium based browsers
  */
-chrome.runtime.onMessage.addListener(() => {
+browser.runtime.onMessage.addListener(() => {
   importAllScripts();
-  return false;
 });
 
-chrome.runtime.onStartup.addListener(() => {
+browser.runtime.onStartup.addListener(() => {
   importAllScripts();
   globalThis.isFirstTimeProfileLoaded = true;
 });
-
-/*
- * This content script is injected programmatically because
- * MAIN world injection does not work properly via manifest
- * https://bugs.chromium.org/p/chromium/issues/detail?id=634381
- */
-const registerInjectedScript = async () => {
-  try {
-    await chrome.scripting.registerContentScripts([
-      {
-        id: "injectedProvider",
-        matches: ["file://*/*", "http://*/*", "https://*/*"],
-        js: ["js/injected.js"],
-        runAt: "document_start",
-        world: "MAIN",
-      },
-    ]);
-  } catch (err: unknown | string) {
-    /**
-     * An error occurs when app-init.js is reloaded. Attempts to avoid the duplicate script error:
-     * 1. registeringContentScripts inside runtime.onInstalled - This caused a race condition
-     *    in which the provider might not be loaded in time.
-     * 2. await chrome.scripting.getRegisteredContentScripts() to check for an existing
-     *    inpage script before registering - The provider is not loaded on time.
-     */
-    log.warn("Dropped attempt to register inpage content script.", err);
-  }
-};
-
-registerInjectedScript();

--- a/src/background/backgroundPage.ts
+++ b/src/background/backgroundPage.ts
@@ -1,6 +1,6 @@
 import log from "loglevel";
 import "subworkers";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import CryptKeeperController from "@src/background/cryptKeeper";
 import { deferredPromise } from "@src/background/shared/utils";

--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { InjectedMessageData, ReduxAction, ConnectedIdentity } from "@src/types";
 import { setStatus } from "@src/ui/ducks/app";

--- a/src/background/controllers/__tests__/browserUtils.test.ts
+++ b/src/background/controllers/__tests__/browserUtils.test.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import BrowserUtils from "../browserUtils";
 

--- a/src/background/controllers/browserUtils.ts
+++ b/src/background/controllers/browserUtils.ts
@@ -1,4 +1,4 @@
-import { browser, Windows } from "webextension-polyfill-ts";
+import browser, { Windows } from "webextension-polyfill";
 
 interface CreateWindowArgs {
   type: "popup";

--- a/src/background/services/backup/BackupService.ts
+++ b/src/background/services/backup/BackupService.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import HistoryService from "@src/background/services/history";
 import NotificationService from "@src/background/services/notification";

--- a/src/background/services/history/index.ts
+++ b/src/background/services/history/index.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import LockerService from "@src/background/services/lock";
 import NotificationService from "@src/background/services/notification";

--- a/src/background/services/injector/__tests__/injector.test.ts
+++ b/src/background/services/injector/__tests__/injector.test.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { PendingRequestType, RLNProofRequest, SemaphoreProofRequest } from "@src/types";
 

--- a/src/background/services/injector/index.ts
+++ b/src/background/services/injector/index.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import BrowserUtils from "@src/background/controllers/browserUtils";
 import RequestManager from "@src/background/controllers/requestManager";

--- a/src/background/services/lock/__tests__/lockerService.test.ts
+++ b/src/background/services/lock/__tests__/lockerService.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import SimpleStorage from "@src/background/services/storage";
 import { InitializationStep } from "@src/types";

--- a/src/background/services/lock/index.ts
+++ b/src/background/services/lock/index.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import {
   cryptoDecrypt,

--- a/src/background/services/notification/__tests__/notificationService.test.ts
+++ b/src/background/services/notification/__tests__/notificationService.test.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import NotificationService, { CreateNotificationArgs } from "..";
 

--- a/src/background/services/notification/index.ts
+++ b/src/background/services/notification/index.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 export interface CreateNotificationArgs {
   id?: string;

--- a/src/background/services/storage/__tests__/simpleStorage.test.ts
+++ b/src/background/services/storage/__tests__/simpleStorage.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import SimpleStorage from "..";
 

--- a/src/background/services/storage/index.ts
+++ b/src/background/services/storage/index.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 export default class SimpleStorage {
   private key: string;

--- a/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
+++ b/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { bigintToHex } from "bigint-conversion";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import SimpleStorage from "@src/background/services/storage";
 import ZkIdentityService from "@src/background/services/zkIdentity";

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -1,5 +1,5 @@
 import { bigintToHex } from "bigint-conversion";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import BrowserUtils from "@src/background/controllers/browserUtils";
 import { cryptoGenerateEncryptedHmac, cryptoGetAuthenticBackupCiphertext } from "@src/background/services/crypto";

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -47,14 +47,15 @@ jest.mock("@src/config/features", (): unknown => ({
 
 type Changes = Record<string, { oldValue: string | null; newValue: string | null }>;
 
-jest.mock("webextension-polyfill-ts", (): unknown => {
+jest.mock("webextension-polyfill", (): unknown => {
   const storageListeners: ((changes: Changes, namespace: string) => void)[] = [];
   const windowRemoveListeners: ((windowId: number) => void)[] = [];
   const namespace = "namespace";
   const defaultChanges = { key: { oldValue: null, newValue: null } };
 
   return {
-    browser: {
+    __esModule: true,
+    default: {
       tabs: {
         query: jest.fn().mockResolvedValue([]),
         sendMessage: jest.fn().mockResolvedValue(true),
@@ -77,6 +78,7 @@ jest.mock("webextension-polyfill-ts", (): unknown => {
 
       runtime: {
         connect: jest.fn(),
+        sendMessage: jest.fn(),
         getURL: jest.fn(),
       },
 

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -9,7 +9,7 @@ import { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { Provider } from "react-redux";
 import { HashRouter } from "react-router-dom";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { isDebugMode } from "@src/config/env";
 import { connectors } from "@src/connectors";

--- a/src/ui/services/provider/index.ts
+++ b/src/ui/services/provider/index.ts
@@ -1,7 +1,7 @@
 import { MetaMaskInpageProvider } from "@metamask/providers";
 import { detect } from "detect-browser";
 import PortStream from "extension-port-stream";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import type { Duplex } from "stream";
 

--- a/src/util/__tests__/browser.test.ts
+++ b/src/util/__tests__/browser.test.ts
@@ -3,7 +3,7 @@
  */
 
 /* eslint-disable @typescript-eslint/unbound-method */
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl, downloadFile, copyToClipboard } from "../browser";
 

--- a/src/util/__tests__/postMessage.test.ts
+++ b/src/util/__tests__/postMessage.test.ts
@@ -1,16 +1,8 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { RPCAction } from "@src/constants";
 
 import postMessage from "../postMessage";
-
-jest.mock("webextension-polyfill-ts", (): unknown => ({
-  browser: {
-    runtime: {
-      sendMessage: jest.fn(),
-    },
-  },
-}));
 
 jest.unmock("@src/util/postMessage");
 

--- a/src/util/__tests__/pushMessage.test.ts
+++ b/src/util/__tests__/pushMessage.test.ts
@@ -1,16 +1,8 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { RPCAction } from "@src/constants";
 
 import pushMessage from "../pushMessage";
-
-jest.mock("webextension-polyfill-ts", (): unknown => ({
-  browser: {
-    runtime: {
-      sendMessage: jest.fn(),
-    },
-  },
-}));
 
 jest.unmock("@src/util/pushMessage");
 

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 export const getLastActiveTabUrl = async (): Promise<URL | undefined> => {
   const [tab] = await browser.tabs.query({ active: true, lastFocusedWindow: true });

--- a/src/util/postMessage.ts
+++ b/src/util/postMessage.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import type { MessageAction } from "@src/types";
 

--- a/src/util/pushMessage.ts
+++ b/src/util/pushMessage.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 import { ReduxAction } from "@src/types";
 


### PR DESCRIPTION
## Explanation

This PR fixes firefox launch issue. However, user still needs to allow permissions on firefox extension settings to make cryptkeeper work. This is because host permissions in firefox are optional. 

Details are below:
- [x] Replace `webextension-polyfill-ts` with `webextension-polyfill`
- [x] Remove `scripting.registerContentScripts` and use manifest for content scripts
- [x] Firefox compatibility fixes

## More Information

Closes #500 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

Can launch in firefox

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
