### PR TITLE
feat: identity page

### DIFF
--- a/packages/app/src/background/services/injector/__tests__/injector.test.ts
+++ b/packages/app/src/background/services/injector/__tests__/injector.test.ts
@@ -220,6 +220,21 @@ describe("background/services/injector", () => {
       expect(result).toStrictEqual(emptyFullProof);
       expect(pushMessage).toBeCalledTimes(0);
     });
+
+    test("should throw error there is no circuit and zkey files", async () => {
+      mockGetConnectedIdentity.mockResolvedValue({
+        serialize: () => mockSerializedIdentity,
+        genIdentityCommitment: () => "mockIdentityCommitment",
+      });
+      (getBrowserPlatform as jest.Mock).mockReturnValueOnce(BrowserPlatform.Firefox);
+      (browser.runtime.getURL as jest.Mock).mockReturnValue(undefined);
+
+      const service = InjectorService.getInstance();
+
+      await expect(service.generateSemaphoreProof(defaultProofRequest, { origin: mockDefaultHost })).rejects.toThrow(
+        "Error in generateSemaphoreProof(): Injected service: Must set circuitFilePath and zkeyFilePath",
+      );
+    });
   });
 
   describe("rln", () => {

--- a/packages/app/src/background/services/injector/index.ts
+++ b/packages/app/src/background/services/injector/index.ts
@@ -166,8 +166,8 @@ export default class InjectorService {
       });
 
       return fullProof as SemaphoreFullProof;
-    } catch (e) {
-      throw new Error(`Error in generateSemaphoreProof(): ${e as string}`);
+    } catch (error) {
+      throw new Error(`Error in generateSemaphoreProof(): ${(error as Error).message}`);
     } finally {
       if (browserPlatform !== BrowserPlatform.Firefox) {
         await closeChromeOffscreen();

--- a/packages/app/src/background/shared/__tests__/utils.test.ts
+++ b/packages/app/src/background/shared/__tests__/utils.test.ts
@@ -3,13 +3,14 @@
  */
 import { BrowserPlatform } from "@src/constants";
 
-import { createChromeOffscreen, deferredPromise, getBrowserPlatform } from "../utils";
+import { closeChromeOffscreen, createChromeOffscreen, deferredPromise, getBrowserPlatform } from "../utils";
 
 Object.defineProperty(global, "chrome", {
   value: {
     offscreen: {
       hasDocument: jest.fn(),
       createDocument: jest.fn(),
+      closeDocument: jest.fn(),
       Reason: jest.fn(() => ({
         DOM_SCRAPING: "DOM_SCRAPING",
       })),
@@ -44,6 +45,7 @@ describe("background/shared/utils", () => {
 
   test("should check the Chrome browser platform", () => {
     const browserPlatform = getBrowserPlatform();
+
     expect(browserPlatform).toBe(BrowserPlatform.Chrome);
   });
 
@@ -54,6 +56,7 @@ describe("background/shared/utils", () => {
     });
 
     const browserPlatform = getBrowserPlatform();
+
     expect(browserPlatform).toBe(BrowserPlatform.Firefox);
   });
 
@@ -65,6 +68,7 @@ describe("background/shared/utils", () => {
     });
 
     const browserPlatform = getBrowserPlatform();
+
     expect(browserPlatform).toBe(BrowserPlatform.Edge);
   });
 
@@ -76,6 +80,7 @@ describe("background/shared/utils", () => {
     });
 
     const browserPlatform = getBrowserPlatform();
+
     expect(browserPlatform).toBe(BrowserPlatform.Opera);
   });
 
@@ -87,6 +92,7 @@ describe("background/shared/utils", () => {
     Object.defineProperty(window.navigator, "brave", {});
 
     const browserPlatform = getBrowserPlatform();
+
     expect(browserPlatform).toBe(BrowserPlatform.Brave);
   });
 
@@ -108,5 +114,15 @@ describe("background/shared/utils", () => {
 
     expect(global.chrome.offscreen.hasDocument).toBeCalledTimes(1);
     expect(global.chrome.offscreen.createDocument).toBeCalledTimes(0);
+  });
+
+  test("should throw an error if it's not possible to create offscreen", async () => {
+    (global.chrome.offscreen.createDocument as jest.Mock).mockRejectedValue(new Error());
+
+    await expect(createChromeOffscreen()).rejects.toThrowError("CryptKeeper could not create an Offscreen");
+  });
+
+  test("should close offscreen properly", async () => {
+    await expect(closeChromeOffscreen()).resolves.toBeUndefined();
   });
 });

--- a/packages/app/src/background/shared/utils.ts
+++ b/packages/app/src/background/shared/utils.ts
@@ -78,7 +78,7 @@ export async function createChromeOffscreen(): Promise<void> {
       justification: "CryptKeeper Offscreen for generating ZKP",
     });
   } catch (error) {
-    throw new Error("CryptKeeper could not create an Offscreen.");
+    throw new Error("CryptKeeper could not create an Offscreen");
   }
 }
 

