### PR TITLE
feat: hide identity commitment

### DIFF
--- a/packages/app/src/background/contentScript.ts
+++ b/packages/app/src/background/contentScript.ts
@@ -4,7 +4,7 @@ import browser from "webextension-polyfill";
 import { setStatus } from "@src/ui/ducks/app";
 import { setConnectedIdentity } from "@src/ui/ducks/identities";
 
-import type { InjectedMessageData, ReduxAction, ConnectedIdentity } from "@cryptkeeperzk/types";
+import type { InjectedMessageData, ReduxAction, ConnectedIdentityMetadata } from "@cryptkeeperzk/types";
 
 function injectScript() {
   const url = browser.runtime.getURL("js/injected.js");
@@ -38,7 +38,7 @@ function injectScript() {
         window.postMessage(
           {
             target: "injected-injectedscript",
-            payload: [null, action.payload as ConnectedIdentity],
+            payload: [null, action.payload as ConnectedIdentityMetadata],
             nonce: "identityChanged",
           },
           "*",

--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -26,7 +26,6 @@ const RPC_METHOD_ACCESS: Record<RPCAction, boolean> = {
   [RPCAction.APPROVE_HOST]: true,
   [RPCAction.GET_CONNECTED_IDENTITY_DATA]: true,
   [RPCAction.CONNECT_IDENTITY_REQUEST]: true,
-  [RPCAction.GET_COMMITMENTS]: true,
   [RPCAction.GET_HOST_PERMISSIONS]: true,
   [RPCAction.SET_HOST_PERMISSIONS]: true,
   [RPCAction.CREATE_IDENTITY_REQUEST]: true,
@@ -116,12 +115,16 @@ export default class CryptKeeperController {
     this.handler.add(RPCAction.CHECK_PASSWORD, this.lockService.ensure, this.lockService.checkPassword);
 
     // Identities
-    this.handler.add(RPCAction.GET_COMMITMENTS, this.lockService.ensure, this.zkIdentityService.getIdentityCommitments);
     this.handler.add(RPCAction.GET_IDENTITIES, this.lockService.ensure, this.zkIdentityService.getIdentities);
     this.handler.add(
       RPCAction.GET_CONNECTED_IDENTITY_DATA,
       this.lockService.ensure,
       this.zkIdentityService.getConnectedIdentityData,
+    );
+    this.handler.add(
+      RPCAction.GET_CONNECTED_IDENTITY_COMMITMENT,
+      this.lockService.ensure,
+      this.zkIdentityService.getConnectedIdentityCommitment,
     );
     this.handler.add(RPCAction.CONNECT_IDENTITY, this.lockService.ensure, this.zkIdentityService.connectIdentity);
     this.handler.add(

--- a/packages/app/src/ui/components/FullModal/fullModal.scss
+++ b/packages/app/src/ui/components/FullModal/fullModal.scss
@@ -43,6 +43,6 @@
     justify-content: end;
     border-top: 1px solid $gray-800;
     flex: 0 0 auto;
-    padding: 1rem 2rem;
+    padding: 1rem 1.5rem;
   }
 }

--- a/packages/app/src/ui/components/IdentityList/IdentityList.tsx
+++ b/packages/app/src/ui/components/IdentityList/IdentityList.tsx
@@ -70,7 +70,7 @@ export const IdentityList = ({
           scrollbarWidth: "none",
           display: "flex",
           alignItems: "center",
-          justifyContent: "center",
+          flexDirection: "column",
 
           "&::-webkit-scrollbar": {
             display: "none",

--- a/packages/app/src/ui/components/IdentityList/Item/index.tsx
+++ b/packages/app/src/ui/components/IdentityList/Item/index.tsx
@@ -81,6 +81,8 @@ export const IdentityItem = ({
         borderBottom: "1px solid",
         borderColor: "text.800",
         cursor: "pointer",
+        height: 100,
+        width: "100%",
 
         "&:hover": {
           backgroundColor: "text.900",

--- a/packages/app/src/ui/ducks/__tests__/identities.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/identities.test.tsx
@@ -7,7 +7,7 @@ import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 
 import { ZERO_ADDRESS } from "@src/config/const";
-import { EWallet, HistorySettings, OperationType, ConnectedIdentity } from "@src/types";
+import { EWallet, HistorySettings, OperationType, IdentityMetadata } from "@src/types";
 import { store } from "@src/ui/store/configureAppStore";
 import postMessage from "@src/util/postMessage";
 
@@ -77,10 +77,8 @@ describe("ui/ducks/identities", () => {
 
   const defaultSettings: HistorySettings = { isEnabled: true };
 
-  const defaultConnectedIdentity: ConnectedIdentity = {
-    commitment: defaultIdentities[0].commitment,
-    web2Provider: defaultIdentities[0].metadata.web2Provider,
-    host: defaultIdentities[0].metadata.host,
+  const defaultConnectedIdentityMetadata: IdentityMetadata = {
+    ...defaultIdentities[0].metadata,
   };
 
   afterEach(() => {
@@ -88,7 +86,10 @@ describe("ui/ducks/identities", () => {
   });
 
   test("should fetch identities properly", async () => {
-    (postMessage as jest.Mock).mockResolvedValueOnce(defaultIdentities).mockResolvedValueOnce(defaultConnectedIdentity);
+    (postMessage as jest.Mock)
+      .mockResolvedValueOnce(defaultIdentities)
+      .mockResolvedValueOnce(defaultConnectedIdentityMetadata)
+      .mockResolvedValueOnce(defaultIdentities[0].commitment);
 
     await Promise.resolve(store.dispatch(fetchIdentities()));
     const { identities } = store.getState();
@@ -173,12 +174,10 @@ describe("ui/ducks/identities", () => {
   });
 
   test("should set connected identity properly", async () => {
-    await Promise.resolve(store.dispatch(setConnectedIdentity(defaultConnectedIdentity)));
+    await Promise.resolve(store.dispatch(setConnectedIdentity(defaultConnectedIdentityMetadata)));
     const { identities } = store.getState();
 
-    expect(identities.connected.commitment).toBe("1");
-    expect(identities.connected.web2Provider).toBe("twitter");
-    expect(identities.connected.host).toBe("http://localhost:3000");
+    expect(identities.connectedMetadata).toStrictEqual(defaultIdentities[0].metadata);
   });
 
   test("should set identities properly", async () => {

--- a/packages/app/src/ui/pages/CreateIdentity/CreateIdentity.tsx
+++ b/packages/app/src/ui/pages/CreateIdentity/CreateIdentity.tsx
@@ -121,6 +121,7 @@ const CreateIdentity = (): JSX.Element => {
             <Button
               disabled={isLoading || !isWalletInstalled}
               name="metamask"
+              size="small"
               sx={{ textTransform: "none", flex: 1, mr: 1 }}
               type="submit"
               variant="outlined"
@@ -132,6 +133,7 @@ const CreateIdentity = (): JSX.Element => {
             <Button
               disabled={isLoading}
               name="cryptkeeper"
+              size="small"
               sx={{ textTransform: "none", flex: 1, ml: 1 }}
               type="submit"
               variant="contained"

--- a/packages/app/src/ui/pages/Home/components/ActivityList/Item/activityListItemStyles.scss
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/Item/activityListItemStyles.scss
@@ -6,6 +6,7 @@
   display: flex;
   border-bottom: 1px solid $gray-900;
   cursor: pointer;
+  height: 100px;
 
   &:hover {
     background-color: $gray-950;

--- a/packages/app/src/ui/pages/Home/components/ActivityList/activityListStyles.scss
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/activityListStyles.scss
@@ -13,7 +13,6 @@
 .activity-container {
   position: absolute;
   top: 56px;
-  bottom: 56px;
   width: 100%;
 }
 

--- a/packages/demo/index.tsx
+++ b/packages/demo/index.tsx
@@ -39,7 +39,7 @@ const App = () => {
   const {
     client,
     isLocked,
-    connectedIdentity,
+    connectedIdentityMetadata,
     proof,
     connect,
     createIdentity,
@@ -57,7 +57,7 @@ const App = () => {
     return <NotConnected onClick={connect} />;
   }
 
-  if (!connectedIdentity.commitment) {
+  if (!connectedIdentityMetadata) {
     return <NoConnectedIdentityCommitment onConnectIdentity={connectIdentity} />;
   }
 
@@ -66,15 +66,33 @@ const App = () => {
       <hr />
 
       <div>
-        <h2>Identity commitment for the connected identity:</h2>
+        <h2>Connected identity:</h2>
 
-        <p data-testid="connected-commitment">{connectedIdentity.commitment}</p>
-      </div>
+        <div>
+          <strong>Name:</strong>
 
-      <div>
-        <h2>Host name for the connected identity:</h2>
+          <p data-testid="connected-name">{connectedIdentityMetadata.name}</p>
+        </div>
 
-        <p data-testid="connected-host">{connectedIdentity.host}</p>
+        <div>
+          <strong>Strategy:</strong>
+
+          <p data-testid="connected-strategy">{connectedIdentityMetadata.identityStrategy}</p>
+        </div>
+
+        {connectedIdentityMetadata.web2Provider && (
+          <div>
+            <strong>Web2 Provider:</strong>
+
+            <p data-testid="connected-web2-provider">{connectedIdentityMetadata.web2Provider}</p>
+          </div>
+        )}
+
+        <div>
+          <strong>Host:</strong>
+
+          <p data-testid="connected-host">{connectedIdentityMetadata.host}</p>
+        </div>
       </div>
 
       <hr />

--- a/packages/providers/src/constants/rpcAction.ts
+++ b/packages/providers/src/constants/rpcAction.ts
@@ -15,7 +15,7 @@ export enum RPCAction {
   DELETE_IDENTITY = "rpc/identity/deleteIdentity",
   DELETE_ALL_IDENTITIES = "rpc/identity/deleteAllIdentities",
   GET_CONNECTED_IDENTITY_DATA = "rpc/identity/getConnectedIdentityData",
-  GET_COMMITMENTS = "rpc/identity/getIdentityCommitments",
+  GET_CONNECTED_IDENTITY_COMMITMENT = "rpc/identity/getConnectedIdentityCommitment",
   GET_IDENTITIES = "rpc/identity/getIdentities",
   GET_REQUEST_PENDING_STATUS = "rpc/identity/getRequestPendingStatus",
   FINALIZE_REQUEST = "rpc/requests/finalize",

--- a/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
+++ b/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
@@ -2,7 +2,6 @@ import {
   Approvals,
   InjectedMessageData,
   InjectedProviderRequest,
-  ConnectedIdentity,
   SemaphoreFullProof,
   ICreateIdentityRequestArgs,
   IConnectIdentityRequestArgs,
@@ -10,6 +9,7 @@ import {
   RLNSNARKProof,
   ISemaphoreProofRequiredArgs,
   IRlnProofRequiredArgs,
+  ConnectedIdentityMetadata,
 } from "@cryptkeeperzk/types";
 import { ZkProofService } from "@cryptkeeperzk/zk";
 
@@ -115,7 +115,7 @@ export class CryptKeeperInjectedProvider {
 
     const connectedIdentity = await this.getConnectedIdentity();
 
-    if (!connectedIdentity.commitment) {
+    if (!connectedIdentity) {
       await this.connectIdentity({ host: window.location.origin });
     }
 
@@ -186,10 +186,10 @@ export class CryptKeeperInjectedProvider {
    *
    * @returns {Promise<ConnectedIdentity>} A Promise that resolves to the connected identity.
    */
-  async getConnectedIdentity(): Promise<ConnectedIdentity> {
+  async getConnectedIdentity(): Promise<ConnectedIdentityMetadata | undefined> {
     return this.post({
       method: RPCAction.GET_CONNECTED_IDENTITY_DATA,
-    }) as Promise<ConnectedIdentity>;
+    }) as Promise<ConnectedIdentityMetadata>;
   }
 
   /**
@@ -264,17 +264,6 @@ export class CryptKeeperInjectedProvider {
       promises.delete(data.nonce.toString());
     }
   };
-
-  /**
-   * Retrieves the identity commitments.
-   *
-   * @returns {Promise<unknown>} A Promise that resolves to the identity commitments.
-   */
-  async getIdentityCommitments(): Promise<unknown> {
-    return this.post({
-      method: RPCAction.GET_COMMITMENTS,
-    });
-  }
 
   /**
    * Retrieves the host permissions for the specified host.

--- a/packages/types/src/duck/identities.ts
+++ b/packages/types/src/duck/identities.ts
@@ -1,11 +1,5 @@
 import type { CreateIdentityOptions, EWallet, GroupData, IdentityStrategy } from "../identity";
 
-export interface ConnectedIdentity {
-  commitment: string;
-  web2Provider?: string;
-  host?: string;
-}
-
 export interface ICreateIdentityUiArgs {
   strategy: IdentityStrategy;
   options: CreateIdentityOptions;

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -41,6 +41,8 @@ export interface IdentityMetadata {
   host?: string;
 }
 
+export type ConnectedIdentityMetadata = Pick<IdentityMetadata, "name" | "identityStrategy" | "web2Provider" | "host">;
+
 export interface GroupData {
   id: string;
   name: string;


### PR DESCRIPTION


## Explanation

This PR hides identity commitment and keeps it only inside the extension.

Details are below:
- [x] Hide identity commitment from external calls
- [x] Minor style fixes
- [x] Show identity metadata instead for connected identity

## More Information

Related to #313 

## Screenshots/Screencaps

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/cca85026-fc25-4136-b2c5-224e654ade4a)

## Manual Testing Steps

1. Identity commitment can't be retried outside the extension

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
