### PR TITLE
feat: backup onboarding flow 😈

### DIFF
--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -69,10 +69,10 @@ export default class CryptKeeperController {
     this.historyService = HistoryService.getInstance();
     this.walletService = WalletService.getInstance();
     this.backupService = BackupService.getInstance()
-      .add(BackupableServices.APPROVAL, this.approvalService)
-      .add(BackupableServices.IDENTITY, this.zkIdentityService)
       .add(BackupableServices.LOCK, this.lockService)
-      .add(BackupableServices.WALLET, this.walletService);
+      .add(BackupableServices.WALLET, this.walletService)
+      .add(BackupableServices.APPROVAL, this.approvalService)
+      .add(BackupableServices.IDENTITY, this.zkIdentityService);
   }
 
   handle = (request: RequestHandler, sender: Runtime.MessageSender): Promise<unknown> =>
@@ -145,7 +145,12 @@ export default class CryptKeeperController {
 
     // Backup
     this.handler.add(RPCAction.DOWNLOAD_BACKUP, this.lockService.ensure, this.backupService.download);
-    this.handler.add(RPCAction.REQUEST_UPLOAD_BACKUP, this.backupService.createUploadBackupRequest);
+    this.handler.add(
+      RPCAction.REQUEST_UPLOAD_BACKUP,
+      this.lockService.ensure,
+      this.backupService.createUploadBackupRequest,
+    );
+    this.handler.add(RPCAction.REQUEST_ONBOARDING_BACKUP, this.backupService.createOnboardingBackupRequest);
     this.handler.add(RPCAction.UPLOAD_BACKUP, this.backupService.upload);
 
     // Wallet

--- a/packages/app/src/background/services/history/index.ts
+++ b/packages/app/src/background/services/history/index.ts
@@ -76,7 +76,7 @@ export default class HistoryService {
     return { operations: this.operations, settings: this.settings };
   };
 
-  private loadSettings = async (): Promise<HistorySettings> => {
+  loadSettings = async (): Promise<HistorySettings> => {
     this.settings = await this.historySettingsStore
       .get<string>()
       .then((settings) => (settings ? (JSON.parse(settings) as HistorySettings) : undefined));

--- a/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
+++ b/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
@@ -234,7 +234,10 @@ describe("background/services/locker", () => {
       mockSet.mockClear();
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        instance.get.mockResolvedValue(undefined);
+        instance.get
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValue(defaultPassword);
       });
 
       await lockService.uploadEncryptedStorage("encrypted", defaultPassword);

--- a/packages/app/src/background/services/lock/index.ts
+++ b/packages/app/src/background/services/lock/index.ts
@@ -72,8 +72,8 @@ export default class LockerService implements IBackupable {
     }
 
     await this.writePassword(password);
-    await this.unlock(password);
     await this.miscStorage.setInitialization({ initializationStep: InitializationStep.PASSWORD });
+    await this.unlock(password);
   };
 
   resetPassword = async ({ mnemonic, password }: ISecretArgs): Promise<void> => {
@@ -187,10 +187,7 @@ export default class LockerService implements IBackupable {
       throw new Error("Incorrect backup format for password");
     }
 
-    const backup = this.cryptoService.decrypt(authenticBackupCiphertext, { secret: backupPassword });
-    const encrypted = this.cryptoService.encrypt(backup, { mode: ECryptMode.PASSWORD });
-    await this.passwordStorage.set(encrypted);
-    this.cryptoService.setPassword(backupPassword);
+    await this.setupPassword(backupPassword);
   };
 
   private isAuthentic = async (password: string, isBackupAvaiable: boolean): Promise<AuthenticityCheckData> => {

--- a/packages/app/src/constants/paths.ts
+++ b/packages/app/src/constants/paths.ts
@@ -4,6 +4,7 @@ export enum Paths {
   CREATE_IDENTITY = "/create-identity",
   LOGIN = "/login",
   ONBOARDING = "/onboarding",
+  ONBOARDING_BACKUP = "/onboarding-backup",
   GENERATE_MNEMONIC = "/generate-mnemonic",
   REVEAL_MNEMONIC = "/reveal-mnemonic",
   REQUESTS = "/requests",

--- a/packages/app/src/ui/components/Button/index.tsx
+++ b/packages/app/src/ui/components/Button/index.tsx
@@ -1,9 +1,6 @@
 import classNames from "classnames";
 import { ButtonHTMLAttributes } from "react";
 
-import loaderSvg from "@src/static/icons/loader.svg";
-import { Icon } from "@src/ui/components/Icon";
-
 import "./button.scss";
 
 export enum ButtonType {
@@ -41,8 +38,6 @@ export const Button = ({
     type="button"
     {...buttonProps}
   >
-    {loading && <Icon className="button__loader" size={2} url={loaderSvg} />}
-
-    {!loading && children}
+    {children}
   </button>
 );

--- a/packages/app/src/ui/ducks/__tests__/backup.test.ts
+++ b/packages/app/src/ui/ducks/__tests__/backup.test.ts
@@ -7,7 +7,7 @@ import { RPCAction } from "@cryptkeeperzk/providers";
 import { store } from "@src/ui/store/configureAppStore";
 import postMessage from "@src/util/postMessage";
 
-import { createUploadBackupRequest, downloadBackup, uploadBackup } from "../backup";
+import { createOnboardingBackupRequest, createUploadBackupRequest, downloadBackup, uploadBackup } from "../backup";
 
 jest.mock("@src/util/postMessage");
 
@@ -32,6 +32,15 @@ describe("ui/ducks/backup", () => {
     expect(postMessage).toBeCalledTimes(1);
     expect(postMessage).toBeCalledWith({
       method: RPCAction.REQUEST_UPLOAD_BACKUP,
+    });
+  });
+
+  test("should create onboarding backup request properly", async () => {
+    await Promise.resolve(store.dispatch(createOnboardingBackupRequest()));
+
+    expect(postMessage).toBeCalledTimes(1);
+    expect(postMessage).toBeCalledWith({
+      method: RPCAction.REQUEST_ONBOARDING_BACKUP,
     });
   });
 

--- a/packages/app/src/ui/ducks/backup.ts
+++ b/packages/app/src/ui/ducks/backup.ts
@@ -18,6 +18,11 @@ export const createUploadBackupRequest = (): TypedThunk<Promise<void>> => async 
     method: RPCAction.REQUEST_UPLOAD_BACKUP,
   });
 
+export const createOnboardingBackupRequest = (): TypedThunk<Promise<void>> => async () =>
+  postMessage({
+    method: RPCAction.REQUEST_ONBOARDING_BACKUP,
+  });
+
 export const uploadBackup =
   ({ content, password, backupPassword }: IUploadArgs): TypedThunk<Promise<void>> =>
   async () =>

--- a/packages/app/src/ui/pages/Login/Login.tsx
+++ b/packages/app/src/ui/pages/Login/Login.tsx
@@ -23,7 +23,7 @@ const Login = (): JSX.Element => {
       onSubmit={onSubmit}
     >
       <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", p: 3, flexGrow: 1 }}>
-        <Icon className="login-icon" url={logoSVG} />
+        <Icon size={8} url={logoSVG} />
 
         <Typography sx={{ pt: 3, fontWeight: "bold" }} variant="h4">
           Welcome Back!

--- a/packages/app/src/ui/pages/Login/login.scss
+++ b/packages/app/src/ui/pages/Login/login.scss
@@ -2,9 +2,4 @@
 
 .login {
   color: $primary-green;
-
-  &-icon {
-    width: 8rem !important;
-    height: 8rem !important;
-  }
 }

--- a/packages/app/src/ui/pages/Onboarding/Onboarding.tsx
+++ b/packages/app/src/ui/pages/Onboarding/Onboarding.tsx
@@ -1,5 +1,8 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+
 import logoSVG from "@src/static/icons/logo.svg";
-import { ButtonType, Button } from "@src/ui/components/Button";
 import { Icon } from "@src/ui/components/Icon";
 import { PasswordInput } from "@src/ui/components/PasswordInput";
 
@@ -7,20 +10,27 @@ import "./onboarding.scss";
 import { useOnboarding } from "./useOnboarding";
 
 const Onboarding = (): JSX.Element => {
-  const { errors, isLoading, register, onSubmit, isShowPassword, onShowPassword } = useOnboarding();
+  const { errors, isLoading, register, onSubmit, isShowPassword, onShowPassword, onGoToOnboardingBackup } =
+    useOnboarding();
 
   return (
-    <form className="flex flex-col flex-nowrap h-full onboarding" data-testid="onboarding-form" onSubmit={onSubmit}>
-      <div className="flex flex-col items-center flex-grow p-8 onboarding__content">
+    <Box
+      className="onboarding"
+      component="form"
+      data-testid="onboarding-form"
+      sx={{ display: "flex", flexDirection: "column", flexWrap: "nowrap", height: "100%" }}
+      onSubmit={onSubmit}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1, p: 3 }}>
         <Icon size={8} url={logoSVG} />
 
-        <div className="text-lg pt-8">
-          <b>Thanks for using CryptKeeper!</b>
-        </div>
+        <Typography sx={{ pt: 3, fontWeight: "bold" }} variant="h4">
+          Thanks for using CryptKeeper!
+        </Typography>
 
-        <div className="text-base">To continue, please setup a password</div>
+        <Typography>To continue, please setup a password</Typography>
 
-        <div className="py-4 w-full password-input">
+        <Box sx={{ width: "100%", py: 2 }}>
           <PasswordInput
             autoFocus
             isShowEye
@@ -34,24 +44,41 @@ const Onboarding = (): JSX.Element => {
           />
 
           <PasswordInput
-            errorMessage={errors.confirmPassword}
+            errorMessage={errors.confirmPassword || errors.root}
             id="confirmPassword"
             isShowPassword={isShowPassword}
             label="Confirm Password"
             onShowPassword={onShowPassword}
             {...register("confirmPassword")}
           />
-        </div>
-      </div>
+        </Box>
+      </Box>
 
-      {errors.root && <div className="text-red-500 text-sm text-center">{errors.root}</div>}
-
-      <div className="flex flex-row items-center justify-center flex-shrink p-8 onboarding__footer">
-        <Button buttonType={ButtonType.PRIMARY} data-testid="submit-button" loading={isLoading} type="submit">
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          flexShrink: 1,
+          p: 3,
+        }}
+      >
+        <Button
+          data-testid="submit-button"
+          disabled={isLoading}
+          sx={{ textTransform: "none", mb: 1 }}
+          type="submit"
+          variant="contained"
+        >
           Continue
         </Button>
-      </div>
-    </form>
+
+        <Button sx={{ color: "primary.main" }} variant="text" onClick={onGoToOnboardingBackup}>
+          Have backup?
+        </Button>
+      </Box>
+    </Box>
   );
 };
 

--- a/packages/app/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
+++ b/packages/app/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { setupPassword } from "@src/ui/ducks/app";
+import { createOnboardingBackupRequest } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 
 import type { ChangeEvent } from "react";
@@ -19,6 +20,10 @@ jest.mock("react-router-dom", () => ({
 
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   setupPassword: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/backup", (): unknown => ({
+  createOnboardingBackupRequest: jest.fn(),
 }));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
@@ -50,6 +55,7 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
     const { result } = renderHook(() => useOnboarding());
 
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.isShowPassword).toStrictEqual(false);
     expect(result.current.errors).toStrictEqual({ password: undefined, confirmPassword: undefined, root: undefined });
   });
 
