### PR TITLE
feat: add rpc access for controller

### DIFF
--- a/packages/app/src/background/backgroundPage.ts
+++ b/packages/app/src/background/backgroundPage.ts
@@ -1,6 +1,6 @@
 import log from "loglevel";
 import "subworkers";
-import browser from "webextension-polyfill";
+import browser, { type Runtime } from "webextension-polyfill";
 
 import CryptKeeperController from "@src/background/cryptKeeper";
 import { createChromeOffscreen, deferredPromise, getBrowserPlatform } from "@src/background/shared/utils";
@@ -37,7 +37,7 @@ try {
 
   app.initialize();
 
-  browser.runtime.onMessage.addListener(async (request: RequestHandler) => {
+  browser.runtime.onMessage.addListener(async (request: RequestHandler, sender: Runtime.MessageSender) => {
     log.debug("Background: request: ", request);
 
     if (browserPlatform !== BrowserPlatform.Firefox && request.source === "offscreen") {
@@ -45,7 +45,7 @@ try {
     }
 
     try {
-      const response = await app.handle(request);
+      const response = await app.handle(request, sender);
       log.debug("Background: response: ", response);
       return [null, response];
     } catch (e) {

--- a/packages/app/src/background/controllers/__tests__/handler.test.ts
+++ b/packages/app/src/background/controllers/__tests__/handler.test.ts
@@ -1,6 +1,25 @@
+import { getUrlOrigin } from "@src/util/browser";
+
 import Handler from "../handler";
 
+jest.mock("@src/util/browser", (): unknown => ({
+  ...jest.requireActual("@src/util/browser"),
+  getUrlOrigin: jest.fn(),
+  getExtensionUrl: jest.fn(),
+}));
+
 describe("background/controllers/handler", () => {
+  const defaultSender = { url: "http://localhost:3000" };
+  const defaultOptions = { sender: defaultSender };
+
+  beforeEach(() => {
+    (getUrlOrigin as jest.Mock).mockReturnValue(defaultOptions.sender.url);
+  });
+
+  afterEach(() => {
+    (getUrlOrigin as jest.Mock).mockClear();
+  });
+
   test("should add handler method properly and process it", async () => {
     const handler = new Handler();
 
@@ -12,14 +31,40 @@ describe("background/controllers/handler", () => {
       (count: number) => count + 4,
     );
 
-    const result = await handler.handle({ method: "counter", payload: 0 });
+    const result = await handler.handle({ method: "counter", payload: 0 }, defaultOptions);
 
     expect(result).toBe(10);
+  });
+
+  test("should throw error for unauthorized call", async () => {
+    (getUrlOrigin as jest.Mock).mockReturnValueOnce(defaultOptions.sender.url).mockReturnValue("extension-url");
+
+    const handler = new Handler();
+
+    handler.add("counter", (count: number) => count + 1);
+
+    await expect(handler.handle({ method: "counter", payload: 0 }, defaultOptions)).rejects.toThrow(
+      "Method counter is not allowed to be called outside",
+    );
+  });
+
+  test("should bypass url check properly", async () => {
+    (getUrlOrigin as jest.Mock).mockReturnValueOnce(defaultOptions.sender.url).mockReturnValue("extension-url");
+
+    const handler = new Handler();
+
+    handler.add("counter", (count: number) => count + 1);
+
+    const result = await handler.handle({ method: "counter", payload: 0 }, { ...defaultOptions, bypass: true });
+
+    expect(result).toBe(1);
   });
 
   test("should throw error if there is no registered method", () => {
     const handler = new Handler();
 
-    expect(handler.handle({ method: "unknown" })).rejects.toThrowError("method: unknown is not detected");
+    expect(handler.handle({ method: "unknown" }, defaultOptions)).rejects.toThrowError(
+      "method: unknown is not detected",
+    );
   });
 });

--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -2,6 +2,8 @@ import { RPCAction } from "@cryptkeeperzk/providers";
 
 import { BackupableServices, RequestHandler } from "@src/types";
 
+import type { Runtime } from "webextension-polyfill";
+
 import BrowserUtils from "./controllers/browserUtils";
 import Handler from "./controllers/handler";
 import RequestManager from "./controllers/requestManager";
@@ -14,6 +16,23 @@ import MiscStorageService from "./services/misc";
 import { validateZkInputs } from "./services/validation";
 import WalletService from "./services/wallet";
 import ZkIdentityService from "./services/zkIdentity";
+
+const RPC_METHOD_ACCESS: Record<RPCAction, boolean> = {
+  ...Object.values(RPCAction).reduce((acc, method) => ({ ...acc, [method]: false }), {} as Record<RPCAction, boolean>),
+  [RPCAction.CLOSE_POPUP]: true,
+  [RPCAction.CONNECT]: true,
+  [RPCAction.APPROVE_HOST]: true,
+  [RPCAction.GET_CONNECTED_IDENTITY_DATA]: true,
+  [RPCAction.CONNECT_IDENTITY_REQUEST]: true,
+  [RPCAction.GET_COMMITMENTS]: true,
+  [RPCAction.GET_HOST_PERMISSIONS]: true,
+  [RPCAction.SET_HOST_PERMISSIONS]: true,
+  [RPCAction.CREATE_IDENTITY_REQUEST]: true,
+  [RPCAction.PREPARE_SEMAPHORE_PROOF_REQUEST]: true,
+  [RPCAction.PREPARE_RLN_PROOF_REQUEST]: true,
+};
+
+Object.freeze(RPC_METHOD_ACCESS);
 
 export default class CryptKeeperController {
   private handler: Handler;
@@ -56,7 +75,8 @@ export default class CryptKeeperController {
       .add(BackupableServices.WALLET, this.walletService);
   }
 
-  handle = (request: RequestHandler): Promise<unknown> => this.handler.handle(request);
+  handle = (request: RequestHandler, sender: Runtime.MessageSender): Promise<unknown> =>
+    this.handler.handle(request, { sender, bypass: RPC_METHOD_ACCESS[request.method as RPCAction] });
 
   initialize = (): CryptKeeperController => {
     // common

--- a/packages/app/src/ui/components/PermissionModal/PermissionModal.tsx
+++ b/packages/app/src/ui/components/PermissionModal/PermissionModal.tsx
@@ -19,11 +19,11 @@ export const PermissionModal = ({ refreshConnectionStatus, onClose }: Connection
   return (
     <FullModal data-testid="connection-modal" onClose={onClose}>
       <FullModalHeader onClose={onClose}>
-        {url?.protocol === "chrome-extension:" ? "Chrome Extension Page" : url?.host}
+        {url?.protocol.includes("extension:") ? "Chrome Extension Page" : url?.host}
       </FullModalHeader>
 
       <FullModalContent className="flex flex-col items-center">
-        {url?.protocol === "chrome-extension:" ? (
+        {url?.protocol.includes("extension:") ? (
           <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0 flex flex-row items-center justify-center">
             <Icon className="text-gray-700" fontAwesome="fas fa-tools" size={1.5} />
           </div>

--- a/packages/app/src/util/__tests__/browser.test.ts
+++ b/packages/app/src/util/__tests__/browser.test.ts
@@ -5,7 +5,14 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import browser from "webextension-polyfill";
 
-import { getLastActiveTabUrl, redirectToNewTab, getExtensionUrl, downloadFile, copyToClipboard } from "../browser";
+import {
+  getLastActiveTabUrl,
+  redirectToNewTab,
+  getExtensionUrl,
+  downloadFile,
+  copyToClipboard,
+  getUrlOrigin,
+} from "../browser";
 
 describe("util/browser", () => {
   const defaultTabs = [{ url: "http://localhost:3000" }];
@@ -78,5 +85,10 @@ describe("util/browser", () => {
 
     expect(spyCopy).toBeCalledTimes(1);
     expect(spyCopy).toBeCalledWith("content");
+  });
+
+  test("should get url origin properly", () => {
+    expect(getUrlOrigin()).toBe("");
+    expect(getUrlOrigin("http://localhost:1234/#/page1?search=0")).toBe("http://localhost:1234");
   });
 });

--- a/packages/app/src/util/browser.ts
+++ b/packages/app/src/util/browser.ts
@@ -27,3 +27,11 @@ export const downloadFile = (content: string, filename: string): Promise<void> =
 export const copyToClipboard = async (content: string): Promise<void> => {
   await navigator.clipboard.writeText(content);
 };
+
+export const getUrlOrigin = (url?: string): string => {
+  if (!url) {
+    return "";
+  }
+
+  return new URL(url).origin;
+};


### PR DESCRIPTION
## Explanation

This PR adds access control for rpc controller which cuts all the unauthorized calls from outside.

Details are below:
- [x] Add sender for handler and controller
- [x] Check source and extension url
- [x] Enable guard by default
- [x] Use rpc method access object for bypass check

## More Information

Blocked by #627 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

Try to call any method from provider which doesn't have bypass setting. 

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
