### PR TITLE
refactor: move crypto logic from lock service

### DIFF
--- a/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
+++ b/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
@@ -1,23 +1,19 @@
-import CryptoService from "@src/background/services/crypto";
 import SimpleStorage from "@src/background/services/storage";
 
 import ApprovalService from "..";
 
 const mockDefaultHosts = ["https://localhost:3000"];
 const mockSerializedApprovals = JSON.stringify([[mockDefaultHosts[0], { canSkipApprove: true }]]);
-const mockAuthenticityCheckData = {
-  isNewOnboarding: false,
-};
 
-jest.mock("@src/background/services/lock", (): unknown => ({
+jest.mock("@src/background/services/crypto", (): unknown => ({
+  ...jest.requireActual("@src/background/services/crypto"),
   getInstance: jest.fn(() => ({
     encrypt: jest.fn(() => mockSerializedApprovals),
     decrypt: jest.fn(() => mockSerializedApprovals),
-    isAuthentic: jest.fn(() => mockAuthenticityCheckData),
+    generateEncryptedHmac: jest.fn(() => "encrypted"),
+    getAuthenticCiphertext: jest.fn(() => "encrypted"),
   })),
 }));
-
-jest.mock("@src/background/services/crypto");
 
 jest.mock("@src/background/services/storage");
 
@@ -34,13 +30,6 @@ describe("background/services/approval", () => {
       instance.set.mockReturnValue(undefined);
       instance.clear.mockReturnValue(undefined);
     });
-
-    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
-      /* eslint-disable no-param-reassign */
-      instance.generateEncryptedHmac = jest.fn(() => "encrypted");
-      instance.getAuthenticCiphertext = jest.fn(() => "encrypted");
-      /* eslint-enable no-param-reassign */
-    });
   });
 
   afterEach(async () => {
@@ -51,11 +40,6 @@ describe("background/services/approval", () => {
       instance.get.mockClear();
       instance.set.mockClear();
       instance.clear.mockClear();
-    });
-
-    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
-      (instance.generateEncryptedHmac as jest.Mock).mockClear();
-      (instance.getAuthenticCiphertext as jest.Mock).mockClear();
     });
   });
 

--- a/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
+++ b/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
@@ -1,3 +1,4 @@
+import CryptoService from "@src/background/services/crypto";
 import SimpleStorage from "@src/background/services/storage";
 
 import ApprovalService from "..";
@@ -16,10 +17,7 @@ jest.mock("@src/background/services/lock", (): unknown => ({
   })),
 }));
 
-jest.mock("@src/background/services/crypto", (): unknown => ({
-  cryptoGenerateEncryptedHmac: jest.fn(() => "encrypted"),
-  cryptoGetAuthenticBackupCiphertext: jest.fn(() => "encrypted"),
-}));
+jest.mock("@src/background/services/crypto");
 
 jest.mock("@src/background/services/storage");
 
@@ -36,6 +34,13 @@ describe("background/services/approval", () => {
       instance.set.mockReturnValue(undefined);
       instance.clear.mockReturnValue(undefined);
     });
+
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      /* eslint-disable no-param-reassign */
+      instance.generateEncryptedHmac = jest.fn(() => "encrypted");
+      instance.getAuthenticCiphertext = jest.fn(() => "encrypted");
+      /* eslint-enable no-param-reassign */
+    });
   });
 
   afterEach(async () => {
@@ -46,6 +51,11 @@ describe("background/services/approval", () => {
       instance.get.mockClear();
       instance.set.mockClear();
       instance.clear.mockClear();
+    });
+
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      (instance.generateEncryptedHmac as jest.Mock).mockClear();
+      (instance.getAuthenticCiphertext as jest.Mock).mockClear();
     });
   });
 

--- a/packages/app/src/background/services/crypto/__tests__/crypto.test.ts
+++ b/packages/app/src/background/services/crypto/__tests__/crypto.test.ts
@@ -1,34 +1,45 @@
 import fc from "fast-check";
 