@@ -101,13 +107,7 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
     expect(result.current.errors.root).toBe(error.message);
   });
 
-  test("should isShowPassword set to false as default", () => {
-    const { result } = renderHook(() => useOnboarding());
-
-    expect(result.current.isShowPassword).toStrictEqual(false);
-  });
-
-  test("should be able to change isShowPassword", () => {
+  test("should change password visibility properly", () => {
     const { result } = renderHook(() => useOnboarding());
 
     act(() => result.current.onShowPassword());
@@ -115,5 +115,14 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
 
     act(() => result.current.onShowPassword());
     expect(result.current.isShowPassword).toStrictEqual(false);
+  });
+
+  test("should go to onboardin backup page properly", () => {
+    const { result } = renderHook(() => useOnboarding());
+
+    act(() => result.current.onGoToOnboardingBackup());
+
+    expect(mockDispatch).toBeCalledTimes(1);
+    expect(createOnboardingBackupRequest).toBeCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/Onboarding/useOnboarding.ts
+++ b/packages/app/src/ui/pages/Onboarding/useOnboarding.ts
@@ -6,6 +6,7 @@ import { object, ref, string } from "yup";
 import { Paths } from "@src/constants";
 import { PasswordFormFields } from "@src/types";
 import { setupPassword } from "@src/ui/ducks/app";
+import { createOnboardingBackupRequest } from "@src/ui/ducks/backup";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { useValidationResolver } from "@src/ui/hooks/validation";
 
@@ -16,6 +17,7 @@ export interface IUseOnboardingData {
   register: UseFormRegister<PasswordFormFields>;
   onSubmit: (event?: BaseSyntheticEvent) => Promise<void>;
   onShowPassword: () => void;
+  onGoToOnboardingBackup: () => void;
 }
 
 const passwordRules = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/;
@@ -64,6 +66,10 @@ export const useOnboarding = (): IUseOnboardingData => {
     setIsShowPassword((isShow) => !isShow);
   }, [setIsShowPassword]);
 
+  const onGoToOnboardingBackup = useCallback(() => {
+    dispatch(createOnboardingBackupRequest()).then(() => navigate(Paths.ONBOARDING_BACKUP));
+  }, [dispatch, navigate]);
+
   return {
     isLoading: isLoading || isSubmitting,
     isShowPassword,
@@ -75,5 +81,6 @@ export const useOnboarding = (): IUseOnboardingData => {
     register,
     onSubmit: handleSubmit(onSubmit),
     onShowPassword,
+    onGoToOnboardingBackup,
   };
 };

--- a/packages/app/src/ui/pages/OnboardingBackup/OnboardingBackup.tsx
+++ b/packages/app/src/ui/pages/OnboardingBackup/OnboardingBackup.tsx
@@ -6,14 +6,15 @@ import { Icon } from "@src/ui/components/Icon";
 import { PasswordInput } from "@src/ui/components/PasswordInput";
 import { UploadInput } from "@src/ui/components/UploadInput/UploadInput";
 
-import { useUploadBackup } from "./useUploadBackup";
+import { useOnboardingBackup } from "./useOnboardingBackup";
 
-const UploadBackup = (): JSX.Element => {
-  const { isShowPassword, isLoading, errors, register, onDrop, onGoBack, onShowPassword, onSubmit } = useUploadBackup();
+const OnboardingBackup = (): JSX.Element => {
+  const { isShowPassword, isLoading, errors, register, onDrop, onGoBack, onShowPassword, onSubmit } =
+    useOnboardingBackup();
 
   return (
     <Box
-      data-testid="upload-backup-page"
+      data-testid="onboarding-backup-page"
       sx={{ display: "flex", flexDirection: "column", flexWrap: "nowrap", height: "100%" }}
     >
       <Box sx={{ display: "flex", flexDirection: "column", p: 2, flexGrow: 1 }}>
@@ -36,11 +37,11 @@ const UploadBackup = (): JSX.Element => {
         >
           <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexGrow: 1, width: "100%" }}>
             <Typography fontWeight="bold" variant="body1">
-              To upload your backup, please provide backup file and enter your current and backup password.
+              To upload your backup, please provide backup file and backup password.
             </Typography>
 
             <Typography sx={{ my: 1, alignSelf: "flex-start" }} variant="body1">
-              Note: backup will not override your password and mnemonic phrase
+              Note: backup will use backup password as your login password and mnemonic phrase from backup file
             </Typography>
 
             <UploadInput
@@ -55,17 +56,6 @@ const UploadBackup = (): JSX.Element => {
             <Box sx={{ width: "100%" }}>
               <PasswordInput
                 isShowEye
-                errorMessage={errors.password}
-                id="password"
-                isShowPassword={isShowPassword}
-                label="Password"
-                onShowPassword={onShowPassword}
-                {...register("password", { required: "Password is required" })}
-              />
-            </Box>
-
-            <Box sx={{ width: "100%" }}>
-              <PasswordInput
                 errorMessage={errors.backupPassword}
                 id="backupPassword"
                 isShowPassword={isShowPassword}
@@ -97,4 +87,4 @@ const UploadBackup = (): JSX.Element => {
   );
 };
 
-export default UploadBackup;
+export default OnboardingBackup;

--- a/packages/app/src/ui/pages/OnboardingBackup/__tests__/OnboardingBackup.test.tsx
+++ b/packages/app/src/ui/pages/OnboardingBackup/__tests__/OnboardingBackup.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+
+import { createDataTransfer, mockJsonFile } from "@src/config/mock/file";
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
+
+import UploadBackup from "..";
+import { IUseOnboardingBackupData, useOnboardingBackup } from "../useOnboardingBackup";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
+}));
+
+jest.mock("../useOnboardingBackup", (): unknown => ({
+  useOnboardingBackup: jest.fn(),
+}));
+
+describe("ui/pages/OnboardingBackup", () => {
+  const defaultHookData: IUseOnboardingBackupData = {
+    isLoading: false,
+    isShowPassword: false,
+    register: jest.fn(),
+    errors: {},
+    onDrop: jest.fn(),
+    onShowPassword: jest.fn(),
+    onSubmit: jest.fn(),
+    onGoBack: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useOnboardingBackup as jest.Mock).mockReturnValue(defaultHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { container, findByTestId } = render(
+      <Suspense>
+        <UploadBackup />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const page = await findByTestId("onboarding-backup-page");
+
+    expect(page).toBeInTheDocument();
+  });
+
+  test("should submit form properly", async () => {
+    const { container, findByLabelText, findByTestId } = render(
+      <Suspense>
+        <UploadBackup />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const data = createDataTransfer([mockJsonFile]);
+    await act(() => fireEvent.drop(container.querySelector(".dropzone")!, data));
+
+    const backupPasswordInput = await findByLabelText("Backup password");
+    await act(() => fireEvent.change(backupPasswordInput, { target: { value: "password" } }));
+
+    const button = await findByTestId("upload-button");
+    await act(async () => Promise.resolve(fireEvent.submit(button)));
+
+    expect(defaultHookData.onDrop).toBeCalledTimes(1);
+    expect(defaultHookData.onSubmit).toBeCalledTimes(1);
+  });
+});

--- a/packages/app/src/ui/pages/OnboardingBackup/__tests__/useOnboardingBackup.test.ts
+++ b/packages/app/src/ui/pages/OnboardingBackup/__tests__/useOnboardingBackup.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
+
+import { mockJsonFile } from "@src/config/mock/file";
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { Paths } from "@src/constants";
+import { closePopup, fetchStatus } from "@src/ui/ducks/app";
+import { uploadBackup } from "@src/ui/ducks/backup";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { useCryptKeeperWallet } from "@src/ui/hooks/wallet";
+import { readFile } from "@src/util/file";
+
+import { useOnboardingBackup } from "../useOnboardingBackup";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useCryptKeeperWallet: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/app", (): unknown => ({
+  fetchStatus: jest.fn(),
+  closePopup: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/backup", (): unknown => ({
+  uploadBackup: jest.fn(),
+}));
+
+jest.mock("@src/util/file", (): unknown => ({
+  readFile: jest.fn(),
+}));
+
+describe("ui/pages/OnboardingBackup/useOnboardingBackup", () => {
+  const mockNavigate = jest.fn();
+  const mockDispatch = jest.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    (readFile as jest.Mock).mockResolvedValue({ target: { result: "{}" } });
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return initial data", () => {
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isShowPassword).toBe(false);
+    expect(result.current.errors).toStrictEqual({
+      backupPassword: undefined,
+      backupFile: undefined,
+      root: undefined,
+    });
+  });
+
+  test("should toggle password properly", () => {
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    act(() => result.current.onShowPassword());
+    expect(result.current.isShowPassword).toStrictEqual(true);
+
+    act(() => result.current.onShowPassword());
+    expect(result.current.isShowPassword).toStrictEqual(false);
+  });
+
+  test("should go back properly", () => {
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    act(() => result.current.onGoBack());
+
+    expect(mockDispatch).toBeCalledTimes(1);
+    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(-1);
+  });
+
+  test("should drop files properly", () => {
+    const acceptedFiles = [mockJsonFile];
+
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    act(() => result.current.onDrop(acceptedFiles, [], new Event("drop")));
+
+    expect(result.current.errors.backupFile).toBeUndefined();
+  });
+
+  test("should drop files and handle reject errors properly", () => {
+    const rejectedFiles = [{ file: mockJsonFile, errors: [{ code: "code", message: "error" }] }];
+
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    act(() => result.current.onDrop([], rejectedFiles, new Event("drop")));
+
+    expect(result.current.errors.backupFile).toBe("error");
+  });
+
+  test("should submit properly", async () => {
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    await act(() =>
+      Promise.resolve(result.current.register("backupPassword").onChange({ target: { value: "backupPassword" } })),
+    );
+
+    await act(() => Promise.resolve(result.current.onDrop([mockJsonFile], [], new Event("drop"))));
+
+    await act(() => Promise.resolve(result.current.onSubmit()));
+
+    expect(uploadBackup).toBeCalledTimes(1);
+    expect(fetchStatus).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+  });
+
+  test("should handle submit error properly", async () => {
+    const error = new Error("error");
+    (mockDispatch as jest.Mock).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    await act(() => Promise.resolve(result.current.onSubmit()));
+
+    expect(result.current.errors.root).toBe(error.message);
+  });
+
+  test("should handle empty file read error properly", async () => {
+    (readFile as jest.Mock).mockResolvedValue("");
+
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    await act(() => Promise.resolve(result.current.onSubmit()));
+
+    expect(result.current.errors.root).toBe("Backup file is empty");
+  });
+
+  test("should handle file read error properly", async () => {
+    const error = new Error("error");
+    (readFile as jest.Mock).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useOnboardingBackup());
+
+    await act(() => Promise.resolve(result.current.onSubmit()));
+
+    expect(result.current.errors.root).toBe(error.message);
+  });
+});

