### PR TITLE
feat: onboarding with user mnemonic

### DIFF
--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -9,17 +9,7 @@ module.exports = {
     "@src/(.*)$": "<rootDir>/src/$1",
   },
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/test/",
-    "/__tests__/",
-    "/src/ui/popup.tsx",
-    "/src/ui/theme.ts",
-    "/src/background/backgroundPage.ts",
-    "/src/background/appInit.ts",
-    "/src/background/contentScript.ts",
-    "/src/background/injectedScript.ts",
-  ],
+  coveragePathIgnorePatterns: ["/node_modules/", "/test/", "/__tests__/"],
   collectCoverageFrom: ["src/**/*.{ts,tsx}"],
   coverageThreshold: {
     global: {

--- a/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
+++ b/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
@@ -147,6 +147,16 @@ describe("background/services/wallet", () => {
       expect(mnemonic).toBe(defaultMnemonic);
     });
 
+    test("should generate mnemonic with user option properly", async () => {
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        instance.get.mockReturnValue(undefined);
+      });
+
+      const mnemonic = await walletService.generateMnemonic(defaultMnemonic);
+
+      expect(mnemonic).toBe(defaultMnemonic);
+    });
+
     test("should throw an error if key pair is already created", async () => {
       await expect(walletService.generateMnemonic()).rejects.toThrowError("Key pair is already generated");
     });

--- a/packages/app/src/background/services/wallet/index.ts
+++ b/packages/app/src/background/services/wallet/index.ts
@@ -45,7 +45,7 @@ export default class WalletService implements IBackupable {
     return WalletService.INSTANCE;
   };
 
