### PR TITLE
feat: integrate `RLN` UI

### DIFF
--- a/packages/app/src/background/controllers/__tests__/requestManager.test.ts
+++ b/packages/app/src/background/controllers/__tests__/requestManager.test.ts
@@ -1,4 +1,5 @@
-import { PendingRequestType, RequestResolutionStatus } from "@src/types";
+import { PendingRequestType, RequestResolutionStatus } from "@cryptkeeperzk/types";
+
 import { setPendingRequests } from "@src/ui/ducks/requests";
 import pushMessage from "@src/util/pushMessage";
 

--- a/packages/app/src/background/controllers/handler.ts
+++ b/packages/app/src/background/controllers/handler.ts
@@ -1,6 +1,6 @@
 import { getExtensionUrl, getUrlOrigin } from "@src/util/browser";
 
-import type { RequestHandler } from "@src/types";
+import type { RequestHandler } from "@cryptkeeperzk/types";
 import type { Runtime } from "webextension-polyfill";
 
 // TODO: eslint fix any

--- a/packages/app/src/background/controllers/requestManager.ts
+++ b/packages/app/src/background/controllers/requestManager.ts
@@ -1,6 +1,11 @@
+import {
+  PendingRequest,
+  PendingRequestType,
+  RequestResolutionAction,
+  RequestResolutionStatus,
+} from "@cryptkeeperzk/types";
 import { EventEmitter2 } from "eventemitter2";
 
-import { PendingRequest, PendingRequestType, RequestResolutionAction, RequestResolutionStatus } from "@src/types";
 import { setPendingRequests } from "@src/ui/ducks/requests";
 import pushMessage from "@src/util/pushMessage";
 

--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -1,6 +1,7 @@
 import { RPCAction } from "@cryptkeeperzk/providers";
+import { RequestHandler } from "@cryptkeeperzk/types";
 
-import { BackupableServices, RequestHandler } from "@src/types";
+import { BackupableServices } from "@src/types";
 
 import type { Runtime } from "webextension-polyfill";
 

