### PR TITLE
fix: disable commit signing for release bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,9 @@ jobs:
           git config user.name "$GIT_AUTHOR_NAME"
           git config user.email "$GIT_AUTHOR_EMAIL"
           npm config set commit-hooks false
-          git config commit.gpgsign true
-          git config user.signingkey $GPG_SIGNING_KEY_ID
+          # TODO: support commit signing when it's supported https://github.com/jscutlery/semver/issues/489
+          # git config commit.gpgsign true
+          # git config user.signingkey $GPG_SIGNING_KEY_ID
           npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
         env:
           GPG_SIGNING_KEY_ID: ${{ secrets.GPG_SIGNING_KEY_ID }}


### PR DESCRIPTION
## Explanation

Disable commit singing

## More Information

Related to #675 

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