-  generateMnemonic = async (): Promise<string> => {
+  generateMnemonic = async (userMnemonic?: string): Promise<string> => {
     const accounts = await this.accountStorage.get<string>();
 
     if (accounts) {
@@ -54,11 +54,11 @@ export default class WalletService implements IBackupable {
 
     const encryptedMnemonic = await this.mnemonicStorage.get<string>();
 
-    if (encryptedMnemonic) {
+    if (encryptedMnemonic && !userMnemonic) {
       return this.cryptoService.decrypt(encryptedMnemonic, { mode: ECryptMode.PASSWORD });
     }
 
-    const mnemonic = generateMnemonic();
+    const mnemonic = userMnemonic ?? generateMnemonic();
     this.cryptoService.setMnemonic(mnemonic);
     const encrypted = this.cryptoService.encrypt(mnemonic, { mode: ECryptMode.PASSWORD });
     await this.mnemonicStorage.set(encrypted);

--- a/packages/app/src/ui/components/MnemonicInput/MnemonicInput.tsx
+++ b/packages/app/src/ui/components/MnemonicInput/MnemonicInput.tsx
@@ -64,14 +64,11 @@ const MnemonicInputUI = (
         {...rest}
       />
 
-      <Typography sx={{ color: "error.main" }} variant="body2">
-        {errorMessage}
-      </Typography>
-
       {!hideOptions && (
-        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", my: 2, width: "100%" }}>
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: 1, width: "100%" }}>
           <Button
             disabled={isCopied}
+            size="small"
             sx={{ mr: 1, textTransform: "none", width: "100%" }}
             variant="outlined"
             onClick={onCopy}
@@ -81,6 +78,7 @@ const MnemonicInputUI = (
 
           <Button
             disabled={isDownloaded}
+            size="small"
             sx={{ ml: 1, textTransform: "none", width: "100%" }}
             variant="outlined"
             onClick={onDownload}
@@ -89,6 +87,10 @@ const MnemonicInputUI = (
           </Button>
         </Box>
       )}
+
+      <Typography sx={{ color: "error.main", my: 1, height: 20 }} variant="body2">
+        {errorMessage}
+      </Typography>
     </Box>
   );
 };

--- a/packages/app/src/ui/ducks/app.ts
+++ b/packages/app/src/ui/ducks/app.ts
@@ -95,10 +95,12 @@ export const getWalletConnection =
     dispatch(appSlice.actions.setDisconnectedPermanently(Boolean(response?.isDisconnectedPermanently)));
   };
 
-export const generateMnemonic = (): TypedThunk<Promise<void>> => async (dispatch) => {
-  const mnemonic = await postMessage<string>({ method: RPCAction.GENERATE_MNEMONIC });
-  dispatch(appSlice.actions.setMnemonic(mnemonic));
-};
+export const generateMnemonic =
+  (userMnemonic?: string): TypedThunk<Promise<void>> =>
+  async (dispatch) => {
+    const mnemonic = await postMessage<string>({ method: RPCAction.GENERATE_MNEMONIC, payload: userMnemonic });
+    dispatch(appSlice.actions.setMnemonic(mnemonic));
+  };
 
 export const saveMnemonic = (): TypedThunk<Promise<void>> => async (dispatch) => {
   await postMessage({ method: RPCAction.SAVE_MNEMONIC });

--- a/packages/app/src/ui/hooks/validation/__tests__/useValidationResolver.test.ts
+++ b/packages/app/src/ui/hooks/validation/__tests__/useValidationResolver.test.ts
@@ -3,19 +3,16 @@
  */
 
 import { renderHook } from "@testing-library/react";
-import { object, string } from "yup";
 
-import { useValidationResolver } from "..";
+import { defaultMnemonic } from "@src/config/mock/wallet";
+
+import { useValidationResolver, mnemonicValidationSchema } from "..";
 
 describe("ui/hooks/validation", () => {
-  const schema = object().shape({
-    password: string().required("Password is required").min(8, "Min password length is 8 symbols"),
-  });
-
   test("should return validated values properly", async () => {
-    const { result } = renderHook(() => useValidationResolver(schema));
+    const { result } = renderHook(() => useValidationResolver(mnemonicValidationSchema));
 
-    const args = { password: "12345678" };
+    const args = { mnemonic: defaultMnemonic };
     const { values, errors } = await result.current(args);
 
     expect(values).toStrictEqual(args);
@@ -23,16 +20,31 @@ describe("ui/hooks/validation", () => {
   });
 
   test("should handle validation errors properly", async () => {
-    const { result } = renderHook(() => useValidationResolver(schema));
+    const { result } = renderHook(() => useValidationResolver(mnemonicValidationSchema));
 
-    const args = { password: "" };
+    const args = { mnemonic: "" };
     const { values, errors } = await result.current(args);
 
     expect(values).toStrictEqual(args);
     expect(errors).toStrictEqual({
-      password: {
-        type: "min",
-        message: "Min password length is 8 symbols",
+      mnemonic: {
+        type: "required",
+        message: "Mnemonic is required",
+      },
+    });
+  });
+
+  test("should handle mnemonic validation errors properly", async () => {
+    const { result } = renderHook(() => useValidationResolver(mnemonicValidationSchema));
+
+    const args = { mnemonic: "invalid" };
+    const { values, errors } = await result.current(args);
+
+    expect(values).toStrictEqual(args);
+    expect(errors).toStrictEqual({
+      mnemonic: {
+        type: "mnemonic",
+        message: "Mnemonic is invalid",
       },
     });
   });

--- a/packages/app/src/ui/hooks/validation/index.ts
+++ b/packages/app/src/ui/hooks/validation/index.ts
@@ -1,9 +1,16 @@
 import { useCallback } from "react";
+import { object, string, type Schema, type ValidationError } from "yup";
 
-import type { Schema, ValidationError } from "yup";
+import { validateMnemonic } from "@src/background/services/mnemonic";
 
 export type ValidationResolver<T> = (data: T) => Promise<{ values: T; errors: Errors }>;
 type Errors = Record<string, { type: string; message: string }>;
+
+export const mnemonicValidationSchema = object({
+  mnemonic: string()
+    .test("mnemonic", "Mnemonic is invalid", (mnemonic?: string) => (mnemonic ? validateMnemonic(mnemonic) : false))
+    .required("Mnemonic is required"),
+});
 
 export const useValidationResolver = <T>(validationSchema: Schema<T>): ValidationResolver<T> =>
   useCallback(

--- a/packages/app/src/ui/pages/GenerateMnemonic/GenerateMnemonic.tsx
+++ b/packages/app/src/ui/pages/GenerateMnemonic/GenerateMnemonic.tsx
@@ -1,52 +1,78 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 
 import logoSVG from "@src/static/icons/logo.svg";
 import { Icon } from "@src/ui/components/Icon";
 import { MnemonicInput } from "@src/ui/components/MnemonicInput";
 
-import { useGenerateMnemonic } from "./useGenerateMnemonic";
+import { EGenerateMnemonicMode, useGenerateMnemonic } from "./useGenerateMnemonic";
 
 const GenerateMnemonic = (): JSX.Element => {
-  const { isLoading, error, mnemonic, onSaveMnemonic } = useGenerateMnemonic();
+  const { isLoading, errors, mode, mnemonic, register, onChooseGenerateMode, onChooseInputMode, onSaveMnemonic } =
+    useGenerateMnemonic();
 
   return (
     <Box
+      component="form"
       data-testid="generate-mnemonic-page"
       sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1, p: 3 }}
+      onSubmit={onSaveMnemonic}
     >
-      <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1, width: "100%" }}>
         <Icon size={8} url={logoSVG} />
 
-        <Typography sx={{ mt: 2 }} variant="h4">
+        <Typography sx={{ mt: 1 }} variant="h4">
           One step left!
         </Typography>
 
-        <Typography sx={{ mt: 1, mb: 2 }} variant="body1">
+        <Typography sx={{ my: 1 }} variant="body1">
           Please keep your mnemonic phrase safely
         </Typography>
 
-        {mnemonic ? <MnemonicInput value={mnemonic} /> : <Skeleton height={175} variant="rectangular" width={337} />}
+        <MnemonicInput
+          autoFocus={mode === EGenerateMnemonicMode.INPUT}
+          data-testid="mnemonic-input"
+          errorMessage={errors.mnemonic}
+          hideOptions={mode === EGenerateMnemonicMode.INPUT}
+          id="mnemonic"
+          minRows={4}
+          placeholder="Enter mnemonic"
+          {...register("mnemonic")}
+          value={mnemonic}
+        />
       </Box>
 
-      <Button
-        data-testid="submit-button"
-        disabled={isLoading}
-        sx={{ textTransform: "none" }}
-        type="button"
-        variant="contained"
-        onClick={onSaveMnemonic}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexDirection: "column",
+          width: "100%",
+        }}
       >
-        Get started!
-      </Button>
+        <Button
+          data-testid="submit-button"
+          disabled={isLoading}
+          sx={{ textTransform: "none", width: "100%", mb: 1 }}
+          type="submit"
+          variant="contained"
+        >
+          Get started!
+        </Button>
 
-      {error && (
-        <Typography color="error" sx={{ my: 2 }} variant="body1">
-          {error}
-        </Typography>
-      )}
+        <Button
+          data-testid="change-mode-button"
+          disabled={isLoading}
+          sx={{ textTransform: "none", width: "100%" }}
+          type="button"
+          variant="text"
+          onClick={mode === EGenerateMnemonicMode.INPUT ? onChooseGenerateMode : onChooseInputMode}
+        >
+          {mode === EGenerateMnemonicMode.INPUT ? "Generate mnemonic" : "Use own mnemonic"}
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/packages/app/src/ui/pages/GenerateMnemonic/__tests__/GenerateMnemonic.test.tsx
+++ b/packages/app/src/ui/pages/GenerateMnemonic/__tests__/GenerateMnemonic.test.tsx
@@ -4,18 +4,25 @@
 
 import { act, render, waitFor } from "@testing-library/react";
 
+import { defaultMnemonic } from "@src/config/mock/wallet";
+
 import Mnemonic from "..";
-import { IUseGenerateMnemonicData, useGenerateMnemonic } from "../useGenerateMnemonic";
+import { EGenerateMnemonicMode, IUseGenerateMnemonicData, useGenerateMnemonic } from "../useGenerateMnemonic";
 
 jest.mock("../useGenerateMnemonic", (): unknown => ({
+  ...jest.requireActual("../useGenerateMnemonic"),
   useGenerateMnemonic: jest.fn(),
 }));
 
 describe("ui/pages/GenerateMnemonic", () => {
   const defaultHookData: IUseGenerateMnemonicData = {
     isLoading: false,
-    error: "",
-    mnemonic: "mnemonic",
+    errors: {},
+    mnemonic: defaultMnemonic,
+    mode: EGenerateMnemonicMode.GENERATE,
+    register: jest.fn(),
+    onChooseGenerateMode: jest.fn(),
+    onChooseInputMode: jest.fn(),
     onSaveMnemonic: jest.fn(),
   };
 
@@ -36,8 +43,33 @@ describe("ui/pages/GenerateMnemonic", () => {
     expect(page).toBeInTheDocument();
   });
 
+  test("should change to input mode properly", async () => {
+    const { container, findByTestId } = render(<Mnemonic />);
+    await waitFor(() => container.firstChild !== null);
+
+    const button = await findByTestId("change-mode-button");
+    await act(() => Promise.resolve(button.click()));
+
+    expect(defaultHookData.onChooseInputMode).toBeCalledTimes(1);
+  });
+
+  test("should change to generate mode properly", async () => {
+    (useGenerateMnemonic as jest.Mock).mockReturnValue({ ...defaultHookData, mode: EGenerateMnemonicMode.INPUT });
+
+    const { container, findByTestId } = render(<Mnemonic />);
+    await waitFor(() => container.firstChild !== null);
+
+    const button = await findByTestId("change-mode-button");
+    await act(() => Promise.resolve(button.click()));
+
+    expect(defaultHookData.onChooseGenerateMode).toBeCalledTimes(1);
+  });
+
   test("should render error properly", async () => {
-    (useGenerateMnemonic as jest.Mock).mockReturnValue({ ...defaultHookData, mnemonic: undefined, error: "error" });
+    (useGenerateMnemonic as jest.Mock).mockReturnValue({
+      ...defaultHookData,
+      errors: { mnemonic: "error" },
+    });
 
     const { container, findByText } = render(<Mnemonic />);
     await waitFor(() => container.firstChild !== null);
@@ -47,7 +79,7 @@ describe("ui/pages/GenerateMnemonic", () => {
     expect(error).toBeInTheDocument();
   });
 
-  test("should go home properly", async () => {
+  test("should submit form properly", async () => {
     const { container, findByTestId } = render(<Mnemonic />);
     await waitFor(() => container.firstChild !== null);
 

--- a/packages/app/src/ui/pages/GenerateMnemonic/useGenerateMnemonic.ts
+++ b/packages/app/src/ui/pages/GenerateMnemonic/useGenerateMnemonic.ts
@@ -1,47 +1,96 @@
 import { useCallback, useEffect, useState } from "react";
+import { UseFormRegister, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { saveMnemonic, generateMnemonic, useAppStatus, useGeneratedMnemonic } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { mnemonicValidationSchema, useValidationResolver } from "@src/ui/hooks/validation";
 
 export interface IUseGenerateMnemonicData {
   isLoading: boolean;
-  error: string;
-  mnemonic?: string;
+  errors: Partial<MnemonicFormFields>;
+  register: UseFormRegister<MnemonicFormFields>;
+  mode: EGenerateMnemonicMode;
+  mnemonic: string;
   onSaveMnemonic: () => void;
+  onChooseGenerateMode: () => void;
+  onChooseInputMode: () => void;
+}
+
+export enum EGenerateMnemonicMode {
+  GENERATE,
+  INPUT,
+}
+
+interface MnemonicFormFields {
+  mnemonic: string;
 }
 
 export const useGenerateMnemonic = (): IUseGenerateMnemonicData => {
-  const { isMnemonicGenerated } = useAppStatus();
-  const mnemonic = useGeneratedMnemonic();
+  const resolver = useValidationResolver(mnemonicValidationSchema);
+  const {
+    formState: { isLoading, isSubmitting, errors },
+    setError,
+    setValue,
+    register,
+    watch,
+    handleSubmit,
+  } = useForm<MnemonicFormFields>({
+    resolver,
+    defaultValues: {
+      mnemonic: "",
+    },
+  });
 
-  const [isLoading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const { isMnemonicGenerated } = useAppStatus();
+  const generatedMnemonic = useGeneratedMnemonic();
+
+  const [mode, setMode] = useState(EGenerateMnemonicMode.GENERATE);
 
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const onSaveMnemonic = useCallback(() => {
-    setLoading(true);
-    dispatch(saveMnemonic())
-      .then(() => navigate(Paths.HOME))
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [mnemonic, navigate, dispatch, setLoading, setError]);
+  const onSaveMnemonic = useCallback(
+    (data: MnemonicFormFields) => {
+      (mode === EGenerateMnemonicMode.INPUT ? dispatch(generateMnemonic(data.mnemonic)) : Promise.resolve())
+        .then(() => dispatch(saveMnemonic()))
+        .then(() => navigate(Paths.HOME))
+        .catch((err: Error) => setError("mnemonic", { message: err.message }));
+    },
+    [generatedMnemonic, mode, navigate, dispatch, setError],
+  );
+
+  const onChooseGenerateMode = useCallback(() => {
+    setMode(EGenerateMnemonicMode.GENERATE);
+    setValue("mnemonic", generatedMnemonic as string);
+  }, [generatedMnemonic, setMode, setValue]);
+
+  const onChooseInputMode = useCallback(() => {
+    setMode(EGenerateMnemonicMode.INPUT);
+    setValue("mnemonic", "");
+  }, [setMode, setValue]);
 
   useEffect(() => {
     if (isMnemonicGenerated) {
       navigate(Paths.HOME);
-    } else if (!mnemonic) {
+    } else if (!generatedMnemonic) {
       dispatch(generateMnemonic());
+    } else {
+      setValue("mnemonic", generatedMnemonic);
     }
-  }, [isMnemonicGenerated, navigate, dispatch]);
+  }, [isMnemonicGenerated, generatedMnemonic, setValue, navigate, dispatch]);
 
   return {
-    isLoading,
-    error,
-    mnemonic,
-    onSaveMnemonic,
+    isLoading: isLoading || isSubmitting,
+    mode,
+    mnemonic: watch("mnemonic"),
+    errors: {
+      mnemonic: errors.mnemonic?.message,
+    },
+    register,
+    onSaveMnemonic: handleSubmit(onSaveMnemonic),
+    onChooseGenerateMode,
+    onChooseInputMode,
   };
 };

--- a/packages/app/src/ui/pages/Recover/__tests__/useRecover.test.ts
+++ b/packages/app/src/ui/pages/Recover/__tests__/useRecover.test.ts
@@ -27,6 +27,7 @@ jest.mock("@src/ui/ducks/app", (): unknown => ({
 }));
 
 jest.mock("@src/ui/hooks/validation", (): unknown => ({
+  ...jest.requireActual("@src/ui/hooks/validation"),
   useValidationResolver: jest.fn(),
 }));
 

--- a/packages/app/src/ui/pages/Recover/useRecover.ts
+++ b/packages/app/src/ui/pages/Recover/useRecover.ts
@@ -1,13 +1,11 @@
 import { useCallback } from "react";
 import { UseFormRegister, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import { object, string } from "yup";
 
-import { validateMnemonic } from "@src/background/services/mnemonic";
 import { Paths } from "@src/constants";
 import { checkMnemonic } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { useValidationResolver } from "@src/ui/hooks/validation";
+import { mnemonicValidationSchema, useValidationResolver } from "@src/ui/hooks/validation";
 
 export interface IUseRecoverData {
   isLoading: boolean;
@@ -21,17 +19,11 @@ interface RestoreFormFields {
   mnemonic: string;
 }
 
-const validationSchema = object({
-  mnemonic: string()
-    .test("mnemonic", "Mnemonic is invalid", (mnemonic?: string) => (mnemonic ? validateMnemonic(mnemonic) : false))
-    .required("Mnemonic is required"),
-});
-
 export const useRecover = (): IUseRecoverData => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
-  const resolver = useValidationResolver(validationSchema);
+  const resolver = useValidationResolver(mnemonicValidationSchema);
   const {
     formState: { isLoading, isSubmitting, errors },
     setError,

--- a/packages/e2e/helpers/account.ts
+++ b/packages/e2e/helpers/account.ts
@@ -4,10 +4,19 @@ import { CRYPT_KEEPER_PASSWORD } from "../constants";
 import { type TestExtension, expect } from "../fixtures";
 import { CryptKeeper } from "../pages";
 
-export async function createAccount({ page }: TestExtension): Promise<void> {
+interface ICreateAccountArgs extends TestExtension {
+  password?: string;
+  mnemonic?: string;
+}
+
+export async function createAccount({
+  page,
+  password = CRYPT_KEEPER_PASSWORD,
+  mnemonic,
+}: ICreateAccountArgs): Promise<void> {
   const cryptKeeper = await connectCryptKeeper(page);
 
-  await cryptKeeper.createAccount(CRYPT_KEEPER_PASSWORD);
+  await cryptKeeper.createAccount({ password, mnemonic });
   await cryptKeeper.approve();
   await cryptKeeper.connectIdentity();
 
@@ -28,10 +37,15 @@ export async function connectWallet({ page, cryptKeeperExtensionId }: TestExtens
   await cryptKeeper.connectWallet();
 }
 
-export async function unlockAccount(
-  { page, cryptKeeperExtensionId }: TestExtension,
+interface IUnlockAccountArgs extends TestExtension {
+  password?: string;
+}
+
+export async function unlockAccount({
+  page,
+  cryptKeeperExtensionId,
   password = CRYPT_KEEPER_PASSWORD,
-): Promise<void> {
+}: IUnlockAccountArgs): Promise<void> {
   const cryptKeeper = new CryptKeeper(page);
   await cryptKeeper.openPopup(cryptKeeperExtensionId);
 

--- a/packages/e2e/pages/cryptKeeper/CryptKeeper.ts
+++ b/packages/e2e/pages/cryptKeeper/CryptKeeper.ts
@@ -8,6 +8,12 @@ import Identities from "./Identities";
 import Recover from "./Recover";
 import Settings from "./Settings";
 
+interface ICreateAccountArgs {
+  password: string;
+  confirmPassword?: string;
+  mnemonic?: string;
+}
+
 export default class CryptKeeper extends BasePage {
   activity = new Activity(this.page);
 
@@ -42,11 +48,20 @@ export default class CryptKeeper extends BasePage {
     await metamaskCommands.acceptAccess();
   }
 
-  async createAccount(password: string, confirmPassword = password): Promise<void> {
+  async createAccount({ password, confirmPassword = password, mnemonic }: ICreateAccountArgs): Promise<void> {
     await this.page.getByLabel("Password", { exact: true }).type(password);
     await this.page.getByLabel("Confirm Password", { exact: true }).type(confirmPassword);
     await this.page.getByText("Continue", { exact: true }).click();
-    await this.page.getByText("Copy").click();
+
+    if (!mnemonic) {
+      await this.page.getByText("Copy").click();
+    }
+
+    if (mnemonic) {
+      await this.page.getByTestId("change-mode-button").click();
+      await this.page.getByTestId("mnemonic-input").locator("textarea").first().type(mnemonic);
+    }
+
     await this.page.getByText("Get started!", { exact: true }).click();
   }
 

--- a/packages/e2e/pages/cryptKeeper/Recover.ts
+++ b/packages/e2e/pages/cryptKeeper/Recover.ts
@@ -6,7 +6,7 @@ export default class Recover extends BasePage {
   }
 
   async checkMnemonic(mnemonic: string): Promise<void> {
-    await this.page.getByTestId("mnemonic-input").type(mnemonic);
+    await this.page.getByTestId("mnemonic-input").locator("textarea").first().type(mnemonic);
     await this.page.getByText("Restore", { exact: true }).click();
   }
 

--- a/packages/e2e/tests/recover.test.ts
+++ b/packages/e2e/tests/recover.test.ts
@@ -1,4 +1,4 @@
-import { CRYPT_KEEPER_PASSWORD } from "../constants";
+import { CRYPT_KEEPER_PASSWORD, METAMASK_SEED_PHRASE } from "../constants";
 import { expect, test } from "../fixtures";
 import { createAccount, lockAccount, unlockAccount } from "../helpers/account";
 import { CryptKeeper } from "../pages";
@@ -19,12 +19,46 @@ test.describe("recover", () => {
     await extension.recover.resetPassword(newPassword);
 
     await lockAccount({ page, cryptKeeperExtensionId, context });
-    await unlockAccount({ page, cryptKeeperExtensionId, context }, newPassword);
+    await unlockAccount({ page, cryptKeeperExtensionId, context, password: newPassword });
 
     await expect(page.getByTestId("home-page")).toBeVisible();
 
     await extension.activity.openTab();
     await expect(extension.activity.getByText("Password reset")).toHaveCount(1);
+  });
+
+  test("should recover access with user defined mnemonic properly", async ({
+    page,
+    cryptKeeperExtensionId,
+    context,
+  }) => {
+    await createAccount({ page, cryptKeeperExtensionId, context, mnemonic: METAMASK_SEED_PHRASE });
+    await lockAccount({ page, cryptKeeperExtensionId, context });
+
+    const extension = new CryptKeeper(page);
+    await extension.focus();
+
+    const newPassword = `${CRYPT_KEEPER_PASSWORD}new`;
+
+    await extension.recover.open();
+    await extension.recover.checkMnemonic(METAMASK_SEED_PHRASE);
+    await extension.recover.resetPassword(newPassword);
+
+    await lockAccount({ page, cryptKeeperExtensionId, context });
+    await unlockAccount({ page, cryptKeeperExtensionId, context, password: newPassword });
+
+    await expect(page.getByTestId("home-page")).toBeVisible();
+
+    await extension.activity.openTab();
+    await expect(extension.activity.getByText("Password reset")).toHaveCount(1);
+
+    await extension.settings.openPage();
+    await extension.settings.openTab("Security");
+    await extension.settings.goToRevealMnemonic();
+
+    const revealedMnemonic = await extension.recover.getMnemonic(newPassword);
+
+    expect(revealedMnemonic).toBe(METAMASK_SEED_PHRASE);
   });
 
   test("should change password properly", async ({ page, cryptKeeperExtensionId, context }) => {
@@ -45,7 +79,7 @@ test.describe("recover", () => {
     await extension.recover.resetPassword(newPassword);
 
     await lockAccount({ page, cryptKeeperExtensionId, context });
-    await unlockAccount({ page, cryptKeeperExtensionId, context }, newPassword);
+    await unlockAccount({ page, cryptKeeperExtensionId, context, password: newPassword });
 
     await expect(page.getByTestId("home-page")).toBeVisible();
 


### PR DESCRIPTION
## Explanation

This PR adds support for creating cryptkeeper account with user defined mnemonic.

Details are below:
- [x] Add user mnemonic input for onboarding flow
- [x] Add e2e tests


## More Information

Closes #575 
Closes #381 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/07dfeee2-bae3-469e-9948-9f8a643e1153)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/18b41e68-4115-4652-88a1-015a01d1fa1c)


## Manual Testing Steps

1. Reinstall the extension
2. Create account with generated mnemonic and with user defined mnemonic
3. Check reveak mnemonic page has the same mnemonic

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
