### PR TITLE
feat: metamask connection indicator

### DIFF
--- a/e2e/tests/backup.test.ts
+++ b/e2e/tests/backup.test.ts
@@ -10,7 +10,7 @@ test.describe("backup", () => {
     await expect(page.getByTestId("home-page")).toBeVisible();
 
     await connectWallet({ page, cryptKeeperExtensionId, context });
-    await expect(page.getByText("Ethereum mainnet")).toBeVisible();
+    await expect(page.getByText("Connected to Metamask")).toBeVisible();
   });
 
   test("should download backup properly", async ({ page }) => {

--- a/e2e/tests/identity.test.ts
+++ b/e2e/tests/identity.test.ts
@@ -10,7 +10,7 @@ test.describe("identity", () => {
     await expect(page.getByTestId("home-page")).toBeVisible();
 
     await connectWallet({ page, cryptKeeperExtensionId, context });
-    await expect(page.getByText("Ethereum mainnet")).toBeVisible();
+    await expect(page.getByText("Connected to Metamask")).toBeVisible();
   });
 
   test("should create and delete different types of identities properly", async ({ page }) => {

--- a/e2e/tests/initialization.test.ts
+++ b/e2e/tests/initialization.test.ts
@@ -11,6 +11,6 @@ test.describe("initialization", () => {
 
     await connectWallet({ page, cryptKeeperExtensionId, context });
 
-    await expect(page.getByText("Ethereum mainnet")).toBeVisible();
+    await expect(page.getByText("Connected to Metamask")).toBeVisible();
   });
 });

--- a/e2e/tests/proofGeneration.test.ts
+++ b/e2e/tests/proofGeneration.test.ts
@@ -9,7 +9,7 @@ test.describe("proof generation", () => {
     await expect(page.getByTestId("home-page")).toBeVisible();
 
     await connectWallet({ page, cryptKeeperExtensionId, context });
-    await expect(page.getByText("Ethereum mainnet")).toBeVisible();
+    await expect(page.getByText("Connected to Metamask")).toBeVisible();
 
     await page.goto("/");
   });

--- a/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
+++ b/src/background/services/zkIdentity/__test__/zkIdentity.test.ts
@@ -466,7 +466,7 @@ describe("background/services/zkIdentity", () => {
 
       const result = await zkIdentityService.createIdentity({
         strategy: identityStrategy,
-        walletType: EWallet.CRYPT_KEEPER_WALLET,
+        walletType: EWallet.CRYPTKEEPER_WALLET,
         options: identityOptions,
         groups: [],
         host: "http://localhost:3000",

--- a/src/background/services/zkIdentity/index.ts
+++ b/src/background/services/zkIdentity/index.ts
@@ -307,7 +307,7 @@ export default class ZkIdentityService implements IBackupable {
       messageSignature: strategy === "interrep" ? messageSignature : undefined,
     };
 
-    if (walletType === EWallet.CRYPT_KEEPER_WALLET && strategy === "interrep") {
+    if (walletType === EWallet.CRYPTKEEPER_WALLET && strategy === "interrep") {
       config.messageSignature = await this.walletService.signMessage({
         message: options.message,
         address: options.account,

--- a/src/connectors/__tests__/cryptKeeper.test.ts
+++ b/src/connectors/__tests__/cryptKeeper.test.ts
@@ -7,7 +7,7 @@ import { ZERO_ADDRESS } from "@src/config/const";
 import { initializeInjectedProvider } from "@src/providers";
 import postMessage from "@src/util/postMessage";
 
-import { cryptKeeper, cryptKeeperHooks, CryptKeeperConnector } from "..";
+import { cryptKeeper, cryptKeeperHooks, CryptkeeperConnector } from "..";
 
 jest.mock("@src/providers", (): unknown => ({
   initializeInjectedProvider: jest.fn(),
@@ -53,7 +53,7 @@ describe("connectors/cryptKeeper", () => {
   test("should activate connector properly", async () => {
     (postMessage as jest.Mock).mockResolvedValue(mockAddresses);
 
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.activate();
 
@@ -62,7 +62,7 @@ describe("connectors/cryptKeeper", () => {
   });
 
   test("should activate connector twice properly", async () => {
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.activate();
     await connector.activate();
@@ -76,7 +76,7 @@ describe("connectors/cryptKeeper", () => {
     mockProvider.connect = jest.fn(() => Promise.resolve());
     (initializeInjectedProvider as jest.Mock).mockReturnValue(mockProvider);
 
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.activate();
 
@@ -86,7 +86,7 @@ describe("connectors/cryptKeeper", () => {
   test("should throw error if there is no provider", async () => {
     (initializeInjectedProvider as jest.Mock).mockReturnValue(undefined);
 
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await expect(connector.activate()).rejects.toThrow("No cryptkeeper installed");
     expect(mockActions.startActivation).toBeCalledTimes(1);
@@ -96,7 +96,7 @@ describe("connectors/cryptKeeper", () => {
   test("should handle incomming events properly", async () => {
     (postMessage as jest.Mock).mockResolvedValue(mockAddresses);
 
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.activate();
 
@@ -110,7 +110,7 @@ describe("connectors/cryptKeeper", () => {
 
   test("should not connect eagerly if there is no provider", async () => {
     (initializeInjectedProvider as jest.Mock).mockReturnValue(undefined);
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.connectEagerly();
 
@@ -122,7 +122,7 @@ describe("connectors/cryptKeeper", () => {
     (initializeInjectedProvider as jest.Mock).mockImplementation(() => {
       throw new Error();
     });
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.connectEagerly();
 
@@ -134,7 +134,7 @@ describe("connectors/cryptKeeper", () => {
   test("should connect eagerly and set accounts properly", async () => {
     (postMessage as jest.Mock).mockResolvedValue(mockAddresses);
 
-    const connector = new CryptKeeperConnector(mockActions);
+    const connector = new CryptkeeperConnector(mockActions);
 
     await connector.connectEagerly();
 

--- a/src/connectors/__tests__/utils.test.ts
+++ b/src/connectors/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import { ConnectorNames } from "@src/types";
 
 import type { Actions, Connector } from "@web3-react/types";
 
-import { getConnectorName, CryptKeeperConnector } from "..";
+import { getConnectorName, CryptkeeperConnector } from "..";
 import { MockConnector } from "../mock";
 
 describe("connectors/utils", () => {
@@ -12,6 +12,6 @@ describe("connectors/utils", () => {
     expect(getConnectorName({} as Connector)).toBe(ConnectorNames.UNKNOWN);
     expect(getConnectorName(new MetaMask({} as MetaMaskConstructorArgs))).toBe(ConnectorNames.METAMASK);
     expect(getConnectorName(new MockConnector({} as Actions))).toBe(ConnectorNames.MOCK);
-    expect(getConnectorName(new CryptKeeperConnector({} as Actions))).toBe(ConnectorNames.CRYPT_KEEPER);
+    expect(getConnectorName(new CryptkeeperConnector({} as Actions))).toBe(ConnectorNames.CRYPTKEEPER);
   });
 });

--- a/src/connectors/cryptKeeper.ts
+++ b/src/connectors/cryptKeeper.ts
@@ -5,7 +5,7 @@ import { RPCAction } from "@src/constants";
 import { type CryptKeeperInjectedProvider, initializeInjectedProvider } from "@src/providers";
 import postMessage from "@src/util/postMessage";
 
-export class CryptKeeperConnector extends Connector {
+export class CryptkeeperConnector extends Connector {
   private eagerConnection?: Promise<void>;
 
   customProvider?: CryptKeeperInjectedProvider;
@@ -77,6 +77,6 @@ export class CryptKeeperConnector extends Connector {
   }
 }
 
-export const [cryptKeeper, cryptKeeperHooks] = initializeConnector<CryptKeeperConnector>(
-  (actions) => new CryptKeeperConnector(actions),
+export const [cryptKeeper, cryptKeeperHooks] = initializeConnector<CryptkeeperConnector>(
+  (actions) => new CryptkeeperConnector(actions),
 );

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,10 +1,10 @@
 import { Web3ReactHooks } from "@web3-react/core";
 import { MetaMask } from "@web3-react/metamask";
 
-import { type CryptKeeperConnector, cryptKeeper, cryptKeeperHooks } from "./cryptKeeper";
+import { type CryptkeeperConnector, cryptKeeper, cryptKeeperHooks } from "./cryptKeeper";
 import { metamask, metamaskHooks } from "./metamask";
 
-export const connectors: [[MetaMask, Web3ReactHooks], [CryptKeeperConnector, Web3ReactHooks]] = [
+export const connectors: [[MetaMask, Web3ReactHooks], [CryptkeeperConnector, Web3ReactHooks]] = [
   [metamask, metamaskHooks],
   [cryptKeeper, cryptKeeperHooks],
 ];

--- a/src/connectors/utils.ts
+++ b/src/connectors/utils.ts
@@ -4,7 +4,7 @@ import { ConnectorNames } from "@src/types";
 
 import type { Connector } from "@web3-react/types";
 
-import { CryptKeeperConnector } from "./cryptKeeper";
+import { CryptkeeperConnector } from "./cryptKeeper";
 import { MockConnector } from "./mock";
 
 export function getConnectorName(connector: Connector): ConnectorNames {
@@ -12,8 +12,8 @@ export function getConnectorName(connector: Connector): ConnectorNames {
     return ConnectorNames.METAMASK;
   }
 
-  if (connector instanceof CryptKeeperConnector) {
-    return ConnectorNames.CRYPT_KEEPER;
+  if (connector instanceof CryptkeeperConnector) {
+    return ConnectorNames.CRYPTKEEPER;
   }
 
   if (connector instanceof MockConnector) {

--- a/src/types/hooks/index.ts
+++ b/src/types/hooks/index.ts
@@ -4,8 +4,8 @@ import type BigNumber from "bignumber.js";
 import type { BrowserProvider } from "ethers";
 
 export enum ConnectorNames {
-  METAMASK = "Metamask",
-  CRYPT_KEEPER = "Cryptkeeper",
+  METAMASK = "MetaMask",
+  CRYPTKEEPER = "CryptKeeper",
   MOCK = "Mock",
   UNKNOWN = "Unknown",
 }

--- a/src/types/hooks/index.ts
+++ b/src/types/hooks/index.ts
@@ -4,8 +4,8 @@ import type BigNumber from "bignumber.js";
 import type { BrowserProvider } from "ethers";
 
 export enum ConnectorNames {
-  METAMASK = "MetaMask",
-  CRYPT_KEEPER = "CryptKeeper",
+  METAMASK = "Metamask",
+  CRYPT_KEEPER = "Cryptkeeper",
   MOCK = "Mock",
   UNKNOWN = "Unknown",
 }

--- a/src/types/identity/index.ts
+++ b/src/types/identity/index.ts
@@ -29,7 +29,7 @@ export type NewIdentityRequest = {
 
 export enum EWallet {
   ETH_WALLET,
-  CRYPT_KEEPER_WALLET,
+  CRYPTKEEPER_WALLET,
 }
 
 export interface IdentityMetadata {

--- a/src/ui/components/AccountMenu/AccountMenu.tsx
+++ b/src/ui/components/AccountMenu/AccountMenu.tsx
@@ -19,8 +19,8 @@ export interface IAccountMenuProps {
 }
 
 const WALLET_LABEL_BY_TYPE = {
-  [EWallet.ETH_WALLET]: "Metamask",
-  [EWallet.CRYPT_KEEPER_WALLET]: "Cryptkeeper",
+  [EWallet.ETH_WALLET]: "MetaMask",
+  [EWallet.CRYPTKEEPER_WALLET]: "CryptKeeper",
 };
 
 export const AccountMenu = ({ ethWallet, cryptKeeperWallet }: IAccountMenuProps): JSX.Element => {
@@ -57,7 +57,7 @@ export const AccountMenu = ({ ethWallet, cryptKeeperWallet }: IAccountMenuProps)
             key={`${account.type}-${account.address}`}
             data-testid={`${account.type}-${account.address}`}
             sx={{ display: "flex", alignItems: "center", width: 200 }}
-            onClick={account.type === EWallet.CRYPT_KEEPER_WALLET ? () => onSelectAccount(account.address) : undefined}
+            onClick={account.type === EWallet.CRYPTKEEPER_WALLET ? () => onSelectAccount(account.address) : undefined}
           >
             <Jazzicon diameter={16} seed={jsNumberForAddress(account.address)} />
 

--- a/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -24,7 +24,7 @@ describe("ui/components/Header", () => {
   const defaultHookData: IUseAccountMenuData = {
     isOpen: true,
     accounts: [
-      { type: EWallet.CRYPT_KEEPER_WALLET, address: ZERO_ADDRESS, active: true },
+      { type: EWallet.CRYPTKEEPER_WALLET, address: ZERO_ADDRESS, active: true },
       { type: EWallet.ETH_WALLET, address: ZERO_ADDRESS, active: true },
     ],
     anchorEl: document.body,

--- a/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
+++ b/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
@@ -64,7 +64,7 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     expect(result.current.accounts).toStrictEqual([
       { type: EWallet.ETH_WALLET, address: defaultWalletHookData.address, active: true },
-      { type: EWallet.CRYPT_KEEPER_WALLET, address: defaultWalletHookData.address, active: true },
+      { type: EWallet.CRYPTKEEPER_WALLET, address: defaultWalletHookData.address, active: true },
     ]);
     expect(result.current.isOpen).toBe(false);
     expect(result.current.anchorEl).toBeUndefined();

--- a/src/ui/components/AccountMenu/useAccountMenu.ts
+++ b/src/ui/components/AccountMenu/useAccountMenu.ts
@@ -92,7 +92,7 @@ export const useAccountMenu = ({ ethWallet, cryptKeeperWallet }: IUseAccountMenu
   const cryptKeeperAddresses = useMemo(
     () =>
       cryptKeeperWallet.addresses?.map((address) => ({
-        type: EWallet.CRYPT_KEEPER_WALLET,
+        type: EWallet.CRYPTKEEPER_WALLET,
         address: address.toLowerCase(),
         active: cryptKeeperWallet.address === address,
       })) ?? [],

--- a/src/ui/components/Header/__tests__/Header.test.tsx
+++ b/src/ui/components/Header/__tests__/Header.test.tsx
@@ -51,9 +51,9 @@ describe("ui/components/Header", () => {
 
     const { findByText } = render(<Header />);
 
-    const chain = await findByText(defaultWalletHookData.chain?.name as string);
+    const connected = await findByText("Connected to Mock");
 
-    expect(chain).toBeInTheDocument();
+    expect(connected).toBeInTheDocument();
   });
 
   test("should render properly without connected wallet", async () => {

--- a/src/ui/components/Header/index.tsx
+++ b/src/ui/components/Header/index.tsx
@@ -24,7 +24,9 @@ export const Header = (): JSX.Element => {
       <Icon data-testid="logo" size={3} url={logoSvg} onClick={onGoToHome} />
 
       <div className="flex-grow flex flex-row items-center justify-end header__content">
-        {ethWallet.chain && <div className="text-sm rounded-full header__network-type">{ethWallet.chain.name}</div>}
+        {ethWallet.isActive && ethWallet.connectorName && (
+          <div className="text-sm rounded-full header__network-type">{`Connected to ${ethWallet.connectorName}`}</div>
+        )}
 
         <div className="header__account-icon">
           <AccountMenu cryptKeeperWallet={cryptKeeperWallet} ethWallet={ethWallet} />

--- a/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
+++ b/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
@@ -76,7 +76,7 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
     expect(result.current.isInjectedWallet).toBe(false);
     expect(result.current.chain).toBeUndefined();
     expect(result.current.address).toBe(defaultWalletHookData.address);
-    expect(result.current.connectorName).toBe(ConnectorNames.CRYPT_KEEPER);
+    expect(result.current.connectorName).toBe(ConnectorNames.CRYPTKEEPER);
     expect(result.current.connector).toBeDefined();
     expect(result.current.provider).toBeUndefined();
   });

--- a/src/ui/hooks/wallet/useCryptKeeper.ts
+++ b/src/ui/hooks/wallet/useCryptKeeper.ts
@@ -37,7 +37,7 @@ export const useCryptKeeperWallet = (): IUseWalletData => {
     isInjectedWallet: Boolean(window.cryptkeeper),
     address,
     addresses,
-    connectorName: ConnectorNames.CRYPT_KEEPER,
+    connectorName: ConnectorNames.CRYPTKEEPER,
     connector: cryptKeeper,
     balance: undefined,
     chain: undefined,

--- a/src/ui/hooks/wallet/useEthWallet.ts
+++ b/src/ui/hooks/wallet/useEthWallet.ts
@@ -14,7 +14,7 @@ import type { BrowserProvider } from "ethers";
 const hooksByConnectorName = {
   [ConnectorNames.METAMASK]: { connector: metamask, hooks: metamaskHooks },
   [ConnectorNames.MOCK]: undefined,
-  [ConnectorNames.CRYPT_KEEPER]: undefined,
+  [ConnectorNames.CRYPTKEEPER]: undefined,
   [ConnectorNames.UNKNOWN]: undefined,
 };
 

--- a/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -163,7 +163,7 @@ describe("ui/pages/CreateIdentity", () => {
       messageSignature: undefined,
       options: { message: mockMessage, account: ZERO_ADDRESS },
       strategy: "random",
-      walletType: EWallet.CRYPT_KEEPER_WALLET,
+      walletType: EWallet.CRYPTKEEPER_WALLET,
     });
   });
 
@@ -188,7 +188,7 @@ describe("ui/pages/CreateIdentity", () => {
       messageSignature: undefined,
       options: { message: mockMessage, account: ZERO_ADDRESS },
       strategy: "random",
-      walletType: EWallet.CRYPT_KEEPER_WALLET,
+      walletType: EWallet.CRYPTKEEPER_WALLET,
     });
   });
 

--- a/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -204,7 +204,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
       messageSignature: undefined,
       options: { account: defaultWalletHookData.address, message: mockMessage, nonce: 0, web2Provider: "twitter" },
       strategy: "interrep",
-      walletType: EWallet.CRYPT_KEEPER_WALLET,
+      walletType: EWallet.CRYPTKEEPER_WALLET,
     });
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(Paths.HOME);

--- a/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -124,7 +124,7 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
   );
 
   const onCreateIdentityWithCryptkeeper = useCallback(
-    async (data: FormFields) => createNewIdentity(data, EWallet.CRYPT_KEEPER_WALLET),
+    async (data: FormFields) => createNewIdentity(data, EWallet.CRYPTKEEPER_WALLET),
     [setError, createNewIdentity],
   );
 


### PR DESCRIPTION
## Explanation

This PR adds support for displaying current connector.

Details are below:
- [x] Add connector name to header instead of network

## More Information

Related to #445 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/e7c2793b-b30f-4b62-9a2c-9461e8a6effb)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/f483fd68-45d9-470f-973d-fc3c964bf390)


## Manual Testing Steps

1. Connect with metamask
2. See "Connected to Metamask" label in header

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
