### PR TITLE
chore: make EventName an enum (#738)

### DIFF
--- a/packages/app/src/background/contentScript.ts
+++ b/packages/app/src/background/contentScript.ts
@@ -1,3 +1,4 @@
+import { EventName } from "@cryptkeeperzk/providers/dist/src/event/types";
 import log from "loglevel";
 import browser from "webextension-polyfill";
 
@@ -39,7 +40,7 @@ function injectScript() {
           {
             target: "injected-injectedscript",
             payload: [null, action.payload as ConnectedIdentityMetadata],
-            nonce: "identityChanged",
+            nonce: EventName.IDENTITY_CHANGED,
           },
           "*",
         );
@@ -50,7 +51,7 @@ function injectScript() {
           {
             target: "injected-injectedscript",
             payload: [null],
-            nonce: !(action.payload as { isUnlocked: boolean }).isUnlocked ? "logout" : "login",
+            nonce: !(action.payload as { isUnlocked: boolean }).isUnlocked ? EventName.LOGOUT : EventName.LOGIN,
           },
           "*",
         );
@@ -63,23 +64,23 @@ function injectScript() {
 
   browser.runtime.onMessage.addListener((request: { action: string }) => {
     switch (request.action) {
-      case "addVerifiableCredential": {
+      case EventName.ADD_VERIFIABLE_CREDENTIAL: {
         window.postMessage(
           {
             target: "injected-injectedscript",
             payload: [null, (request as { action: string; verifiableCredentialHash: string }).verifiableCredentialHash],
-            nonce: "addVerifiableCredential",
+            nonce: EventName.ADD_VERIFIABLE_CREDENTIAL,
           },
           "*",
         );
         break;
       }
-      case "rejectVerifiableCredential": {
+      case EventName.REJECT_VERIFIABLE_CREDENTIAL: {
         window.postMessage(
           {
             target: "injected-injectedscript",
             payload: [null],
-            nonce: "rejectVerifiableCredential",
+            nonce: EventName.REJECT_VERIFIABLE_CREDENTIAL,
           },
           "*",
         );

--- a/packages/app/src/background/services/credentials/index.ts
+++ b/packages/app/src/background/services/credentials/index.ts
@@ -1,3 +1,4 @@
+import { EventName } from "@cryptkeeperzk/providers/dist/src/event/types";
 import browser from "webextension-polyfill";
 
 import BrowserUtils from "@src/background/controllers/browserUtils";
@@ -76,7 +77,7 @@ export default class VerifiableCredentialsService implements IBackupable {
       tabs.map((tab) =>
         browser.tabs
           .sendMessage(tab.id!, {
-            action: "rejectVerifiableCredential",
+            action: EventName.REJECT_VERIFIABLE_CREDENTIAL,
           })
           .catch(() => undefined),
       ),
@@ -242,7 +243,7 @@ export default class VerifiableCredentialsService implements IBackupable {
       tabs.map((tab) =>
         browser.tabs
           .sendMessage(tab.id!, {
-            action: "addVerifiableCredential",
+            action: EventName.ADD_VERIFIABLE_CREDENTIAL,
             verifiableCredentialHash,
           })
           .catch(() => undefined),

--- a/packages/app/src/connectors/__tests__/cryptKeeper.test.ts
+++ b/packages/app/src/connectors/__tests__/cryptKeeper.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { initializeCryptKeeperProvider } from "@cryptkeeperzk/providers";
+import { EventName } from "@cryptkeeperzk/providers/dist/src/event/types";
 import EventEmitter2 from "eventemitter2";
 
 import { ZERO_ADDRESS } from "@src/config/const";
@@ -97,8 +98,8 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.activate();
 
-    await Promise.resolve(mockProvider.emit("login"));
-    await Promise.resolve(mockProvider.emit("logout"));
+    await Promise.resolve(mockProvider.emit(EventName.LOGIN));
+    await Promise.resolve(mockProvider.emit(EventName.LOGOUT));
 
     expect(mockActions.update).toBeCalledTimes(1);
     expect(mockActions.update).toBeCalledWith({ accounts: mockAddresses });

--- a/packages/app/src/connectors/cryptKeeper.ts
+++ b/packages/app/src/connectors/cryptKeeper.ts
@@ -1,4 +1,5 @@
 import { type CryptKeeperInjectedProvider, initializeCryptKeeperProvider, RPCAction } from "@cryptkeeperzk/providers";
+import { EventName } from "@cryptkeeperzk/providers/dist/src/event/types";
 import { initializeConnector } from "@web3-react/core";
 import { Connector } from "@web3-react/types";
 
@@ -57,12 +58,12 @@ export class CryptkeeperConnector extends Connector {
 
     this.customProvider = initializeCryptKeeperProvider();
     this.eagerConnection = this.customProvider?.connect().then(() => {
-      this.customProvider?.on("login", async () => {
+      this.customProvider?.on(EventName.LOGIN, async () => {
         const accounts = await this.loadAccounts();
         this.actions.update({ accounts });
       });
 
-      this.customProvider?.on("logout", () => {
+      this.customProvider?.on(EventName.LOGOUT, () => {
         this.actions.resetState();
       });
     });

--- a/packages/demo/useCryptKeeper.ts
+++ b/packages/demo/useCryptKeeper.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { cryptkeeperConnect, type CryptKeeperInjectedProvider } from "@cryptkeeperzk/providers";
+import { EventName } from "@cryptkeeperzk/providers/dist/src/event/types";
 import { Identity } from "@cryptkeeperzk/semaphore-identity";
 import { bigintToHex } from "bigint-conversion";
 import { encodeBytes32String } from "ethers";
@@ -217,11 +218,11 @@ export const useCryptKeeper = (): IUseCryptKeeperData => {
       return undefined;
     }
 
-    client.on("login", onLogin);
-    client.on("identityChanged", onIdentityChanged);
-    client.on("logout", onLogout);
-    client.on("addVerifiableCredential", onAddVerifiableCredential);
-    client.on("rejectVerifiableCredential", onRejectVerifiableCredential);
+    client.on(EventName.LOGIN, onLogin);
+    client.on(EventName.IDENTITY_CHANGED, onIdentityChanged);
+    client.on(EventName.LOGOUT, onLogout);
+    client.on(EventName.ADD_VERIFIABLE_CREDENTIAL, onAddVerifiableCredential);
+    client.on(EventName.REJECT_VERIFIABLE_CREDENTIAL, onRejectVerifiableCredential);
 
     getConnectedIdentity();
 

--- a/packages/providers/src/event/index.ts
+++ b/packages/providers/src/event/index.ts
@@ -1,2 +1,3 @@
 export { EventEmitter } from "./EventEmitter";
-export type { EventHandler, EventName, Events } from "./types";
+export type { EventHandler, Events } from "./types";
+export { EventName } from "./types";

--- a/packages/providers/src/event/types.ts
+++ b/packages/providers/src/event/types.ts
@@ -8,17 +8,23 @@
 export type EventHandler = (data: unknown) => void;
 
 /**
- * Represents the name of an event.
+ * Enumeration representing possible event names.
  *
- * @type {EventName}
- * @typedef {("login" | "identityChanged" | "logout" | "addVerifiableCredential" | "rejectVerifiableCredential")} EventName
+ * @enum {string}
+ * @readonly
+ * @property {string} LOGIN - "login"
+ * @property {string} IDENTITY_CHANGED - "identityChanged"
+ * @property {string} LOGOUT - "logout"
+ * @property {string} ADD_VERIFIABLE_CREDENTIAL - "addVerifiableCredential"
+ * @property {string} REJECT_VERIFIABLE_CREDENTIAL - "rejectVerifiableCredential"
  */
-export type EventName =
-  | "login"
-  | "identityChanged"
-  | "logout"
-  | "addVerifiableCredential"
-  | "rejectVerifiableCredential";
+export enum EventName {
+  LOGIN = "login",
+  IDENTITY_CHANGED = "identityChanged",
+  LOGOUT = "logout",
+  ADD_VERIFIABLE_CREDENTIAL = "addVerifiableCredential",
+  REJECT_VERIFIABLE_CREDENTIAL = "rejectVerifiableCredential",
+}
 
 /**
  * Represents the events object that maps event names to event handlers.

--- a/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
+++ b/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
@@ -217,33 +217,33 @@ export class CryptKeeperInjectedProvider {
     const { data } = event;
 
     if (data.target === "injected-injectedscript") {
-      if (data.nonce === "identityChanged") {
+      if (data.nonce === (EventName.IDENTITY_CHANGED as string)) {
         const [, res] = data.payload;
-        this.emit("identityChanged", res);
+        this.emit(EventName.IDENTITY_CHANGED, res);
         return;
       }
 
-      if (data.nonce === "logout") {
+      if (data.nonce === (EventName.LOGOUT as string)) {
         const [, res] = data.payload;
-        this.emit("logout", res);
+        this.emit(EventName.LOGOUT, res);
         return;
       }
 
-      if (data.nonce === "login") {
+      if (data.nonce === (EventName.LOGIN as string)) {
         const [, res] = data.payload;
-        this.emit("login", res);
+        this.emit(EventName.LOGIN, res);
         return;
       }
 
-      if (data.nonce === "addVerifiableCredential") {
+      if (data.nonce === (EventName.ADD_VERIFIABLE_CREDENTIAL as string)) {
         const [, res] = data.payload;
-        this.emit("addVerifiableCredential", res);
+        this.emit(EventName.ADD_VERIFIABLE_CREDENTIAL, res);
         return;
       }
 
-      if (data.nonce === "rejectVerifiableCredential") {
+      if (data.nonce === (EventName.REJECT_VERIFIABLE_CREDENTIAL as string)) {
         const [, res] = data.payload;
-        this.emit("rejectVerifiableCredential", res);
+        this.emit(EventName.REJECT_VERIFIABLE_CREDENTIAL, res);
         return;
       }
 


### PR DESCRIPTION
## Explanation

As discussed [here](https://github.com/CryptKeeperZK/crypt-keeper-extension/pull/674#discussion_r1295363554), it would be nice to have explicit event names to avoid potential typos or mismatches when emitting/receiving events. We make `EventName` an enum and change all magic string event names to use the new EventName. 

- [ ] Add `EventName` enum

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