--- a/packages/app/src/constants/index.ts
+++ b/packages/app/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { SelectOption } from "@src/types";
+import { IdentityStrategy, IdentityWeb2Provider, SelectOption } from "@src/types";
 
 export const WEB2_PROVIDER_OPTIONS: readonly SelectOption[] = [
   { value: "twitter", label: "Twitter", icon: ["fab", "twitter"] },
@@ -10,6 +10,17 @@ export const IDENTITY_TYPES: readonly SelectOption[] = [
   { value: "interrep", label: "InterRep", icon: null },
   { value: "random", label: "Random", icon: null },
 ];
+
+export const WEB2_PROVIDER_TITLE_MAP: Record<IdentityWeb2Provider, string> = {
+  twitter: "Twitter",
+  reddit: "Reddit",
+  github: "Github",
+};
+
+export const IDENTITY_TYPES_TITLE_MAP: Record<IdentityStrategy, string> = {
+  interrep: "InterRep",
+  random: "Random",
+};
 
 export enum BrowserPlatform {
   Brave = "Brave",

--- a/packages/app/src/constants/paths.ts
+++ b/packages/app/src/constants/paths.ts
@@ -1,6 +1,7 @@
 export enum Paths {
   ROOT = "/",
   HOME = "/home",
+  IDENTITY = "/identity/:id",
   CREATE_IDENTITY = "/create-identity",
   LOGIN = "/login",
   ONBOARDING = "/onboarding",

--- a/packages/app/src/manifest/v2/manifest.firefox.json
+++ b/packages/app/src/manifest/v2/manifest.firefox.json
@@ -3,8 +3,8 @@
   "name": "CryptKeeper",
   "description": "Extension that stores credentials and creates semaphore proofs",
   "version": "0.0.1",
-  "action": {
-    "default_icon": "/icons/logo.png",
+  "browser_action": {
+    "default_icon": "./icons/logo.png",
     "default_popup": "popup.html"
   },
   "background": {
@@ -26,28 +26,23 @@
     }
   ],
   "icons": {
-    "16": "icon-16.png",
-    "48": "icon-48.png",
-    "128": "icon-128.png"
+    "16": "./icons/icon-16.png",
+    "48": "./icons/icon-48.png",
+    "128": "./icons/icon-128.png"
   },
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval' blob:; object-src 'self';",
-  "permissions": ["scripting", "clipboardWrite", "activeTab", "storage", "notifications", "unlimitedStorage"],
-  "host_permissions": ["http://*/", "https://*/"],
-  "resources": [
-    {
-      "resources": ["js/content.js"],
-      "matches": ["*://*/*"]
-    },
-    {
-      "resources": ["js/injected.js"],
-      "matches": ["*://*/*"]
-    },
-    {
-      "resources": ["js/zkeyFiles/*"],
-      "matches": ["*://*/*"]
-    }
+  "permissions": [
+    "http://*/",
+    "https://*/",
+    "scripting",
+    "clipboardWrite",
+    "activeTab",
+    "storage",
+    "notifications",
+    "unlimitedStorage"
   ],
-  "browser_specific_settings": {
+  "web_accessible_resources": ["js/content.js", "js/injected.js", "js/zkeyFiles/*"],
+  "applications": {
     "gecko": {
       "id": "{840d8da7-e1a6-48ac-afe2-59e07fa0c390}",
       "strict_min_version": "91"

--- a/packages/app/src/offscreen/Offscreen.ts
+++ b/packages/app/src/offscreen/Offscreen.ts
@@ -55,6 +55,7 @@ export class OffscreenController {
       circuitFilePath,
       zkeyFilePath,
     });
+
     return fullProof;
   };
 
@@ -88,6 +89,7 @@ export class OffscreenController {
       merkleStorageAddress,
       merkleProofProvided,
     });
+
     return JSON.stringify(rlnFullProof);
   };
 }

--- a/packages/app/src/ui/components/IdentityList/Item/useIdentityItem.ts
+++ b/packages/app/src/ui/components/IdentityList/Item/useIdentityItem.ts
@@ -1,0 +1,88 @@
+import { type ChangeEvent, type FormEvent, type MouseEvent as ReactMouseEvent, useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+import { redirectToNewTab, replaceUrlParams } from "@src/util/browser";
+
+import type { IdentityMetadata } from "@cryptkeeperzk/types";
+
+export interface IUseIdentityItemArgs {
+  commitment: string;
+  metadata: IdentityMetadata;
+  onDeleteIdentity: (commitment: string) => Promise<void>;
+  onUpdateIdentityName: (commitment: string, name: string) => Promise<void>;
+  onSelectIdentity?: (commitment: string) => void;
+}
+
+export interface IUseIdentityItemData {
+  name: string;
+  isRenaming: boolean;
+  handleDeleteIdentity: () => void;
+  handleSelectIdentity: () => void;
+  handleChangeName: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleToggleRenaming: () => void;
+  handleUpdateName: (event: FormEvent | ReactMouseEvent) => void;
+  handleGoToHost: () => void;
+  handleGoToIdentity: () => void;
+}
+
+export const useIdentityItem = ({
+  metadata,
+  commitment,
+  onDeleteIdentity,
+  onUpdateIdentityName,
+  onSelectIdentity,
+}: IUseIdentityItemArgs): IUseIdentityItemData => {
+  const [name, setName] = useState(metadata.name);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const navigate = useNavigate();
+
+  const handleDeleteIdentity = useCallback(() => {
+    onDeleteIdentity(commitment);
+  }, [commitment, onDeleteIdentity]);
+
+  const handleSelectIdentity = useCallback(() => {
+    onSelectIdentity?.(commitment);
+  }, [commitment, onSelectIdentity]);
+
+  const handleChangeName = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setName(event.target.value);
+    },
+    [setName],
+  );
+
+  const handleToggleRenaming = useCallback(() => {
+    setIsRenaming((value) => !value);
+  }, [setIsRenaming]);
+
+  const handleUpdateName = useCallback(
+    (event: FormEvent | ReactMouseEvent) => {
+      event.preventDefault();
+      onUpdateIdentityName(commitment, name).finally(() => {
+        setIsRenaming(false);
+      });
+    },
+    [commitment, name, onUpdateIdentityName],
+  );
+
+  const handleGoToHost = useCallback(() => {
+    redirectToNewTab(metadata.host!);
+  }, [metadata.host]);
+
+  const handleGoToIdentity = useCallback(() => {
+    navigate(replaceUrlParams(Paths.IDENTITY, { id: commitment }));
+  }, [commitment, navigate]);
+
+  return {
+    name,
+    isRenaming,
+    handleDeleteIdentity,
+    handleSelectIdentity,
+    handleChangeName,
+    handleToggleRenaming,
+    handleUpdateName,
+    handleGoToHost,
+    handleGoToIdentity,
+  };
+};

--- a/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { act, render, screen, fireEvent } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
 
 import { ZERO_ADDRESS } from "@src/config/const";
 import { IdentityData } from "@src/types";
@@ -10,6 +11,10 @@ import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { deleteIdentity, setIdentityName, useIdentities } from "@src/ui/ducks/identities";
 
 import { IdentityList, IdentityListProps } from "..";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
@@ -24,6 +29,7 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
 
 describe("ui/components/IdentityList", () => {
   const mockDispatch = jest.fn(() => Promise.resolve());
+  const mockNavigate = jest.fn();
 
   const defaultIdentities: IdentityData[] = [
     {
@@ -58,6 +64,8 @@ describe("ui/components/IdentityList", () => {
 
   beforeEach(() => {
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
     (useIdentities as jest.Mock).mockReturnValue(defaultIdentities);
   });

--- a/packages/app/src/ui/ducks/__tests__/identities.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/identities.test.tsx
@@ -36,6 +36,7 @@ import {
   enableHistory,
   useLinkedIdentities,
   useUnlinkedIdentities,
+  useIdentity,
 } from "../identities";
 
 jest.unmock("@src/ui/ducks/hooks");
@@ -94,6 +95,12 @@ describe("ui/ducks/identities", () => {
     const identitiesHookData = renderHook(() => useIdentities(), {
       wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
     });
+    const identityHookData = renderHook(() => useIdentity(defaultIdentities[0].commitment), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+    const emptyIdentityHookData = renderHook(() => useIdentity(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
     const linkedIdentitiesHookData = renderHook(() => useLinkedIdentities("http://localhost:3000"), {
       wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
     });
@@ -106,6 +113,8 @@ describe("ui/ducks/identities", () => {
 
     expect(identities.identities).toStrictEqual(defaultIdentities);
     expect(identitiesHookData.result.current).toStrictEqual(defaultIdentities);
+    expect(identityHookData.result.current).toStrictEqual(defaultIdentities[0]);
+    expect(emptyIdentityHookData.result.current).toBeUndefined();
     expect(linkedIdentitiesHookData.result.current).toStrictEqual(defaultIdentities.slice(0, 1));
     expect(unlinkedIdentitiesHookData.result.current).toStrictEqual(defaultIdentities.slice(1));
     expect(connectedIdentityHookData.result.current).toStrictEqual(defaultIdentities[0]);

--- a/packages/app/src/ui/ducks/identities.ts
+++ b/packages/app/src/ui/ducks/identities.ts
@@ -130,7 +130,7 @@ export const deleteAllIdentities = () => async (): Promise<boolean> =>
     method: RPCAction.DELETE_ALL_IDENTITIES,
   });
 
-export const fetchIdentities = (): TypedThunk => async (dispatch) => {
+export const fetchIdentities = (): TypedThunk<Promise<void>> => async (dispatch) => {
   const data = await postMessage<IdentityData[]>({ method: RPCAction.GET_IDENTITIES });
   const { commitment, web2Provider, host } = await postMessage<ConnectedIdentity>({
     method: RPCAction.GET_CONNECTED_IDENTITY_DATA,
@@ -173,6 +173,11 @@ export const enableHistory =
   };
 
 export const useIdentities = (): IdentityData[] => useAppSelector((state) => state.identities.identities, deepEqual);
+
+export const useIdentity = (commitment?: string): IdentityData | undefined =>
+  useAppSelector((state) =>
+    commitment ? state.identities.identities.find((identity) => identity.commitment === commitment) : undefined,
+  );
 
 export const useLinkedIdentities = (host: string): IdentityData[] =>
   useAppSelector(

--- a/packages/app/src/ui/hooks/url/__tests__/useUrlParam.test.ts
+++ b/packages/app/src/ui/hooks/url/__tests__/useUrlParam.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useParams } from "react-router-dom";
+
+import { useUrlParam } from "..";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useParams: jest.fn(),
+}));
+
+describe("ui/hooks/url", () => {
+  const defaultUrlParams = {
+    param: "value",
+  };
+
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue(defaultUrlParams);
+  });
+
+  test("should return param from url", () => {
+    const { result } = renderHook(() => useUrlParam("param"));
+
+    expect(result.current).toBe(defaultUrlParams.param);
+  });
+
+  test("should return undefined if there is no such param", () => {
+    const { result } = renderHook(() => useUrlParam("unknown"));
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/app/src/ui/hooks/url/index.ts
+++ b/packages/app/src/ui/hooks/url/index.ts
@@ -1,0 +1,7 @@
+import { useParams } from "react-router-dom";
+
+export const useUrlParam = (param: string): string | undefined => {
+  const params = useParams();
+
+  return params[param];
+};

--- a/packages/app/src/ui/pages/Identity/Identity.tsx
+++ b/packages/app/src/ui/pages/Identity/Identity.tsx
@@ -1,0 +1,201 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { type ReactNode, useCallback } from "react";
+
+import { IDENTITY_TYPES_TITLE_MAP, WEB2_PROVIDER_TITLE_MAP } from "@src/constants";
+import { ConfirmDangerModal } from "@src/ui/components/ConfirmDangerModal";
+import { Header } from "@src/ui/components/Header";
+import { Icon } from "@src/ui/components/Icon";
+import { ellipsify } from "@src/util/account";
+
+import { useIdentityPage } from "./useIdentityPage";
+
+const Identity = (): JSX.Element | null => {
+  const {
+    isLoading,
+    isConnectedIdentity,
+    isConfirmModalOpen,
+    isUpdating,
+    errors,
+    commitment,
+    metadata,
+    register,
+    onGoBack,
+    onConfirmDeleteIdentity,
+    onDeleteIdentity,
+    onUpdateIdentity,
+    onGoToHost,
+    onConfirmUpdate,
+  } = useIdentityPage();
+
+  const renderRow = useCallback(
+    (key: string, value?: ReactNode) => (
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Typography fontWeight="bold" variant="h6">
+          {key}:
+        </Typography>
+
+        {value && (
+          <Typography component="div" variant="h6">
+            {value}
+          </Typography>
+        )}
+      </Box>
+    ),
+    [],
+  );
+
+  const renderRenameForm = useCallback(
+    () => (
+      <Box component="form" sx={{ display: "flex", alignItems: "center" }} onSubmit={onConfirmUpdate}>
+        <TextField
+          autoFocus
+          id="identityRename"
+          type="text"
+          {...register("name", { required: "Name is required" })}
+          size="small"
+          variant="outlined"
+        />
+      </Box>
+    ),
+    [register, onConfirmUpdate, onUpdateIdentity],
+  );
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          p: 2,
+          height: "100%",
+        }}
+      >
+        Loading...
+      </Box>
+    );
+  }
+
+  const isIdentityAvailable = commitment && metadata;
+
+  return (
+    <Box
+      data-testid="identity-page"
+      sx={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}
+    >
+      <Header />
+
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", p: 2, pb: 0 }}>
+        <Typography fontWeight="bold" variant="h4">
+          Identity
+        </Typography>
+
+        <Icon data-testid="close-icon" fontAwesome="fas fa-times" size={1.25} onClick={onGoBack} />
+      </Box>
+
+      {!isIdentityAvailable && !errors.root && <Typography sx={{ textAlign: "center" }}>No such identity</Typography>}
+
+      {isIdentityAvailable && (
+        <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
+          <Box
+            sx={{
+              p: 2,
+              position: "absolute",
+              bottom: 70,
+              top: 120,
+              overflow: "auto",
+              width: "100%",
+            }}
+          >
+            {renderRow(
+              "Commitment",
+              <Tooltip title={commitment}>
+                <Typography component="span" variant="h6">
+                  {ellipsify(commitment)}
+                </Typography>
+              </Tooltip>,
+            )}
+
+            {renderRow("Name", !isUpdating ? metadata.name : renderRenameForm())}
+
+            {renderRow("Type", IDENTITY_TYPES_TITLE_MAP[metadata.identityStrategy])}
+
+            {metadata.web2Provider && renderRow("Provider", WEB2_PROVIDER_TITLE_MAP[metadata.web2Provider])}
+
+            {renderRow(
+              "Owner account",
+              <Tooltip title={metadata.account}>
+                <Typography component="span" variant="h6">
+                  {ellipsify(metadata.account)}
+                </Typography>
+              </Tooltip>,
+            )}
+
+            {renderRow(
+              "Connected host",
+              metadata.host ? (
+                <Tooltip title={metadata.host}>
+                  <FontAwesomeIcon data-testid="host" icon="link" style={{ cursor: "pointer" }} onClick={onGoToHost} />
+                </Tooltip>
+              ) : (
+                "Not specified"
+              ),
+            )}
+
+            <Box>
+              {renderRow("Groups", metadata.groups.length === 0 ? "No groups are available" : metadata.groups.length)}
+
+              {metadata.groups.map((group) => (
+                <Box key={group.id} sx={{ ml: 2 }}>
+                  {renderRow("ID", group.id)}
+
+                  {renderRow("Name", group.name)}
+
+                  {renderRow("Description", group.description)}
+
+                  <Box component="hr" sx={{ my: 1 }} />
+                </Box>
+              ))}
+            </Box>
+          </Box>
+
+          <Box sx={{ p: 2, display: "flex", position: "absolute", width: "100%", bottom: 0 }}>
+            <Button
+              sx={{ flex: 1, mr: 1 }}
+              variant="contained"
+              onClick={!isUpdating ? onUpdateIdentity : onConfirmUpdate}
+            >
+              {!isUpdating ? "Update" : "Confirm"}
+            </Button>
+
+            <Button
+              color="error"
+              disabled={isConnectedIdentity}
+              sx={{ flex: 1, ml: 1 }}
+              variant="contained"
+              onClick={onConfirmDeleteIdentity}
+            >
+              Delete
+            </Button>
+          </Box>
+
+          {(errors.root || errors.name) && (
+            <Typography color="error" sx={{ textAlign: "center" }}>
+              {errors.root || errors.name}
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      <ConfirmDangerModal accept={onDeleteIdentity} isOpenModal={isConfirmModalOpen} reject={onConfirmDeleteIdentity} />
+    </Box>
+  );
+};
+
+export default Identity;

--- a/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
+++ b/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+
+import { ZERO_ADDRESS } from "@src/config/const";
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
+
+import Identity from "..";
+import { IUseIdentityPageData, useIdentityPage } from "../useIdentityPage";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useEthWallet: jest.fn(),
+  useCryptKeeperWallet: jest.fn(),
+}));
+
+jest.mock("../useIdentityPage", (): unknown => ({
+  useIdentityPage: jest.fn(),
+}));
+
+describe("ui/pages/Identity", () => {
+  const defaultHookData: IUseIdentityPageData = {
+    isLoading: false,
+    isConnectedIdentity: false,
+    isConfirmModalOpen: false,
+    isUpdating: false,
+    errors: {},
+    commitment: "commitment",
+    metadata: {
+      account: ZERO_ADDRESS,
+      name: "Account #1",
+      identityStrategy: "interrep",
+      groups: [{ id: "1", name: "Group #1", description: "Description #1" }],
+      web2Provider: "twitter",
+      host: "http://localhost:3000",
+    },
+    register: jest.fn(),
+    onGoBack: jest.fn(),
+    onConfirmDeleteIdentity: jest.fn(),
+    onDeleteIdentity: jest.fn(),
+    onUpdateIdentity: jest.fn(),
+    onGoToHost: jest.fn(),
+    onConfirmUpdate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useIdentityPage as jest.Mock).mockReturnValue(defaultHookData);
+
+    (useEthWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+
+    (useCryptKeeperWallet as jest.Mock).mockReturnValue(defaultWalletHookData);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render properly", async () => {
+    const { container, findByTestId } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const page = await findByTestId("identity-page");
+
+    expect(page).toBeInTheDocument();
+  });
+
+  test("should render loading state properly", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({ ...defaultHookData, isLoading: true });
+
+    const { container, findByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const loading = await findByText("Loading...");
+
+    expect(loading).toBeInTheDocument();
+  });
+
+  test("should render error state properly", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({ ...defaultHookData, errors: { name: "Error" } });
+
+    const { container, findByText, queryByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const error = await findByText("Error");
+    const emptyContent = queryByText("No such identity");
+
+    expect(error).toBeInTheDocument();
+    expect(emptyContent).toBeNull();
+  });
+
+  test("should render empty state properly", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({ ...defaultHookData, commitment: undefined });
+
+    const { container, findByText, queryByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const emptyContent = await findByText("No such identity");
+    const error = queryByText("Error");
+
+    expect(emptyContent).toBeInTheDocument();
+    expect(error).toBeNull();
+  });
+
+  test("should render properly without host and groups", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({
+      ...defaultHookData,
+      metadata: { ...defaultHookData.metadata, groups: [], host: undefined },
+    });
+
+    const { container, findByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const emptyGroups = await findByText("No groups are available");
+    const emptyHost = await findByText("Not specified");
+
+    expect(emptyGroups).toBeInTheDocument();
+    expect(emptyHost).toBeInTheDocument();
+  });
+
+  test("should initiate identity removal properly", async () => {
+    const { container, findByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const button = await findByText("Delete");
+    await act(() => Promise.resolve(button.click()));
+
+    expect(defaultHookData.onConfirmDeleteIdentity).toBeCalledTimes(1);
+  });
+
+  test("should delete identity properly", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({
+      ...defaultHookData,
+      isConfirmModalOpen: true,
+    });
+
+    const { container, findByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const noButton = await findByText("No");
+    await act(() => Promise.resolve(noButton.click()));
+    expect(defaultHookData.onConfirmDeleteIdentity).toBeCalledTimes(1);
+
+    const yesButton = await findByText("Yes");
+    await act(() => Promise.resolve(yesButton.click()));
+    expect(defaultHookData.onDeleteIdentity).toBeCalledTimes(1);
+  });
+
+  test("should render update form properly", async () => {
+    (useIdentityPage as jest.Mock).mockReturnValue({
+      ...defaultHookData,
+      isUpdating: true,
+    });
+
+    const { container, findByText } = render(
+      <Suspense>
+        <Identity />
+      </Suspense>,
+    );
+
+    await waitFor(() => container.firstChild !== null);
+
+    const confirmButton = await findByText("Confirm");
+    await act(() => Promise.resolve(confirmButton.click()));
+
+    expect(defaultHookData.onConfirmUpdate).toBeCalledTimes(1);
+  });
+});

--- a/packages/app/src/ui/pages/Identity/__tests__/useIdentityPage.test.ts
+++ b/packages/app/src/ui/pages/Identity/__tests__/useIdentityPage.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
+
+import { ZERO_ADDRESS } from "@src/config/const";
+import { Paths } from "@src/constants";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import {
+  deleteIdentity,
+  fetchIdentities,
+  setIdentityName,
+  useConnectedIdentity,
+  useIdentity,
+} from "@src/ui/ducks/identities";
+import { useUrlParam } from "@src/ui/hooks/url";
+import { redirectToNewTab } from "@src/util/browser";
+
+import type { IdentityData } from "@cryptkeeperzk/types";
+
+import { IUseIdentityPageData, useIdentityPage } from "../useIdentityPage";
+
+jest.mock("react-router-dom", (): unknown => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/url", (): unknown => ({
+  useUrlParam: jest.fn(),
+}));
+
+jest.mock("@src/util/browser", (): unknown => ({
+  redirectToNewTab: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/hooks", (): unknown => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/identities", (): unknown => ({
+  deleteIdentity: jest.fn(),
+  fetchIdentities: jest.fn(),
+  setIdentityName: jest.fn(),
+  useConnectedIdentity: jest.fn(),
+  useIdentity: jest.fn(),
+}));
+
+describe("ui/pages/Identity/useIdentityPage", () => {
+  const defaultIdentity: IdentityData = {
+    commitment: "commitment",
+    metadata: {
+      account: ZERO_ADDRESS,
+      name: "Account #1",
+      identityStrategy: "interrep",
+      groups: [],
+      web2Provider: "twitter",
+      host: "http://localhost:3000",
+    },
+  };
+
+  const mockNavigate = jest.fn();
+  const mockDispatch = jest.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    (useConnectedIdentity as jest.Mock).mockReturnValue(defaultIdentity);
+
+    (useIdentity as jest.Mock).mockReturnValue(defaultIdentity);
+
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    (useUrlParam as jest.Mock).mockReturnValue(defaultIdentity.commitment);
+
+    (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const waitForData = async (data: IUseIdentityPageData): Promise<void> => {
+    await waitFor(() => data.isLoading === false);
+    await waitFor(() => expect(fetchIdentities).toBeCalledTimes(1));
+  };
+
+  test("should return initial data", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isConnectedIdentity).toBe(true);
+    expect(result.current.isConfirmModalOpen).toBe(false);
+    expect(result.current.errors).toStrictEqual({ root: undefined, name: undefined });
+    expect(result.current.commitment).toBe(defaultIdentity.commitment);
+    expect(result.current.metadata).toStrictEqual(defaultIdentity.metadata);
+  });
+
+  test("should go back properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.onGoBack()));
+
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(-1);
+  });
+
+  test("should handle error properly", async () => {
+    const error = new Error("error");
+    (useAppDispatch as jest.Mock).mockReturnValue(jest.fn(() => Promise.reject(error)));
+    (useIdentity as jest.Mock).mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isConnectedIdentity).toBe(false);
+    expect(result.current.commitment).toBeUndefined();
+    expect(result.current.metadata).toBeUndefined();
+    expect(result.current.errors.root).toBe(error.message);
+  });
+
+  test("should delete identity properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.onDeleteIdentity()));
+
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchIdentities).toBeCalledTimes(1);
+    expect(deleteIdentity).toBeCalledTimes(1);
+    expect(deleteIdentity).toBeCalledWith(result.current.commitment);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+  });
+
+  test("should handle delete identity error properly", async () => {
+    const error = new Error("error");
+    (useAppDispatch as jest.Mock)
+      .mockReturnValueOnce(mockDispatch)
+      .mockReturnValue(jest.fn(() => Promise.reject(error)));
+    const { result } = renderHook(() => useIdentityPage());
+
+    await act(() => Promise.resolve(result.current.onDeleteIdentity()));
+
+    expect(result.current.errors.root).toBe(error.message);
+  });
+
+  test("should toggle confirm modal properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.onConfirmDeleteIdentity()));
+    expect(result.current.isConfirmModalOpen).toBe(true);
+
+    await act(() => Promise.resolve(result.current.onConfirmDeleteIdentity()));
+    expect(result.current.isConfirmModalOpen).toBe(false);
+  });
+
+  test("should confirm update properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.register("name").onChange({ target: { value: "Account" } })));
+    await act(() => Promise.resolve(result.current.onConfirmUpdate()));
+
+    expect(result.current.isUpdating).toBe(false);
+    expect(mockDispatch).toBeCalledTimes(2);
+    expect(fetchIdentities).toBeCalledTimes(1);
+    expect(setIdentityName).toBeCalledTimes(1);
+  });
+
+  test("should handle confirm update error properly", async () => {
+    const error = new Error("error");
+    (useAppDispatch as jest.Mock)
+      .mockReturnValueOnce(mockDispatch)
+      .mockReturnValue(jest.fn(() => Promise.reject(error)));
+    const { result } = renderHook(() => useIdentityPage());
+
+    await act(() => Promise.resolve(result.current.register("name").onChange({ target: { value: "Account" } })));
+    await act(() => Promise.resolve(result.current.onConfirmUpdate()));
+
+    expect(result.current.errors.root).toBe(error.message);
+  });
+
+  test("should toggle update identity properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.onUpdateIdentity()));
+    expect(result.current.isUpdating).toBe(true);
+
+    await act(() => Promise.resolve(result.current.onUpdateIdentity()));
+    expect(result.current.isUpdating).toBe(false);
+  });
+
+  test("should go to host properly", async () => {
+    const { result } = renderHook(() => useIdentityPage());
+    await waitForData(result.current);
+
+    await act(() => Promise.resolve(result.current.onGoToHost()));
+
+    expect(redirectToNewTab).toBeCalledTimes(1);
+    expect(redirectToNewTab).toBeCalledWith(defaultIdentity.metadata.host);
+  });
+});

--- a/packages/app/src/ui/pages/Identity/index.ts
+++ b/packages/app/src/ui/pages/Identity/index.ts
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+export default lazy(() => import("./Identity"));

--- a/packages/app/src/ui/pages/Identity/useIdentityPage.ts
+++ b/packages/app/src/ui/pages/Identity/useIdentityPage.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from "react";
+import { UseFormRegister, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import { Paths } from "@src/constants";
+import { useAppDispatch } from "@src/ui/ducks/hooks";
+import {
+  deleteIdentity,
+  fetchIdentities,
+  setIdentityName,
+  useConnectedIdentity,
+  useIdentity,
+} from "@src/ui/ducks/identities";
+import { useUrlParam } from "@src/ui/hooks/url";
+import { redirectToNewTab } from "@src/util/browser";
+
+import type { IdentityMetadata } from "@cryptkeeperzk/types";
+
+export interface IUseIdentityPageData {
+  isLoading: boolean;
+  isConnectedIdentity: boolean;
+  isConfirmModalOpen: boolean;
+  isUpdating: boolean;
+  errors: Partial<{ root: string; name: string }>;
+  commitment?: string;
+  metadata?: IdentityMetadata;
+  register: UseFormRegister<FormFields>;
+  onGoBack: () => void;
+  onConfirmDeleteIdentity: () => void;
+  onDeleteIdentity: () => void;
+  onUpdateIdentity: () => void;
+  onGoToHost: () => void;
+  onConfirmUpdate: () => void;
+}
+
+interface FormFields {
+  name: string;
+}
+
+export const useIdentityPage = (): IUseIdentityPageData => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+  const [isUpdating, setUpdating] = useState(false);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const commitment = useUrlParam("id");
+  const identity = useIdentity(commitment);
+  const connectedIdentity = useConnectedIdentity();
+
+  const {
+    formState: { errors, isSubmitting },
+    setError,
+    setValue,
+    register,
+    handleSubmit,
+  } = useForm({
+    defaultValues: {
+      name: identity?.metadata.name || "",
+    },
+  });
+
+  const onGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    dispatch(fetchIdentities())
+      .catch((err: Error) => setError("root", { message: err.message }))
+      .finally(() => setIsLoading(false));
+  }, [dispatch, setIsLoading, setError]);
+
+  useEffect(() => {
+    if (!identity?.metadata.name) {
+      return;
+    }
+
+    setValue("name", identity.metadata.name);
+  }, [identity?.metadata.name]);
+
+  const onConfirmDeleteIdentity = useCallback(() => {
+    setConfirmModalOpen((value) => !value);
+  }, [setConfirmModalOpen]);
+
+  const onDeleteIdentity = useCallback(() => {
+    dispatch(deleteIdentity(commitment!))
+      .then(() => setConfirmModalOpen(false))
+      .then(() => navigate(Paths.HOME))
+      .catch((err: Error) => setError("root", { message: err.message }));
+  }, [commitment, dispatch, navigate, setConfirmModalOpen, setError]);
+
+  const onUpdateIdentity = useCallback(() => {
+    setUpdating((value) => !value);
+  }, [setUpdating]);
+
+  const onGoToHost = useCallback(() => {
+    redirectToNewTab(identity!.metadata.host!);
+  }, [identity?.metadata.host]);
+
+  const onConfirmUpdate = useCallback(
+    (data: FormFields) => {
+      dispatch(setIdentityName(commitment!, data.name))
+        .then(() => setUpdating(false))
+        .catch((err: Error) => setError("root", { message: err.message }));
+    },
+    [commitment, dispatch, setUpdating, setError],
+  );
+
+  return {
+    isLoading: isLoading || isSubmitting,
+    isConnectedIdentity: identity ? identity.commitment === connectedIdentity?.commitment : false,
+    isConfirmModalOpen,
+    isUpdating,
+    errors: {
+      root: errors.root?.message,
+      name: errors.name?.message,
+    },
+    commitment: identity?.commitment,
+    metadata: identity?.metadata,
+    register,
+    onGoBack,
+    onConfirmDeleteIdentity,
+    onDeleteIdentity,
+    onUpdateIdentity,
+    onGoToHost,
+    onConfirmUpdate: handleSubmit(onConfirmUpdate),
+  };
+};

--- a/packages/app/src/ui/pages/Popup/Popup.tsx
+++ b/packages/app/src/ui/pages/Popup/Popup.tsx
@@ -7,6 +7,7 @@ import CreateIdentity from "@src/ui/pages/CreateIdentity";
 import DownloadBackup from "@src/ui/pages/DownloadBackup";
 import GenerateMnemonic from "@src/ui/pages/GenerateMnemonic";
 import Home from "@src/ui/pages/Home";
+import Identity from "@src/ui/pages/Identity";
 import Login from "@src/ui/pages/Login";
 import Onboarding from "@src/ui/pages/Onboarding";
 import OnboardingBackup from "@src/ui/pages/OnboardingBackup";
@@ -22,6 +23,7 @@ import { usePopup } from "./usePopup";
 
 const routeConfig: RouteObject[] = [
   { path: Paths.HOME, element: <Home /> },
+  { path: Paths.IDENTITY, element: <Identity /> },
   { path: Paths.CREATE_IDENTITY, element: <CreateIdentity /> },
   { path: Paths.LOGIN, element: <Login /> },
   { path: Paths.ONBOARDING, element: <Onboarding /> },

--- a/packages/app/src/util/__tests__/browser.test.ts
+++ b/packages/app/src/util/__tests__/browser.test.ts
@@ -5,6 +5,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import browser from "webextension-polyfill";
 
+import { Paths } from "@src/constants";
+
 import {
   getLastActiveTabUrl,
   redirectToNewTab,
@@ -12,6 +14,7 @@ import {
   downloadFile,
   copyToClipboard,
   getUrlOrigin,
+  replaceUrlParams,
 } from "../browser";
 
 describe("util/browser", () => {
@@ -90,5 +93,11 @@ describe("util/browser", () => {
   test("should get url origin properly", () => {
     expect(getUrlOrigin()).toBe("");
     expect(getUrlOrigin("http://localhost:1234/#/page1?search=0")).toBe("http://localhost:1234");
+  });
+
+  test("should replace url params properly", () => {
+    const result = replaceUrlParams(Paths.IDENTITY, { id: "1234", unknown: "4321" });
+
+    expect(result).toBe("/identity/1234");
   });
 });

--- a/packages/app/src/util/browser.ts
+++ b/packages/app/src/util/browser.ts
@@ -35,3 +35,6 @@ export const getUrlOrigin = (url?: string): string => {
 
   return new URL(url).origin;
 };
+
+export const replaceUrlParams = (path: string, params: Record<string, string>): string =>
+  Object.entries(params).reduce((acc, [key, value]) => acc.replace(`:${key}`, value), path);

--- a/packages/e2e/.eslintignore
+++ b/packages/e2e/.eslintignore
@@ -3,3 +3,5 @@ test-results/
 playwright-report/
 playwright/.cache/
 tmp/
+user-data/
+test-results/

--- a/packages/e2e/pages/cryptKeeper/Identities.ts
+++ b/packages/e2e/pages/cryptKeeper/Identities.ts
@@ -9,6 +9,10 @@ export interface ICreateIdentityArgs {
   nonce?: number;
 }
 
+export interface IUpdateIdentityArgs {
+  name: string;
+}
+
 type WalletType = "eth" | "ck";
 
 type IdentityType = "InterRep" | "Random";
@@ -29,6 +33,24 @@ const PROVIDER_OPTIONS: Record<ProviderType, number> = {
 export default class Identities extends BasePage {
   async openTab(): Promise<void> {
     await this.page.getByText("Identities", { exact: true }).click();
+  }
+
+  async openIdentityPage(index = 0): Promise<void> {
+    const identities = await this.page.locator(".identity-row").all();
+    await identities[index].getByTestId("menu").click();
+    await this.page.getByText("View").click();
+  }
+
+  async updateIdentityFromPage({ name }: IUpdateIdentityArgs): Promise<void> {
+    await this.page.getByText("Update").click();
+
+    await this.page.locator("#identityRename").fill(name);
+    await this.page.locator("#identityRename").press("Enter");
+  }
+
+  async deleteIdentityFromPage(): Promise<void> {
+    await this.page.getByText("Delete").click();
+    await this.page.getByText("Yes").click();
   }
 
   async createIdentityFromHome(params: ICreateIdentityArgs): Promise<void> {

--- a/packages/e2e/tests/identity.test.ts
+++ b/packages/e2e/tests/identity.test.ts
@@ -179,4 +179,24 @@ test.describe("identity", () => {
 
     await expect(extension.getByText(/Account/)).toHaveCount(2);
   });
+
+  test("should check identity page [health-check]", async ({ page }) => {
+    const extension = new CryptKeeper(page);
+    await extension.focus();
+
+    await extension.identities.createIdentityFromHome({ walletType: "eth" });
+    await expect(extension.getByText("Account # 1")).toBeVisible();
+
+    await extension.identities.openIdentityPage(1);
+    await extension.identities.updateIdentityFromPage({ name: "My new account" });
+    await extension.goHome();
+
+    await expect(extension.getByText("My new account")).toBeVisible();
+
+    await extension.identities.openIdentityPage(1);
+    await extension.identities.deleteIdentityFromPage();
+    await extension.goHome();
+
+    await expect(extension.getByText("My new account")).toBeHidden();
+  });
 });


### PR DESCRIPTION
## Explanation

This PR adds identity page to show user full identity metadata.

Details are below:
- [x] Add identity page
- [x] Fix firefox manifest v2
- [x] Minor refactoring for identity list item
- [x] Add delete and update identity actions
- [x] Add e2e test for identity page

## More Information

Closes #683 

## Screenshots/Screencaps

Extended mode:
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/36d326c9-0ad8-4581-b531-c33cd382b5b7)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/8da37aa4-061a-4b7f-baa9-d3f5ad2c01a3)

Popup mode:
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/ba2af657-c932-4f8d-bafa-ba4faf83c522)
![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/c9ba2e12-29f9-417a-b92b-ecbcad133a63)


## Manual Testing Steps

1. Go to home
2. Open identity view
3. See identity metadata

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
