### PR TITLE
chore: optimize webpack prod

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -79,6 +79,7 @@
     "sharp": "^0.32.1",
     "style-loader": "^3.3.3",
     "svgo": "^3.0.2",
+    "terser-webpack-plugin": "^5.3.9",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.3",
     "typescript": "^5.1.3",

--- a/packages/app/webpack.prod.js
+++ b/packages/app/webpack.prod.js
@@ -1,5 +1,6 @@
 const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
 const { merge } = require("webpack-merge");
+const TerserPlugin = require('terser-webpack-plugin');
 
 const common = require("./webpack.common");
 
@@ -11,7 +12,29 @@ module.exports = merge(common, {
     maxAssetSize: 512000,
   },
   optimization: {
+    splitChunks: {
+      cacheGroups: {
+        popupVendor: {
+          maxSize: 4000000,
+          test: /[\\/]node_modules[\\/]/,
+          name: "popup-vendor",
+          enforce: true,
+          chunks: (chunk) => {
+            return chunk.name === "popup";
+          }
+        }
+      }
+    },
     minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          compress: {
+            drop_console: true,
+            drop_debugger: true,
+            pure_funcs: ['console.log', 'console.info'],
+          },
+        },
+      }),
       new ImageMinimizerPlugin({
         minimizer: {
           implementation: ImageMinimizerPlugin.svgoMinify,

--- a/packages/app/webpack.prod.js
+++ b/packages/app/webpack.prod.js
@@ -1,6 +1,6 @@
 const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 const { merge } = require("webpack-merge");
-const TerserPlugin = require('terser-webpack-plugin');
 
 const common = require("./webpack.common");
 
@@ -19,11 +19,9 @@ module.exports = merge(common, {
           test: /[\\/]node_modules[\\/]/,
           name: "popup-vendor",
           enforce: true,
-          chunks: (chunk) => {
-            return chunk.name === "popup";
-          }
-        }
-      }
+          chunks: (chunk) => chunk.name === "popup",
+        },
+      },
     },
     minimizer: [
       new TerserPlugin({
@@ -31,7 +29,7 @@ module.exports = merge(common, {
           compress: {
             drop_console: true,
             drop_debugger: true,
-            pure_funcs: ['console.log', 'console.info'],
+            pure_funcs: ["console.log", "console.info"],
           },
         },
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -345,6 +341,9 @@ importers:
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
+      terser-webpack-plugin:
+        specifier: ^5.3.9
+        version: 5.3.9(@swc/core@1.3.66)(webpack@5.88.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.1.0(@babel/core@7.22.5)(jest@29.5.0)(typescript@5.1.3)
@@ -17064,3 +17063,7 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Explanation

Optimizing webpack prod bundle size, by using `splitChunks` and `TerserPlugin` together. 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

N/A

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