--- a/packages/app/src/ui/pages/OnboardingBackup/index.ts
+++ b/packages/app/src/ui/pages/OnboardingBackup/index.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export default lazy(() => import("./OnboardingBackup"));

--- a/packages/app/src/ui/pages/OnboardingBackup/useOnboardingBackup.ts
+++ b/packages/app/src/ui/pages/OnboardingBackup/useOnboardingBackup.ts
@@ -1,0 +1,117 @@
+import { BaseSyntheticEvent, useCallback, useState } from "react";
+import { FileRejection } from "react-dropzone";
+import { UseFormRegister, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+import { closePopup, fetchStatus } from "@src/ui/ducks/app";
+import { uploadBackup } from "@src/ui/ducks/backup";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import { useCryptKeeperWallet } from "@src/ui/hooks/wallet";
+import { readFile } from "@src/util/file";
+
+import type { onDropCallback } from "@src/ui/components/UploadInput";
+
+export interface IUseOnboardingBackupData {
+  isLoading: boolean;
+  isShowPassword: boolean;
+  errors: { backupPassword?: string; backupFile?: string; root?: string };
+  register: UseFormRegister<IOnboardingBackupFields>;
+  onDrop: onDropCallback;
+  onSubmit: (event?: BaseSyntheticEvent) => Promise<void>;
+  onShowPassword: () => void;
+  onGoBack: () => void;
+}
+
+interface IOnboardingBackupFields {
+  backupPassword: string;
+  backupFile: File;
+}
+
+export const useOnboardingBackup = (): IUseOnboardingBackupData => {
+  const [isShowPassword, setIsShowPassword] = useState(false);
+  const { onConnect } = useCryptKeeperWallet();
+
+  const {
+    formState: { isLoading, isSubmitting, errors },
+    setError,
+    setValue,
+    register,
+    handleSubmit,
+    clearErrors,
+  } = useForm<IOnboardingBackupFields>({
+    defaultValues: {
+      backupPassword: "",
+      backupFile: undefined,
+    },
+  });
+
+  const onDrop = useCallback(
+    ([acceptedFile]: File[], [rejectedFile]: FileRejection[]) => {
+      setValue("backupFile", acceptedFile);
+
+      if (rejectedFile) {
+        setError("backupFile", { message: rejectedFile.errors[0].message });
+      } else {
+        clearErrors();
+      }
+    },
+    [setValue, setError, clearErrors],
+  );
+
+  const navigate = useNavigate();
+
+  const dispatch = useAppDispatch();
+
+  const onGoBack = useCallback(() => {
+    dispatch(closePopup());
+    navigate(-1);
+  }, [dispatch, navigate]);
+
+  const onSubmit = useCallback(
+    async (data: IOnboardingBackupFields) => {
+      const content = await readFile(data.backupFile)
+        .then((res) => {
+          const text = res.target?.result;
+
+          if (!text) {
+            setError("root", { message: "Backup file is empty" });
+          }
+
+          return text?.toString();
+        })
+        .catch((error: Error) => setError("root", { message: error.message }));
+
+      if (!content) {
+        return;
+      }
+
+      dispatch(uploadBackup({ password: "", backupPassword: data.backupPassword, content }))
+        .then(() => onConnect())
+        .then(() => dispatch(fetchStatus()))
+        .then(() => dispatch(closePopup()))
+        .then(() => navigate(Paths.HOME))
+        .catch((error: Error) => setError("root", { message: error.message }));
+    },
+    [dispatch, navigate, setError, onConnect],
+  );
+
+  const onShowPassword = useCallback(() => {
+    setIsShowPassword((isShow) => !isShow);
+  }, [setIsShowPassword]);
+
+  return {
+    isLoading: isLoading || isSubmitting,
+    isShowPassword,
+    errors: {
+      backupPassword: errors.backupPassword?.message,
+      backupFile: errors.backupFile?.message,
+      root: errors.root?.message,
+    },
+    register,
+    onDrop,
+    onSubmit: handleSubmit(onSubmit),
+    onShowPassword,
+    onGoBack,
+  };
+};

--- a/packages/app/src/ui/pages/Popup/Popup.tsx
+++ b/packages/app/src/ui/pages/Popup/Popup.tsx
@@ -9,6 +9,7 @@ import GenerateMnemonic from "@src/ui/pages/GenerateMnemonic";
 import Home from "@src/ui/pages/Home";
 import Login from "@src/ui/pages/Login";
 import Onboarding from "@src/ui/pages/Onboarding";
+import OnboardingBackup from "@src/ui/pages/OnboardingBackup";
 import Recover from "@src/ui/pages/Recover";
 import ResetPassword from "@src/ui/pages/ResetPassword";
 import RevealMnemonic from "@src/ui/pages/RevealMnemonic";
@@ -24,6 +25,7 @@ const routeConfig: RouteObject[] = [
   { path: Paths.CREATE_IDENTITY, element: <CreateIdentity /> },
   { path: Paths.LOGIN, element: <Login /> },
   { path: Paths.ONBOARDING, element: <Onboarding /> },
+  { path: Paths.ONBOARDING_BACKUP, element: <OnboardingBackup /> },
   { path: Paths.REQUESTS, element: <ConfirmRequestModal /> },
   { path: Paths.SETTINGS, element: <Settings /> },
   { path: Paths.DOWNLOAD_BACKUP, element: <DownloadBackup /> },

--- a/packages/providers/src/constants/rpcAction.ts
+++ b/packages/providers/src/constants/rpcAction.ts
@@ -39,6 +39,7 @@ export enum RPCAction {
   ENABLE_OPERATION_HISTORY = "rpc/identity/historyEnable",
   DOWNLOAD_BACKUP = "rpc/backup/download",
   REQUEST_UPLOAD_BACKUP = "rpc/backup/requestUpload",
+  REQUEST_ONBOARDING_BACKUP = "rpc/backup/requestOnboarding",
   UPLOAD_BACKUP = "rpc/backup/upload",
   SAVE_MNEMONIC = "rpc/mnemonic/save",
   GENERATE_MNEMONIC = "rpc/mnemonic/generate",


### PR DESCRIPTION
## Explanation

This PR adds support for uploading backup file as a part of onboarding flow.

Details are below:
- [x] Add backup flow for new users
- [x] Fix styles for onboarding page
- [x] Fix styles for backup upload page
- [x] Support redirect param for common paths
- [x] Integrate new user backup upload
- [x] Update backup upload method to load data in the right sequence

## More Information

Blocked by #664
Related to #330 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/4923cdf3-53ed-4b4d-a848-70ccf49eeca2)

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/f89f77e3-b7d0-4fd2-8c4b-a0c92875544b)


## Manual Testing Steps

1. Install the extension
2. Create new account
3. Create some identities, generate some proofs from demo
4. Download backup file
5. Delete and install the extension again
6. Try to upload backup file from onboarding flow
7. Check the accounts, identities and all data related

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