-import { cryptoEncrypt, cryptoDecrypt, cryptoGenerateEncryptedHmac, cryptoGetAuthenticBackupCiphertext } from "..";
+import CryptoService from "..";
 
 describe("background/services/crypto", () => {
   test("should encrypt and decrypt data properly", () => {
-    expect(() => cryptoEncrypt("text", "")).toThrow("Password is not provided");
-    expect(() => cryptoDecrypt("text", "")).toThrow("Password is not provided");
+    const service = new CryptoService();
+
+    expect(() => service.encrypt("text")).toThrow("Secret is not provided");
+    expect(() => service.decrypt("text")).toThrow("Secret is not provided");
+    expect(() => service.encrypt("text", "")).toThrow("Secret is not provided");
+    expect(() => service.decrypt("text", "")).toThrow("Secret is not provided");
 
     fc.assert(
       fc.property(fc.string(), fc.string(), (text, password) => {
         fc.pre(password !== "");
 
-        const encrypted = cryptoEncrypt(text, password);
-        const decrypted = cryptoDecrypt(encrypted, password);
+        service.setSecret(password);
 
-        return decrypted === text;
+        const encrypted = service.encrypt(text);
+        const decrypted = service.decrypt(encrypted);
+        const encryptedWithPassword = service.encrypt(text, password);
+        const decryptedWithPassword = service.decrypt(encryptedWithPassword, password);
+
+        return decrypted === text && decryptedWithPassword === text;
       }),
     );
   });
 
   test("should check hmac properly", () => {
-    expect(() => cryptoGetAuthenticBackupCiphertext("text", "")).toThrow("Backup password is not provided");
-    expect(() => cryptoGetAuthenticBackupCiphertext("text", "password")).toThrow("This backup file is not authentic");
+    const service = new CryptoService();
+
+    expect(() => service.generateEncryptedHmac("text")).toThrow("Secret is not provided");
+    expect(() => service.getAuthenticCiphertext("text")).toThrow("Secret is not provided");
+    expect(() => service.getAuthenticCiphertext("text", "password")).toThrow("This ciphertext is not authentic");
 
     fc.assert(
       fc.property(fc.string(), fc.string(), (text, password) => {
         fc.pre(password !== "");
 
-        const encrypted = cryptoGenerateEncryptedHmac(text, password);
-        const decrypted = cryptoGetAuthenticBackupCiphertext(encrypted, password);
+        const encrypted = service.generateEncryptedHmac(text, password);
+        const decrypted = service.getAuthenticCiphertext(encrypted, password);
 
         return decrypted === text;
       }),

--- a/packages/app/src/background/services/crypto/__tests__/crypto.test.ts
+++ b/packages/app/src/background/services/crypto/__tests__/crypto.test.ts
@@ -1,21 +1,35 @@
 import fc from "fast-check";
 
+import { defaultMnemonic } from "@src/config/mock/wallet";
+
 import CryptoService from "..";
 
 describe("background/services/crypto", () => {
-  test("should encrypt and decrypt data properly", () => {
-    const service = new CryptoService();
+  const service = CryptoService.getInstance();
 
-    expect(() => service.encrypt("text")).toThrow("Secret is not provided");
-    expect(() => service.decrypt("text")).toThrow("Secret is not provided");
-    expect(() => service.encrypt("text", "")).toThrow("Secret is not provided");
-    expect(() => service.decrypt("text", "")).toThrow("Secret is not provided");
+  afterEach(() => {
+    service.clear();
+  });
+
+  test("should set mnemonic properly", () => {
+    expect(() => service.setMnemonic(defaultMnemonic)).not.toThrow();
+  });
+
+  test("should throw error if mnemonic is invalid", () => {
+    expect(() => service.setMnemonic("invalid")).toThrow("Mnemonic is invalid");
+  });
+
+  test("should encrypt and decrypt data properly", () => {
+    expect(() => service.encrypt("text")).toThrow("Password is not provided");
+    expect(() => service.decrypt("text")).toThrow("Password is not provided");
+    expect(() => service.encrypt("text", "")).toThrow("Password is not provided");
+    expect(() => service.decrypt("text", "")).toThrow("Password is not provided");
 
     fc.assert(
       fc.property(fc.string(), fc.string(), (text, password) => {
         fc.pre(password !== "");
 
-        service.setSecret(password);
+        service.setPassword(password);
 
         const encrypted = service.encrypt(text);
         const decrypted = service.decrypt(encrypted);
@@ -28,15 +42,18 @@ describe("background/services/crypto", () => {
   });
 
   test("should check hmac properly", () => {
-    const service = new CryptoService();
+    expect(() => service.generateEncryptedHmac("text", "")).toThrow("Password is not provided");
+    expect(() => service.getAuthenticCiphertext("text", "")).toThrow("Password is not provided");
 
-    expect(() => service.generateEncryptedHmac("text")).toThrow("Secret is not provided");
-    expect(() => service.getAuthenticCiphertext("text")).toThrow("Secret is not provided");
+    service.setPassword("password");
     expect(() => service.getAuthenticCiphertext("text", "password")).toThrow("This ciphertext is not authentic");
+    expect(() => service.getAuthenticCiphertext("text", "wrong")).toThrow("Password doesn't match with current");
 
     fc.assert(
       fc.property(fc.string(), fc.string(), (text, password) => {
         fc.pre(password !== "");
+
+        service.setPassword(password);
 
         const encrypted = service.generateEncryptedHmac(text, password);
         const decrypted = service.getAuthenticCiphertext(encrypted, password);

--- a/packages/app/src/background/services/history/__tests__/history.test.ts
+++ b/packages/app/src/background/services/history/__tests__/history.test.ts
@@ -66,14 +66,12 @@ jest.mock("@src/background/services/notification", (): unknown => ({
   },
 }));
 
-jest.mock("@src/background/services/lock", (): unknown => ({
-  __esModule: true,
-  default: {
-    getInstance: jest.fn(() => ({
-      encrypt: jest.fn(() => Promise.resolve(mockSerializedDefaultOperations)),
-      decrypt: jest.fn(() => Promise.resolve(mockSerializedDefaultOperations)),
-    })),
-  },
+jest.mock("@src/background/services/crypto", (): unknown => ({
+  ...jest.requireActual("@src/background/services/crypto"),
+  getInstance: jest.fn(() => ({
+    encrypt: jest.fn(() => mockSerializedDefaultOperations),
+    decrypt: jest.fn(() => mockSerializedDefaultOperations),
+  })),
 }));
 
 jest.mock("@src/background/services/storage");

--- a/packages/app/src/background/services/history/index.ts
+++ b/packages/app/src/background/services/history/index.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import browser from "webextension-polyfill";
 
-import LockerService from "@src/background/services/lock";
+import CryptoService from "@src/background/services/crypto";
 import NotificationService from "@src/background/services/notification";
 import SimpleStorage from "@src/background/services/storage";
 import { getEnabledFeatures } from "@src/config/features";
@@ -19,7 +19,7 @@ export default class HistoryService {
 
   private historySettingsStore: SimpleStorage;
 
-  private lockService: LockerService;
+  private cryptoService: CryptoService;
 
   private notificationService: NotificationService;
 
@@ -30,7 +30,7 @@ export default class HistoryService {
   private constructor() {
     this.historyStore = new SimpleStorage(HISTORY_KEY);
     this.historySettingsStore = new SimpleStorage(HISTORY_SETTINGS_KEY);
-    this.lockService = LockerService.getInstance();
+    this.cryptoService = CryptoService.getInstance();
     this.notificationService = NotificationService.getInstance();
     this.operations = [];
     this.settings = undefined;
@@ -64,7 +64,7 @@ export default class HistoryService {
     const features = getEnabledFeatures();
     const serializedOperations = await this.historyStore
       .get<string>()
-      .then((raw) => (raw ? this.lockService.decrypt(raw) : JSON.stringify([])))
+      .then((raw) => (raw ? this.cryptoService.decrypt(raw) : JSON.stringify([])))
       .then((serialized) => JSON.parse(serialized) as Operation[]);
 
     this.operations = serializedOperations
@@ -105,7 +105,7 @@ export default class HistoryService {
   };
 
   private writeOperations = async (operations: Operation[]) => {
-    const ciphertext = this.lockService.encrypt(JSON.stringify(operations));
+    const ciphertext = this.cryptoService.encrypt(JSON.stringify(operations));
     await this.historyStore.set(ciphertext);
   };
 

--- a/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
+++ b/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import browser from "webextension-polyfill";
 
-import CryptoService from "@src/background/services/crypto";
 import SimpleStorage from "@src/background/services/storage";
 import { InitializationStep } from "@src/types";
 import { setStatus } from "@src/ui/ducks/app";
@@ -12,7 +11,17 @@ import LockerService from "..";
 const defaultPassword = "password";
 const passwordChecker = "Password is correct";
 
-jest.mock("@src/background/services/crypto");
+jest.mock("@src/background/services/crypto", (): unknown => ({
+  ...jest.requireActual("@src/background/services/crypto"),
+  getInstance: jest.fn(() => ({
+    encrypt: jest.fn(() => defaultPassword),
+    decrypt: jest.fn(() => passwordChecker),
+    setPassword: jest.fn(),
+    clear: jest.fn(),
+    generateEncryptedHmac: jest.fn(() => "encrypted"),
+    getAuthenticCiphertext: jest.fn(() => "encrypted"),
+  })),
+}));
 
 jest.mock("@src/background/services/misc", (): unknown => ({
   ...jest.requireActual("@src/background/services/misc"),
@@ -44,16 +53,6 @@ describe("background/services/locker", () => {
     (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
       instance.get.mockReturnValue(defaultPassword);
     });
-
-    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
-      /* eslint-disable no-param-reassign */
-      instance.encrypt = jest.fn(() => defaultPassword);
-      instance.decrypt = jest.fn(() => passwordChecker);
-      instance.generateEncryptedHmac = jest.fn(() => "encrypted");
-      instance.getAuthenticCiphertext = jest.fn(() => "encrypted");
-      instance.setSecret = jest.fn(() => undefined);
-      /* eslint-enable no-param-reassign */
-    });
   });
 
   describe("ensure", () => {
@@ -69,24 +68,6 @@ describe("background/services/locker", () => {
       const result = await lockService.ensure({ args: [1, 2, 3] });
 
       expect(result).toStrictEqual({ args: [1, 2, 3] });
-    });
-  });
-
-  describe("encrypt / decrypt", () => {
-    test("should encrypt properly", async () => {
-      await lockService.unlock(defaultPassword);
-
-      const result = lockService.encrypt(defaultPassword);
-
-      expect(result).toStrictEqual(defaultPassword);
-    });
-
-    test("should decrypt properly", async () => {
-      await lockService.unlock(defaultPassword);
-
-      const result = lockService.decrypt(defaultPassword);
-
-      expect(result).toStrictEqual(passwordChecker);
     });
   });
 
@@ -159,52 +140,11 @@ describe("background/services/locker", () => {
     });
 
     test("should not unlock if there is wrong password", async () => {
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue({ toString: () => "" });
-
-      await expect(lockService.unlock(defaultPassword)).rejects.toThrowError("Incorrect password");
-    });
-
-    test("should check password is correct", async () => {
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        instance.get.mockReturnValue(undefined);
+        instance.get.mockReturnValueOnce(undefined).mockReturnValue(defaultPassword);
       });
 
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue(passwordChecker);
-
-      const result = await lockService.isAuthentic(defaultPassword, true);
-
-      expect(result).toStrictEqual({ isNewOnboarding: true });
-    });
-
-    test("should check password is correct with filled storage", async () => {
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue(passwordChecker);
-
-      const result = await lockService.isAuthentic(defaultPassword, true);
-
-      expect(result).toStrictEqual({ isNewOnboarding: false });
-    });
-
-    test("should throw error if password is incorrect", async () => {
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue("");
-
-      await expect(lockService.isAuthentic(defaultPassword, false)).rejects.toThrowError("Incorrect password");
-    });
-
-    test("should throw error if data is corrupted", async () => {
-      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        instance.get.mockReturnValue(undefined);
-      });
-
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue(passwordChecker);
-
-      await expect(lockService.isAuthentic(defaultPassword, false)).rejects.toThrowError(
-        "Something badly gone wrong (reinstallation probably required)",
-      );
+      await expect(lockService.unlock("wrong")).rejects.toThrowError("Incorrect password");
     });
   });
 
@@ -213,14 +153,11 @@ describe("background/services/locker", () => {
       const [{ get: mockGet }] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
       mockGet.mockClear();
 
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue(passwordChecker);
-
       const result = await lockService.downloadEncryptedStorage(defaultPassword);
 
       expect(result).toBeDefined();
 
-      expect(mockGet).toBeCalledTimes(3);
+      expect(mockGet).toBeCalledTimes(1);
     });
 
     test("should not download encrypted password storage if storage is empty", async () => {
@@ -253,19 +190,6 @@ describe("background/services/locker", () => {
       await lockService.uploadEncryptedStorage("encrypted", defaultPassword);
 
       expect(mockSet).toBeCalledTimes(1);
-    });
-
-    test("should throw error if uploading invalid data", async () => {
-      const [cryptoService] = (CryptoService as jest.Mock).mock.instances as [CryptoService];
-      (cryptoService.decrypt as jest.Mock).mockReturnValue({ toString: () => "" });
-
-      const [{ set: mockSet }] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
-      mockSet.mockClear();
-
-      await expect(lockService.uploadEncryptedStorage("encrypted", "wrong-password")).rejects.toThrow(
-        "Incorrect password",
-      );
-      expect(mockSet).toBeCalledTimes(0);
     });
   });
 });

--- a/packages/app/src/background/services/lock/index.ts
+++ b/packages/app/src/background/services/lock/index.ts
@@ -1,11 +1,6 @@
 import browser from "webextension-polyfill";
 
-import {
-  cryptoDecrypt,
-  cryptoEncrypt,
-  cryptoGenerateEncryptedHmac,
-  cryptoGetAuthenticBackupCiphertext,
-} from "@src/background/services/crypto";
+import CryptoService from "@src/background/services/crypto";
 import MiscStorageService from "@src/background/services/misc";
 import SimpleStorage from "@src/background/services/storage";
 import { InitializationStep } from "@src/types";
@@ -34,7 +29,7 @@ export default class LockerService implements IBackupable {
 
   private miscStorage: MiscStorageService;
 
-  private password?: string;
+  private cryptoService: CryptoService;
 
   private unlockCB?: () => void;
 
@@ -43,8 +38,7 @@ export default class LockerService implements IBackupable {
     this.passwordChecker = "Password is correct";
     this.passwordStorage = new SimpleStorage(PASSWORD_DB_KEY);
     this.miscStorage = MiscStorageService.getInstance();
-    this.password = undefined;
-    this.unlockCB = undefined;
+    this.cryptoService = new CryptoService();
   }
 
   static getInstance(): LockerService {
@@ -59,7 +53,14 @@ export default class LockerService implements IBackupable {
    *  This method is called when install event occurs
    */
   setupPassword = async (password: string): Promise<void> => {
-    const ciphertext = cryptoEncrypt(this.passwordChecker, password);
+    const encryptedPassword = await this.passwordStorage.get();
+
+    if (encryptedPassword) {
+      throw new Error("Password is already initialized");
+    }
+
+    this.cryptoService.setSecret(password);
+    const ciphertext = this.cryptoService.encrypt(this.passwordChecker);
     await this.passwordStorage.set(ciphertext);
     await this.unlock(password);
     await this.miscStorage.setInitialization({ initializationStep: InitializationStep.PASSWORD });
@@ -100,13 +101,18 @@ export default class LockerService implements IBackupable {
       return true;
     }
 
-    await this.isAuthentic(password, false);
+    this.cryptoService.setSecret(password);
+    await this.isAuthentic(password, false)
+      .then(() => {
+        this.isUnlocked = true;
+        return this.notifyStatusChange();
+      })
+      .then(() => this.onUnlocked())
+      .catch((error) => {
+        this.cryptoService.setSecret("");
 
-    this.password = password;
-    this.isUnlocked = true;
-
-    await this.notifyStatusChange();
-    this.onUnlocked();
+        throw error;
+      });
 
     return true;
   };
@@ -119,14 +125,14 @@ export default class LockerService implements IBackupable {
     }
 
     await this.isAuthentic(backupPassword, true);
-    return cryptoGenerateEncryptedHmac(backupEncryptedData, backupPassword);
+    return this.cryptoService.generateEncryptedHmac(backupEncryptedData, backupPassword);
   };
 
   uploadEncryptedStorage = async (backupEncryptedData: string, backupPassword: string): Promise<void> => {
     const { isNewOnboarding } = await this.isAuthentic(backupPassword, true);
 
     if (isNewOnboarding && backupEncryptedData) {
-      const authenticBackupCiphertext = cryptoGetAuthenticBackupCiphertext(backupEncryptedData, backupPassword);
+      const authenticBackupCiphertext = this.cryptoService.getAuthenticCiphertext(backupEncryptedData, backupPassword);
       await this.passwordStorage.set(authenticBackupCiphertext);
     }
   };
@@ -155,43 +161,27 @@ export default class LockerService implements IBackupable {
   };
 
   private isLockerPasswordAuthentic = async (password: string): Promise<boolean> => {
-    if (!password) {
-      throw new Error("Password is not provided");
-    }
-
     const ciphertext = await this.passwordStorage.get<string>();
 
     if (!ciphertext) {
       return false;
     }
 
-    const decryptedPasswordChecker = cryptoDecrypt(ciphertext, password);
+    const decryptedPasswordChecker = this.cryptoService.decrypt(ciphertext, password);
     return decryptedPasswordChecker === this.passwordChecker;
   };
 
   ensure = (payload: unknown = null): unknown | null | false => {
-    if (!this.isUnlocked || !this.password) {
+    if (!this.isUnlocked) {
       return false;
     }
 
     return payload;
   };
 
-  encrypt = (payload: string): string => {
-    if (!this.password) {
-      throw new Error("Password is not provided");
-    }
+  encrypt = (payload: string): string => this.cryptoService.encrypt(payload);
 
-    return cryptoEncrypt(payload, this.password);
-  };
-
-  decrypt = (ciphertext: string): string => {
-    if (!this.password) {
-      throw new Error("Password is not provided");
-    }
-
-    return cryptoDecrypt(ciphertext, this.password);
-  };
+  decrypt = (ciphertext: string): string => this.cryptoService.decrypt(ciphertext);
 
   logout = async (): Promise<boolean> => {
     await this.internalLogout();
@@ -201,7 +191,7 @@ export default class LockerService implements IBackupable {
 
   private internalLogout = async (): Promise<LockStatus> => {
     this.isUnlocked = false;
-    this.password = undefined;
+    this.cryptoService.setSecret("");
     this.unlockCB = undefined;
 
     return this.notifyStatusChange();

--- a/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
+++ b/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
@@ -1,5 +1,6 @@
 import { HDNodeWallet, Wallet } from "ethers";
 
+import CryptoService from "@src/background/services/crypto";
 import { generateMnemonic } from "@src/background/services/mnemonic";
 import SimpleStorage from "@src/background/services/storage";
 import { ZERO_ADDRESS } from "@src/config/const";
@@ -47,10 +48,7 @@ jest.mock("@src/background/services/misc", (): unknown => ({
   })),
 }));
 
-jest.mock("@src/background/services/crypto", (): unknown => ({
-  cryptoGenerateEncryptedHmac: jest.fn(() => "encrypted"),
-  cryptoGetAuthenticBackupCiphertext: jest.fn(() => "encrypted"),
-}));
+jest.mock("@src/background/services/crypto");
 
 jest.mock("@src/background/services/storage");
 
@@ -72,6 +70,13 @@ describe("background/services/wallet", () => {
       instance.clear.mockReturnValue(undefined);
     });
 
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      /* eslint-disable no-param-reassign */
+      instance.generateEncryptedHmac = jest.fn(() => "encrypted");
+      instance.getAuthenticCiphertext = jest.fn(() => "encrypted");
+      /* eslint-enable no-param-reassign */
+    });
+
     Wallet.fromPhrase = jest.fn(() => mockAccounts[0] as unknown as HDNodeWallet);
 
     (generateMnemonic as jest.Mock).mockReturnValue(defaultMnemonic);
@@ -86,6 +91,11 @@ describe("background/services/wallet", () => {
       instance.get.mockClear();
       instance.set.mockClear();
       instance.clear.mockClear();
+    });
+
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      (instance.generateEncryptedHmac as jest.Mock).mockClear();
+      (instance.getAuthenticCiphertext as jest.Mock).mockClear();
     });
   });
 

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -3,6 +3,7 @@ import { createNewIdentity } from "@cryptkeeperzk/zk";
 import { bigintToHex } from "bigint-conversion";
 import browser from "webextension-polyfill";
 
+import CryptoService from "@src/background/services/crypto";
 import SimpleStorage from "@src/background/services/storage";
 import ZkIdentityService from "@src/background/services/zkIdentity";
 import { ZERO_ADDRESS } from "@src/config/const";
@@ -43,10 +44,7 @@ jest.mock("@src/background/services/lock", (): unknown => ({
   })),
 }));
 
-jest.mock("@src/background/services/crypto", (): unknown => ({
-  cryptoGenerateEncryptedHmac: jest.fn(() => "encrypted"),
-  cryptoGetAuthenticBackupCiphertext: jest.fn(() => "encrypted"),
-}));
+jest.mock("@src/background/services/crypto");
 
 jest.mock("@src/background/services/history", (): unknown => ({
   getInstance: jest.fn(() => ({
@@ -105,6 +103,13 @@ describe("background/services/zkIdentity", () => {
       instance.clear.mockReturnValue(undefined);
     });
 
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      /* eslint-disable no-param-reassign */
+      instance.generateEncryptedHmac = jest.fn(() => "encrypted");
+      instance.getAuthenticCiphertext = jest.fn(() => "encrypted");
+      /* eslint-enable no-param-reassign */
+    });
+
     (createNewIdentity as jest.Mock).mockReturnValue(defaultNewIdentity);
   });
 
@@ -113,6 +118,11 @@ describe("background/services/zkIdentity", () => {
       instance.get.mockClear();
       instance.set.mockClear();
       instance.clear.mockClear();
+    });
+
+    (CryptoService as jest.Mock).mock.instances.forEach((instance: CryptoService) => {
+      (instance.generateEncryptedHmac as jest.Mock).mockClear();
+      (instance.getAuthenticCiphertext as jest.Mock).mockClear();
     });
 
     (pushMessage as jest.Mock).mockClear();


### PR DESCRIPTION
## Explanation

This PR moves crypto logic from lock service to a separate one to support encrypt/decrypt with mnemonic phrase. 

Details are below:
- [x] Add crypto service
- [x] Adapt lock service to work with crypto service
- [x] Update test mocks and remove duplicated tests
- [x] Use crypto service instead of locker
- [x] Simplify password check
- [x] Prepare for mnemonic encrypt/decrypt

## More Information

Related to #585 
Blocked by #584 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