--- a/packages/app/src/background/services/history/types.ts
+++ b/packages/app/src/background/services/history/types.ts
@@ -1,4 +1,6 @@
-import { IdentityData, OperationType, Operation, HistorySettings } from "@src/types";
+import { IdentityData } from "@cryptkeeperzk/types";
+
+import { OperationType, Operation, HistorySettings } from "@src/types";
 
 export interface OperationOptions {
   identity?: IdentityData;

--- a/packages/app/src/background/services/injector/types.ts
+++ b/packages/app/src/background/services/injector/types.ts
@@ -5,10 +5,6 @@ export interface IProofRequest<P = IRlnProofRequest | ISemaphoreProofRequest> {
   payload: P;
 }
 
-export interface IMeta {
-  origin: string;
-}
-
 export interface IConnectData {
   isApproved: boolean;
   canSkipApprove: boolean;

--- a/packages/app/src/background/services/validation/__tests__/zkValidator.test.ts
+++ b/packages/app/src/background/services/validation/__tests__/zkValidator.test.ts
@@ -1,4 +1,4 @@
-import { ZkInputs } from "@src/types";
+import { ZkInputs } from "@cryptkeeperzk/types";
 
 import { validateZkInputs } from "..";
 

--- a/packages/app/src/background/services/validation/artifact.ts
+++ b/packages/app/src/background/services/validation/artifact.ts
@@ -1,4 +1,4 @@
-import type { MerkleProofArtifacts } from "@src/types";
+import type { MerkleProofArtifacts } from "@cryptkeeperzk/types";
 
 export enum ArtifactsProofValidatorErrors {
   INVALID_DEPTH = "invalid-depth",

--- a/packages/app/src/background/services/validation/index.ts
+++ b/packages/app/src/background/services/validation/index.ts
@@ -1,4 +1,4 @@
-import { ZkInputs } from "@src/types";
+import { ZkInputs } from "@cryptkeeperzk/types";
 
 import { ArtifactsProofValidator } from "./artifact";
 import { MerkleProofValidator } from "./merkle";

--- a/packages/app/src/offscreen/__tests__/offscreenController.test.ts
+++ b/packages/app/src/offscreen/__tests__/offscreenController.test.ts
@@ -31,6 +31,7 @@ describe("offscreen/offscreenController", () => {
     circuitFilePath: "circuitFilePath",
     verificationKey: "verificationKey",
     zkeyFilePath: "zkeyFilePath",
+    urlOrigin: "origin",
   };
 
   const defaultMerkleProof: MerkleProof = {

--- a/packages/app/src/ui/components/AccountMenu/AccountMenu.tsx
+++ b/packages/app/src/ui/components/AccountMenu/AccountMenu.tsx
@@ -1,3 +1,4 @@
+import { EWallet } from "@cryptkeeperzk/types";
 import Badge from "@mui/material/Badge";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
@@ -8,7 +9,7 @@ import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 
-import { EWallet, IUseWalletData } from "@src/types";
+import { IUseWalletData } from "@src/types";
 import { ellipsify } from "@src/util/account";
 import { isExtensionPopupOpen } from "@src/util/browser";
 

--- a/packages/app/src/ui/components/AccountMenu/useAccountMenu.ts
+++ b/packages/app/src/ui/components/AccountMenu/useAccountMenu.ts
@@ -1,8 +1,9 @@
+import { EWallet } from "@cryptkeeperzk/types";
 import { useCallback, useMemo, useState, MouseEvent as ReactMouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
-import { EWallet, IUseWalletData } from "@src/types";
+import { IUseWalletData } from "@src/types";
 import { selectAccount } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { redirectToNewTab } from "@src/util/browser";

--- a/packages/app/src/ui/components/ConfirmRequestModal/ConfirmRequestModal.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/ConfirmRequestModal.tsx
@@ -1,6 +1,7 @@
-import { PendingRequest, PendingRequestType, ZKProofPayload } from "@src/types";
+import { IRlnProofRequest, PendingRequest, PendingRequestType, ZKProofPayload } from "@cryptkeeperzk/types";
 
-import { ProofModal, ConnectionApprovalModal, DefaultApprovalModal } from "./components";
+import { SemaphoreProofModal, ConnectionApprovalModal, DefaultApprovalModal } from "./components";
+import { RlnProofModal } from "./components/RlnProofModal";
 import "./confirmModal.scss";
 import { useConfirmRequestModal } from "./useConfirmRequestModal";
 
@@ -22,14 +23,24 @@ const ConfirmRequestModal = (): JSX.Element | null => {
         />
       );
     case PendingRequestType.SEMAPHORE_PROOF:
-    case PendingRequestType.RLN_PROOF:
       return (
-        <ProofModal
+        <SemaphoreProofModal
           accept={accept}
           error={error}
           len={pendingRequests.length}
           loading={loading}
           pendingRequest={pendingRequest as PendingRequest<ZKProofPayload>}
+          reject={reject}
+        />
+      );
+    case PendingRequestType.RLN_PROOF:
+      return (
+        <RlnProofModal
+          accept={accept}
+          error={error}
+          len={pendingRequests.length}
+          loading={loading}
+          pendingRequest={pendingRequest as PendingRequest<Omit<IRlnProofRequest, "identitySerialized">>}
           reject={reject}
         />
       );

--- a/packages/app/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/__tests__/ConfirmRequestModal.test.tsx
@@ -128,7 +128,7 @@ describe("ui/components/ConfirmRequestModal", () => {
 
     await waitFor(() => container.firstChild !== null);
 
-    const title = await screen.findByText("Generate RLN Proof");
+    const title = await screen.findByText("Generate Rate-Limiting Nullifier (RLN) Proof");
 
     expect(title).toBeInTheDocument();
   });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/ConnectionApprovalModal.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/ConnectionApprovalModal.tsx
@@ -1,4 +1,5 @@
-import { PendingRequest } from "@src/types";
+import { PendingRequest } from "@cryptkeeperzk/types";
+
 import { ButtonType, Button } from "@src/ui/components/Button";
 import { Checkbox } from "@src/ui/components/Checkbox";
 import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/index.ts
@@ -1,1 +1,1 @@
-export * from "./ConnectionApprovalModal";
+export { ConnectionApprovalModal, type ConnectionApprovalModalProps } from "./ConnectionApprovalModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/useConnectionApprovalModal.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/useConnectionApprovalModal.ts
@@ -1,7 +1,7 @@
+import { PendingRequest } from "@cryptkeeperzk/types";
 import { getLinkPreview } from "link-preview-js";
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
 
-import { PendingRequest } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchHostPermissions, setHostPermissions, useHostPermission } from "@src/ui/ducks/permissions";
 

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/DefaultApprovalModal.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/DefaultApprovalModal.tsx
@@ -1,4 +1,5 @@
-import { PendingRequest } from "@src/types";
+import { PendingRequest } from "@cryptkeeperzk/types";
+
 import { ButtonType, Button } from "@src/ui/components/Button";
 import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
 

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/index.ts
@@ -1,1 +1,1 @@
-export * from "./DefaultApprovalModal";
+export { DefaultApprovalModal, type DefaultApprovalModalProps } from "./DefaultApprovalModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ProofModal/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ProofModal/index.ts
@@ -1,1 +1,0 @@
-export * from "./ProofModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/RlnProofModal.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/RlnProofModal.tsx
@@ -1,4 +1,5 @@
-import { PendingRequest, ZKProofPayload } from "@src/types";
+import { IRlnProofRequest, PendingRequest } from "@cryptkeeperzk/types";
+
 import { ButtonType, Button } from "@src/ui/components/Button";
 import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
 import { Icon } from "@src/ui/components/Icon";
@@ -6,21 +7,27 @@ import { Input } from "@src/ui/components/Input";
 
 import "../../confirmModal.scss";
 
-import { useProofModal } from "./useProofModal";
+import { useRlnProofModal } from "./useRlnProofModal";
 
-export interface ProofModalProps {
+export interface RlnProofModalProps {
   len: number;
   loading: boolean;
   error: string;
-  pendingRequest: PendingRequest<ZKProofPayload>;
+  pendingRequest: PendingRequest<Omit<IRlnProofRequest, "identitySerialized">>;
   accept: () => void;
   reject: () => void;
 }
 
-export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error }: ProofModalProps): JSX.Element => {
+export const RlnProofModal = ({
+  pendingRequest,
+  len,
+  reject,
+  accept,
+  loading,
+  error,
+}: RlnProofModalProps): JSX.Element => {
   const {
-    host,
-    operation,
+    urlOrigin,
     payload,
     faviconUrl,
     onAccept,
@@ -28,7 +35,7 @@ export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error
     onOpenCircuitFile,
     onOpenVerificationKeyFile,
     onOpenZkeyFile,
-  } = useProofModal({
+  } = useRlnProofModal({
     pendingRequest,
     accept,
     reject,
@@ -37,8 +44,7 @@ export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error
   return (
     <FullModal className="confirm-modal" data-testid="proof-modal" onClose={onReject}>
       <FullModalHeader>
-        {operation}
-
+        Generate Rate-Limiting Nullifier (RLN) Proof
         {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
       </FullModalHeader>
 
@@ -55,7 +61,7 @@ export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error
           />
         </div>
 
-        <div className="text-lg font-semibold mb-2 text-center">{`${host} is requesting a semaphore proof`}</div>
+        <div className="text-lg font-semibold mb-2 text-center">{`${urlOrigin} is requesting a Rate-Limiting Nullifier (RLN) proof`}</div>
 
         <div className="semaphore-proof__files flex flex-row items-center mb-2">
           <div className="semaphore-proof__file">
@@ -81,9 +87,22 @@ export const ProofModal = ({ pendingRequest, len, reject, accept, loading, error
           </div>
         </div>
 
-        <Input readOnly className="w-full mb-2" defaultValue={payload?.externalNullifier} label="External Nullifier" />
+        <Input
+          readOnly
+          className="w-full mb-2"
+          defaultValue={payload?.rlnIdentifier.toString()}
+          label="Rln Identifier"
+        />
 
-        <Input readOnly className="w-full mb-2" defaultValue={payload?.signal} label="Signal" />
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.message} label="Message" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.messageId.toString()} label="Message Id" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.messageLimit.toString()} label="Message Limit" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.messageId.toString()} label="Message Id" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.epoch.toString()} label="Epoch" />
       </FullModalContent>
 
       {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/RlnProofModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/RlnProofModal.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { PendingRequestType } from "@cryptkeeperzk/types";
+import { act, render, screen } from "@testing-library/react";
+
+import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
+
+import { RlnProofModal, RlnProofModalProps } from "..";
+import { IUseRlnProofModalData, useRlnProofModal } from "../useRlnProofModal";
+
+jest.mock("../useRlnProofModal", (): unknown => ({
+  useRlnProofModal: jest.fn(),
+}));
+
+describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
+  const defaultProps: RlnProofModalProps = {
+    len: 1,
+    loading: false,
+    error: "",
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.SEMAPHORE_PROOF,
+      payload: {
+        rlnIdentifier: "rlnIdentifier",
+        message: "externalNullifier",
+        messageId: 1,
+        messageLimit: 0,
+        epoch: "1234",
+        circuitFilePath: "circuitFilePath",
+        verificationKey: "verificationKey",
+        zkeyFilePath: "zkeyFilePath",
+        urlOrigin: "http://localhost:3000",
+      },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const defaultHookData: IUseRlnProofModalData = {
+    urlOrigin: defaultProps.pendingRequest.payload!.urlOrigin,
+    faviconUrl: "",
+    payload: defaultProps.pendingRequest.payload,
+    onAccept: jest.fn(),
+    onReject: jest.fn(),
+    onOpenCircuitFile: jest.fn(),
+    onOpenZkeyFile: jest.fn(),
+    onOpenVerificationKeyFile: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useRlnProofModal as jest.Mock).mockReturnValue(defaultHookData);
+
+    createModalRoot();
+  });
+
+  afterEach(() => {
+    deleteModalRoot();
+  });
+
+  test("should render properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const modal = await screen.findByTestId("proof-modal");
+
+    expect(modal).toBeInTheDocument();
+  });
+
+  test("should render properly with error", async () => {
+    render(<RlnProofModal {...defaultProps} error="Error" len={2} />);
+
+    const error = await screen.findByText("Error");
+
+    expect(error).toBeInTheDocument();
+  });
+
+  test("should approve generation properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const button = await screen.findByText("Approve");
+    act(() => button.click());
+
+    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+  });
+
+  test("should reject proof generation properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const button = await screen.findByText("Reject");
+    act(() => button.click());
+
+    expect(defaultHookData.onReject).toBeCalledTimes(1);
+  });
+
+  test("should open circuit file properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("circuit-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenCircuitFile).toBeCalledTimes(1);
+  });
+
+  test("should open zkey file properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("zkey-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenZkeyFile).toBeCalledTimes(1);
+  });
+
+  test("should open verification key file properly", async () => {
+    render(<RlnProofModal {...defaultProps} />);
+
+    const link = await screen.findByTestId("verification-key-file-link");
+    act(() => link.click());
+
+    expect(defaultHookData.onOpenVerificationKeyFile).toBeCalledTimes(1);
+  });
+});

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/useRlnProofModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/useRlnProofModal.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { PendingRequestType } from "@cryptkeeperzk/types";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { IUseRlnProofModalArgs, IUseRlnProofModalData, useRlnProofModal } from "../useRlnProofModal";
+
+describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal", () => {
+  const defaultArgs: IUseRlnProofModalArgs = {
+    pendingRequest: {
+      id: "1",
+      type: PendingRequestType.SEMAPHORE_PROOF,
+      payload: {
+        rlnIdentifier: "rlnIdentifier",
+        message: "externalNullifier",
+        messageId: 1,
+        messageLimit: 0,
+        epoch: "1234",
+        circuitFilePath: "circuitFilePath",
+        verificationKey: "verificationKey",
+        zkeyFilePath: "zkeyFilePath",
+        urlOrigin: "http://localhost:3000",
+      },
+    },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const jsdomOpen = window.open;
+
+  const waitForData = async (current: IUseRlnProofModalData) => {
+    await waitFor(() => current.urlOrigin !== "");
+    await waitFor(() => current.faviconUrl !== "");
+  };
+
+  beforeAll(() => {
+    window.open = jest.fn();
+  });
+
+  afterAll(() => {
+    window.open = jsdomOpen;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return empty data", () => {
+    const { result } = renderHook(() =>
+      useRlnProofModal({
+        ...defaultArgs,
+        pendingRequest: {
+          ...defaultArgs.pendingRequest,
+          type: -1 as unknown as PendingRequestType,
+          payload: undefined,
+        },
+      }),
+    );
+
+    expect(result.current.faviconUrl).toBe("");
+    expect(result.current.urlOrigin).toBe("");
+    expect(result.current.payload).toBeUndefined();
+  });
+
+  test("should return initial data", async () => {
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    expect(result.current.faviconUrl).toBe("http://localhost:3000/favicon.ico");
+    expect(result.current.urlOrigin).toBe(defaultArgs.pendingRequest.payload?.urlOrigin);
+    expect(result.current.payload).toStrictEqual(defaultArgs.pendingRequest.payload);
+  });
+
+  test("should accept proof generation properly", async () => {
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    act(() => result.current.onAccept());
+
+    expect(defaultArgs.accept).toBeCalledTimes(1);
+  });
+
+  test("should reject proof generation properly", async () => {
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    act(() => result.current.onReject());
+
+    expect(defaultArgs.reject).toBeCalledTimes(1);
+  });
+
+  test("should open circuit file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    act(() => result.current.onOpenCircuitFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
+  });
+
+  test("should open zkey file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    act(() => result.current.onOpenZkeyFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
+  });
+
+  test("should open verification key file properly", async () => {
+    const openSpy = jest.spyOn(window, "open");
+    const { result } = renderHook(() => useRlnProofModal(defaultArgs));
+    await waitForData(result.current);
+
+    act(() => result.current.onOpenVerificationKeyFile());
+
+    expect(openSpy).toBeCalledTimes(1);
+    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
+  });
+});

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/index.ts
@@ -1,0 +1,1 @@
+export { RlnProofModal, type RlnProofModalProps } from "./RlnProofModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/useRlnProofModal.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/useRlnProofModal.ts
@@ -1,19 +1,17 @@
+import { IRlnProofRequest, PendingRequest } from "@cryptkeeperzk/types";
 import { getLinkPreview } from "link-preview-js";
 import { useCallback, useEffect, useState } from "react";
 
-import { PendingRequest, PendingRequestType, ZKProofPayload } from "@src/types";
-
-export interface IUseProofModalArgs {
-  pendingRequest: PendingRequest<ZKProofPayload>;
+export interface IUseRlnProofModalArgs {
+  pendingRequest: PendingRequest<Omit<IRlnProofRequest, "identitySerialized">>;
   accept: () => void;
   reject: () => void;
 }
 
-export interface IUseProofModalData {
-  host: string;
+export interface IUseRlnProofModalData {
+  urlOrigin?: string;
   faviconUrl: string;
-  operation: string;
-  payload?: ZKProofPayload;
+  payload?: Omit<IRlnProofRequest, "identitySerialized">;
   onAccept: () => void;
   onReject: () => void;
   onOpenCircuitFile: () => void;
@@ -21,17 +19,9 @@ export interface IUseProofModalData {
   onOpenVerificationKeyFile: () => void;
 }
 
-type ProofType = PendingRequestType.SEMAPHORE_PROOF | PendingRequestType.RLN_PROOF;
-
-const PROOF_MODAL_TITLES: Record<ProofType, string> = {
-  [PendingRequestType.SEMAPHORE_PROOF]: "Generate Semaphore Proof",
-  [PendingRequestType.RLN_PROOF]: "Generate RLN Proof",
-};
-
-export const useProofModal = ({ pendingRequest, accept, reject }: IUseProofModalArgs): IUseProofModalData => {
+export const useRlnProofModal = ({ pendingRequest, accept, reject }: IUseRlnProofModalArgs): IUseRlnProofModalData => {
   const [faviconUrl, setFaviconUrl] = useState("");
-  const operation = PROOF_MODAL_TITLES[pendingRequest?.type as ProofType] || "Generate proof";
-  const { origin: host = "", circuitFilePath, zkeyFilePath, verificationKey } = pendingRequest.payload || {};
+  const { urlOrigin = "", circuitFilePath, zkeyFilePath, verificationKey } = pendingRequest.payload || {};
 
   const onAccept = useCallback(() => {
     accept();
@@ -51,20 +41,19 @@ export const useProofModal = ({ pendingRequest, accept, reject }: IUseProofModal
   );
 
   useEffect(() => {
-    if (!host) {
+    if (!urlOrigin) {
       return;
     }
 
-    getLinkPreview(host).then((data) => {
+    getLinkPreview(urlOrigin).then((data) => {
       const [favicon] = data.favicons;
       setFaviconUrl(favicon);
     });
-  }, [host, setFaviconUrl]);
+  }, [urlOrigin, setFaviconUrl]);
 
   return {
-    host,
+    urlOrigin,
     payload: pendingRequest.payload,
-    operation,
     faviconUrl,
     onAccept,
     onReject,

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/SemaphoreProofModal.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/SemaphoreProofModal.tsx
@@ -1,0 +1,110 @@
+import { PendingRequest, ZKProofPayload } from "@cryptkeeperzk/types";
+
+import { ButtonType, Button } from "@src/ui/components/Button";
+import { FullModal, FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
+import { Icon } from "@src/ui/components/Icon";
+import { Input } from "@src/ui/components/Input";
+
+import "../../confirmModal.scss";
+
+import { useSemaphoreProofModal } from "./useSemaphoreProofModal";
+
+export interface SemaphoreProofModalProps {
+  len: number;
+  loading: boolean;
+  error: string;
+  pendingRequest: PendingRequest<ZKProofPayload>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export const SemaphoreProofModal = ({
+  pendingRequest,
+  len,
+  reject,
+  accept,
+  loading,
+  error,
+}: SemaphoreProofModalProps): JSX.Element => {
+  const {
+    urlOrigin,
+    operation,
+    payload,
+    faviconUrl,
+    onAccept,
+    onReject,
+    onOpenCircuitFile,
+    onOpenVerificationKeyFile,
+    onOpenZkeyFile,
+  } = useSemaphoreProofModal({
+    pendingRequest,
+    accept,
+    reject,
+  });
+
+  return (
+    <FullModal className="confirm-modal" data-testid="proof-modal" onClose={onReject}>
+      <FullModalHeader>
+        {operation}
+
+        {len > 1 && <div className="flex-grow flex flex-row justify-end">{`1 of ${len}`}</div>}
+      </FullModalHeader>
+
+      <FullModalContent className="flex flex-col items-center">
+        <div className="w-16 h-16 rounded-full my-6 border border-gray-800 p-2 flex-shrink-0">
+          <div
+            className="w-16 h-16"
+            style={{
+              backgroundSize: "contain",
+              backgroundPosition: "center",
+              backgroundRepeat: "no-repeat",
+              backgroundImage: `url(${faviconUrl}`,
+            }}
+          />
+        </div>
+
+        <div className="text-lg font-semibold mb-2 text-center">{`${urlOrigin} is requesting a semaphore proof`}</div>
+
+        <div className="semaphore-proof__files flex flex-row items-center mb-2">
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">Circuit</div>
+
+            <Icon data-testid="circuit-file-link" fontAwesome="fas fa-link" onClick={onOpenCircuitFile} />
+          </div>
+
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">ZKey</div>
+
+            <Icon data-testid="zkey-file-link" fontAwesome="fas fa-link" onClick={onOpenZkeyFile} />
+          </div>
+
+          <div className="semaphore-proof__file">
+            <div className="semaphore-proof__file__title">Verification</div>
+
+            <Icon
+              data-testid="verification-key-file-link"
+              fontAwesome="fas fa-link"
+              onClick={onOpenVerificationKeyFile}
+            />
+          </div>
+        </div>
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.externalNullifier} label="External Nullifier" />
+
+        <Input readOnly className="w-full mb-2" defaultValue={payload?.signal} label="Signal" />
+      </FullModalContent>
+
+      {error && <div className="text-xs text-red-500 text-center pb-1">{error}</div>}
+
+      <FullModalFooter>
+        <Button buttonType={ButtonType.SECONDARY} loading={loading} onClick={onReject}>
+          Reject
+        </Button>
+
+        <Button className="ml-2" loading={loading} onClick={onAccept}>
+          Approve
+        </Button>
+      </FullModalFooter>
+    </FullModal>
+  );
+};

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/SemaphoreProofModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/SemaphoreProofModal.test.tsx
@@ -2,20 +2,20 @@
  * @jest-environment jsdom
  */
 
+import { PendingRequestType } from "@cryptkeeperzk/types";
 import { act, render, screen } from "@testing-library/react";
 
 import { createModalRoot, deleteModalRoot } from "@src/config/mock/modal";
-import { PendingRequestType } from "@src/types";
 
-import { ProofModal, ProofModalProps } from "..";
-import { IUseProofModalData, useProofModal } from "../useProofModal";
+import { SemaphoreProofModal, SemaphoreProofModalProps } from "..";
+import { IUseSemaphoreProofModalData, useSemaphoreProofModal } from "../useSemaphoreProofModal";
 
-jest.mock("../useProofModal", (): unknown => ({
-  useProofModal: jest.fn(),
+jest.mock("../useSemaphoreProofModal", (): unknown => ({
+  useSemaphoreProofModal: jest.fn(),
 }));
 
 describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
-  const defaultProps: ProofModalProps = {
+  const defaultProps: SemaphoreProofModalProps = {
     len: 1,
     loading: false,
     error: "",
@@ -28,15 +28,15 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
         circuitFilePath: "circuitFilePath",
         verificationKey: "verificationKey",
         zkeyFilePath: "zkeyFilePath",
-        origin: "http://localhost:3000",
+        urlOrigin: "http://localhost:3000",
       },
     },
     accept: jest.fn(),
     reject: jest.fn(),
   };
 
-  const defaultHookData: IUseProofModalData = {
-    host: defaultProps.pendingRequest.payload!.origin,
+  const defaultHookData: IUseSemaphoreProofModalData = {
+    urlOrigin: defaultProps.pendingRequest.payload!.urlOrigin,
     faviconUrl: "",
     operation: "Generate Semaphore Proof",
     payload: defaultProps.pendingRequest.payload,
@@ -48,7 +48,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   };
 
   beforeEach(() => {
-    (useProofModal as jest.Mock).mockReturnValue(defaultHookData);
+    (useSemaphoreProofModal as jest.Mock).mockReturnValue(defaultHookData);
 
     createModalRoot();
   });
@@ -58,7 +58,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should render properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const modal = await screen.findByTestId("proof-modal");
 
@@ -66,7 +66,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should render properly with error", async () => {
-    render(<ProofModal {...defaultProps} error="Error" len={2} />);
+    render(<SemaphoreProofModal {...defaultProps} error="Error" len={2} />);
 
     const error = await screen.findByText("Error");
 
@@ -74,7 +74,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should approve generation properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const button = await screen.findByText("Approve");
     act(() => button.click());
@@ -83,7 +83,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should reject proof generation properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const button = await screen.findByText("Reject");
     act(() => button.click());
@@ -92,7 +92,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should open circuit file properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const link = await screen.findByTestId("circuit-file-link");
     act(() => link.click());
@@ -101,7 +101,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should open zkey file properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const link = await screen.findByTestId("zkey-file-link");
     act(() => link.click());
@@ -110,7 +110,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
   });
 
   test("should open verification key file properly", async () => {
-    render(<ProofModal {...defaultProps} />);
+    render(<SemaphoreProofModal {...defaultProps} />);
 
     const link = await screen.findByTestId("verification-key-file-link");
     act(() => link.click());

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/useSemaphoreProofModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/useSemaphoreProofModal.test.ts
@@ -2,14 +2,17 @@
  * @jest-environment jsdom
  */
 
+import { PendingRequestType } from "@cryptkeeperzk/types";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
-import { PendingRequestType } from "@src/types";
+import {
+  IUseSemaphoreProofModalArgs,
+  IUseSemaphoreProofModalData,
+  useSemaphoreProofModal,
+} from "../useSemaphoreProofModal";
 
-import { IUseProofModalArgs, IUseProofModalData, useProofModal } from "../useProofModal";
-
-describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal", () => {
-  const defaultArgs: IUseProofModalArgs = {
+describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphoreProofModal", () => {
+  const defaultArgs: IUseSemaphoreProofModalArgs = {
     pendingRequest: {
       id: "1",
       type: PendingRequestType.SEMAPHORE_PROOF,
@@ -19,7 +22,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
         circuitFilePath: "circuitFilePath",
         verificationKey: "verificationKey",
         zkeyFilePath: "zkeyFilePath",
-        origin: "http://localhost:3000",
+        urlOrigin: "http://localhost:3000",
       },
     },
     accept: jest.fn(),
@@ -28,8 +31,8 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
   const jsdomOpen = window.open;
 
-  const waitForData = async (current: IUseProofModalData) => {
-    await waitFor(() => current.host !== "");
+  const waitForData = async (current: IUseSemaphoreProofModalData) => {
+    await waitFor(() => current.urlOrigin !== "");
     await waitFor(() => current.faviconUrl !== "");
   };
 
@@ -47,7 +50,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
   test("should return empty data", () => {
     const { result } = renderHook(() =>
-      useProofModal({
+      useSemaphoreProofModal({
         ...defaultArgs,
         pendingRequest: {
           ...defaultArgs.pendingRequest,
@@ -59,22 +62,22 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
     expect(result.current.operation).toBe("Generate proof");
     expect(result.current.faviconUrl).toBe("");
-    expect(result.current.host).toBe("");
+    expect(result.current.urlOrigin).toBe("");
     expect(result.current.payload).toBeUndefined();
   });
 
   test("should return initial data", async () => {
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     expect(result.current.operation).toBe("Generate Semaphore Proof");
     expect(result.current.faviconUrl).toBe("http://localhost:3000/favicon.ico");
-    expect(result.current.host).toBe(defaultArgs.pendingRequest.payload?.origin);
+    expect(result.current.urlOrigin).toBe(defaultArgs.pendingRequest.payload?.urlOrigin);
     expect(result.current.payload).toStrictEqual(defaultArgs.pendingRequest.payload);
   });
 
   test("should accept proof generation properly", async () => {
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     act(() => result.current.onAccept());
@@ -83,7 +86,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
   });
 
   test("should reject proof generation properly", async () => {
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     act(() => result.current.onReject());
@@ -93,7 +96,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
   test("should open circuit file properly", async () => {
     const openSpy = jest.spyOn(window, "open");
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     act(() => result.current.onOpenCircuitFile());
@@ -104,7 +107,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
   test("should open zkey file properly", async () => {
     const openSpy = jest.spyOn(window, "open");
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     act(() => result.current.onOpenZkeyFile());
@@ -115,7 +118,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
 
   test("should open verification key file properly", async () => {
     const openSpy = jest.spyOn(window, "open");
-    const { result } = renderHook(() => useProofModal(defaultArgs));
+    const { result } = renderHook(() => useSemaphoreProofModal(defaultArgs));
     await waitForData(result.current);
 
     act(() => result.current.onOpenVerificationKeyFile());

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/index.ts
@@ -1,0 +1,1 @@
+export { SemaphoreProofModal, type SemaphoreProofModalProps } from "./SemaphoreProofModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/useSemaphoreProofModal.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/useSemaphoreProofModal.ts
@@ -1,0 +1,78 @@
+import { PendingRequest, PendingRequestType, ZKProofPayload } from "@cryptkeeperzk/types";
+import { getLinkPreview } from "link-preview-js";
+import { useCallback, useEffect, useState } from "react";
+
+export interface IUseSemaphoreProofModalArgs {
+  pendingRequest: PendingRequest<ZKProofPayload>;
+  accept: () => void;
+  reject: () => void;
+}
+
+export interface IUseSemaphoreProofModalData {
+  urlOrigin: string;
+  faviconUrl: string;
+  operation: string;
+  payload?: ZKProofPayload;
+  onAccept: () => void;
+  onReject: () => void;
+  onOpenCircuitFile: () => void;
+  onOpenZkeyFile: () => void;
+  onOpenVerificationKeyFile: () => void;
+}
+
+type ProofType = PendingRequestType.SEMAPHORE_PROOF | PendingRequestType.RLN_PROOF;
+
+const PROOF_MODAL_TITLES: Record<ProofType, string> = {
+  [PendingRequestType.SEMAPHORE_PROOF]: "Generate Semaphore Proof",
+  [PendingRequestType.RLN_PROOF]: "Generate RLN Proof",
+};
+
+export const useSemaphoreProofModal = ({
+  pendingRequest,
+  accept,
+  reject,
+}: IUseSemaphoreProofModalArgs): IUseSemaphoreProofModalData => {
+  const [faviconUrl, setFaviconUrl] = useState("");
+  const operation = PROOF_MODAL_TITLES[pendingRequest?.type as ProofType] || "Generate proof";
+  const { urlOrigin = "", circuitFilePath, zkeyFilePath, verificationKey } = pendingRequest.payload || {};
+
+  const onAccept = useCallback(() => {
+    accept();
+  }, [accept]);
+
+  const onReject = useCallback(() => {
+    reject();
+  }, [reject]);
+
+  const onOpenCircuitFile = useCallback(() => window.open(circuitFilePath, "_blank"), [window, circuitFilePath]);
+
+  const onOpenZkeyFile = useCallback(() => window.open(zkeyFilePath, "_blank"), [window, zkeyFilePath]);
+
+  const onOpenVerificationKeyFile = useCallback(
+    () => window.open(verificationKey, "_blank"),
+    [window, verificationKey],
+  );
+
+  useEffect(() => {
+    if (!urlOrigin) {
+      return;
+    }
+
+    getLinkPreview(urlOrigin).then((data) => {
+      const [favicon] = data.favicons;
+      setFaviconUrl(favicon);
+    });
+  }, [urlOrigin, setFaviconUrl]);
+
+  return {
+    urlOrigin,
+    payload: pendingRequest.payload,
+    operation,
+    faviconUrl,
+    onAccept,
+    onReject,
+    onOpenCircuitFile,
+    onOpenZkeyFile,
+    onOpenVerificationKeyFile,
+  };
+};

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/index.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/index.ts
@@ -1,3 +1,4 @@
-export * from "./ProofModal";
-export * from "./ConnectionApprovalModal";
-export * from "./DefaultApprovalModal";
+export { SemaphoreProofModal } from "./SemaphoreProofModal";
+export { RlnProofModal } from "./RlnProofModal";
+export { ConnectionApprovalModal } from "./ConnectionApprovalModal";
+export { DefaultApprovalModal } from "./DefaultApprovalModal";

--- a/packages/app/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/useConfirmRequestModal.ts
@@ -1,6 +1,6 @@
+import { PendingRequest, RequestResolutionAction, RequestResolutionStatus } from "@cryptkeeperzk/types";
 import { useCallback, useState } from "react";
 
-import { PendingRequest, RequestResolutionAction, RequestResolutionStatus } from "@src/types";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchPendingRequests, finalizeRequest, usePendingRequests } from "@src/ui/ducks/requests";
 

--- a/packages/app/src/ui/components/IdentityList/IdentityList.tsx
+++ b/packages/app/src/ui/components/IdentityList/IdentityList.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentityRequest, deleteIdentity, setIdentityName } from "@src/ui/ducks/identities";
 import { isExtensionPopupOpen } from "@src/util/browser";
 
-import type { IdentityData } from "@src/types";
+import type { IdentityData } from "@cryptkeeperzk/types";
 
 import { IdentityItem } from "./Item";
 

--- a/packages/app/src/ui/components/IdentityList/Item/index.tsx
+++ b/packages/app/src/ui/components/IdentityList/Item/index.tsx
@@ -1,3 +1,4 @@
+import { IdentityMetadata, IdentityWeb2Provider } from "@cryptkeeperzk/types";
 import { IconName, IconPrefix } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Box from "@mui/material/Box";
@@ -5,7 +6,6 @@ import Typography from "@mui/material/Typography";
 import classNames from "classnames";
 
 import { getEnabledFeatures } from "@src/config/features";
-import { IdentityMetadata, IdentityWeb2Provider } from "@src/types";
 import { Icon } from "@src/ui/components/Icon";
 import { Input } from "@src/ui/components/Input";
 import { Menuable } from "@src/ui/components/Menuable";

--- a/packages/app/src/ui/ducks/requests.ts
+++ b/packages/app/src/ui/ducks/requests.ts
@@ -5,7 +5,7 @@ import deepEqual from "fast-deep-equal";
 
 import postMessage from "@src/util/postMessage";
 
-import type { PendingRequest, RequestResolutionAction } from "@src/types";
+import type { PendingRequest, RequestResolutionAction } from "@cryptkeeperzk/types";
 import type { TypedThunk } from "@src/ui/store/configureAppStore";
 
 import { useAppSelector } from "./hooks";

--- a/packages/app/src/ui/pages/ConnectIdentity/useConnectIdentity.ts
+++ b/packages/app/src/ui/pages/ConnectIdentity/useConnectIdentity.ts
@@ -13,7 +13,7 @@ import {
   useUnlinkedIdentities,
 } from "@src/ui/ducks/identities";
 
-import type { IdentityData } from "@src/types";
+import type { IdentityData } from "@cryptkeeperzk/types";
 
 export interface IUseConnectIdentityData {
   host: string;

--- a/packages/app/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/packages/app/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -1,10 +1,11 @@
+import { EWallet, IdentityStrategy, IdentityWeb2Provider } from "@cryptkeeperzk/types";
 import { BaseSyntheticEvent, useCallback, useMemo } from "react";
 import { Control, useForm, UseFormRegister } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
 import { getEnabledFeatures } from "@src/config/features";
 import { WEB2_PROVIDER_OPTIONS, IDENTITY_TYPES, Paths } from "@src/constants";
-import { EWallet, IdentityStrategy, IdentityWeb2Provider, SelectOption } from "@src/types";
+import { SelectOption } from "@src/types";
 import { closePopup } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";

--- a/packages/app/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
@@ -1,8 +1,9 @@
+import { IdentityWeb2Provider } from "@cryptkeeperzk/types";
 import { IconName, IconPrefix } from "@fortawesome/fontawesome-common-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useCallback } from "react";
 
-import { IdentityWeb2Provider, Operation, OperationType } from "@src/types";
+import { Operation, OperationType } from "@src/types";
 import { Icon } from "@src/ui/components/Icon";
 import { Menuable } from "@src/ui/components/Menuable";
 import { ellipsify } from "@src/util/account";

--- a/packages/app/src/ui/pages/Home/useHome.ts
+++ b/packages/app/src/ui/pages/Home/useHome.ts
@@ -6,7 +6,7 @@ import { checkHostApproval } from "@src/ui/ducks/permissions";
 import { useEthWallet } from "@src/ui/hooks/wallet";
 import { getLastActiveTabUrl } from "@src/util/browser";
 
-import type { IdentityData } from "@src/types";
+import type { IdentityData } from "@cryptkeeperzk/types";
 
 export interface IUseHomeData {
   identities: IdentityData[];

--- a/packages/app/src/ui/services/identity/index.ts
+++ b/packages/app/src/ui/services/identity/index.ts
@@ -1,4 +1,4 @@
-import type { IdentityStrategy, IdentityWeb2Provider } from "@src/types";
+import type { IdentityStrategy, IdentityWeb2Provider } from "@cryptkeeperzk/types";
 import type { JsonRpcSigner } from "ethers";
 
 export interface ISignIdentityMessageArgs {

--- a/packages/app/src/util/postMessage.ts
+++ b/packages/app/src/util/postMessage.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 
-import type { MessageAction } from "@src/types";
+import type { MessageAction } from "@cryptkeeperzk/types";
 
 export default async function postMessage<T>(message: MessageAction): Promise<T> {
   const [err, res] = (await browser.runtime.sendMessage(message)) as [string, T];

--- a/packages/app/src/util/pushMessage.ts
+++ b/packages/app/src/util/pushMessage.ts
@@ -1,8 +1,7 @@
+import { ReduxAction, RequestHandler } from "@cryptkeeperzk/types";
 import pick from "lodash/pick";
 import log from "loglevel";
 import browser from "webextension-polyfill";
-
-import { ReduxAction, RequestHandler } from "@src/types";
 
 export default async function pushMessage(message: ReduxAction | RequestHandler): Promise<unknown> {
   try {

--- a/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
+++ b/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
@@ -125,13 +125,13 @@ export class CryptKeeperInjectedProvider {
   /**
    * Attempts to connect to the extension.
    *
-   * @param {string} host - The host origin to connect to.
+   * @param {string} urlOrigin - The host origin to connect to.
    * @returns {Promise<Approvals>} A Promise that resolves to an object containing approval information.
    */
-  private async tryConnect(host: string): Promise<Approvals> {
+  private async tryConnect(urlOrigin: string): Promise<Approvals> {
     return this.post({
       method: RPCAction.CONNECT,
-      payload: { origin: host },
+      payload: { urlOrigin },
     }) as Promise<Approvals>;
   }
 
@@ -154,7 +154,7 @@ export class CryptKeeperInjectedProvider {
             ...message,
             meta: {
               ...message.meta,
-              origin: window.location.origin,
+              urlOrigin: window.location.origin,
             },
             type: message.method,
           },

--- a/packages/types/src/proof/rlnProof.ts
+++ b/packages/types/src/proof/rlnProof.ts
@@ -1,6 +1,6 @@
 import { MerkleProof } from "@cryptkeeperzk/rlnjs";
 
-import { ZkCircuit, ZkInputs } from "./zkProof";
+import { IZkMetadata, ZkCircuit, ZkInputs } from "./zkProof";
 
 export type { RLNFullProof, VerificationKey, RLNSNARKProof } from "@cryptkeeperzk/rlnjs";
 
@@ -41,7 +41,7 @@ export interface IRlnProofRequiredArgs extends Partial<ZkInputs> {
   epoch: string;
 }
 
-export interface IRlnProofRequest extends IRlnProofRequiredArgs, Partial<ZkCircuit> {
+export interface IRlnProofRequest extends IRlnProofRequiredArgs, IZkMetadata, Partial<ZkCircuit> {
   identitySerialized?: string;
 }
 

--- a/packages/types/src/proof/semaphoreProof.ts
+++ b/packages/types/src/proof/semaphoreProof.ts
@@ -1,6 +1,6 @@
 import { FullProof } from "@cryptkeeperzk/semaphore-proof";
 
-import { ZkCircuit, ZkInputs } from "./zkProof";
+import { IZkMetadata, ZkCircuit, ZkInputs } from "./zkProof";
 
 export type SemaphoreFullProof = FullProof;
 
@@ -23,7 +23,7 @@ export interface ISemaphoreProofRequiredArgs extends Partial<ZkInputs> {
   signal: string;
 }
 
-export interface ISemaphoreProofRequest extends ISemaphoreProofRequiredArgs, Partial<ZkCircuit> {
+export interface ISemaphoreProofRequest extends ISemaphoreProofRequiredArgs, IZkMetadata, Partial<ZkCircuit> {
   identitySerialized?: string;
 }
 

--- a/packages/types/src/proof/zkProof.ts
+++ b/packages/types/src/proof/zkProof.ts
@@ -13,6 +13,7 @@ export interface ZkInputs {
   merkleProofArtifactsOrStorageAddress: string | MerkleProofArtifacts;
 }
 
+// TODO: that is a redandant
 export interface ZKProofPayload {
   externalNullifier: string;
   signal: string;
@@ -20,7 +21,11 @@ export interface ZKProofPayload {
   circuitFilePath: string;
   verificationKey: string;
   zkeyFilePath: string;
-  origin: string;
+  urlOrigin: string;
+}
+
+export interface IZkMetadata {
+  urlOrigin?: string;
 }
 
 export enum ZkProofType {

--- a/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
+++ b/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
@@ -69,7 +69,7 @@ describe("background/services/protocols", () => {
 
     test("should generate rln proof properly with remote merkle proof", async () => {
       const rln = new RLNProofService();
-      mockRlnGenerateProof.mockResolvedValueOnce(emptyFullProof);
+      mockRlnGenerateProof.mockResolvedValue(emptyFullProof);
 
       await rln.genProof(identityDecorater, { ...proofRequest, merkleStorageAddress: "http://localhost:3000/merkle" });
 
@@ -78,7 +78,7 @@ describe("background/services/protocols", () => {
 
     test("should generate rln proof properly with remote merkle proof but with string epoch", async () => {
       const rln = new RLNProofService();
-      mockRlnGenerateProof.mockResolvedValueOnce(emptyFullProof);
+      mockRlnGenerateProof.mockResolvedValue(emptyFullProof);
 
       const proofRequestString: IRlnProofRequest = {
         identitySerialized: "identitySerialized",


### PR DESCRIPTION
## Explanation

This PR adds UI RLN Proof screens

## More Information

- Related #91 

## Screenshots/Screencaps

![Screenshot_20230802_130746](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/36774944/92699e59-562a-424a-af43-bc9ef3bc7e93)
![Screenshot_20230802_130723](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/36774944/6b68791c-a04c-48dc-b7d6-b1276b328fd3)

## Manual Testing Steps

- Open demo app local.
- Checkout RLN Proof generation options.
- Review the RLN Approve Proof screen.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
