### PR TITLE
fix: use pat instead of github token

### DIFF
--- a/.github/workflows/publishChrome.yml
+++ b/.github/workflows/publishChrome.yml
@@ -80,4 +80,4 @@ jobs:
         run: |-
           gh release upload "${{ github.ref_name }}" "cryptkeeper-chrome-extension-v${{ env.EXTENSION_VERSION }}.zip" "cryptkeeper-chrome-extension-checksum-v${{ env.EXTENSION_VERSION }}.txt" "cryptkeeper-chrome-extension-v${{ env.EXTENSION_VERSION }}.zip.asc"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/publishFirefox.yml
+++ b/.github/workflows/publishFirefox.yml
@@ -83,4 +83,4 @@ jobs:
         run: |-
           gh release upload "${{ github.ref_name }}" "cryptkeeper-firefox-extension-v${{ env.EXTENSION_VERSION }}.zip" "cryptkeeper-firefox-extension-checksum-v${{ env.EXTENSION_VERSION }}.txt" "cryptkeeper-firefox-extension-v${{ env.EXTENSION_VERSION }}.zip.asc"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/publishPackages.yml
+++ b/.github/workflows/publishPackages.yml
@@ -88,4 +88,4 @@ jobs:
         run: |-
           gh release upload "${{ github.ref_name }}" "cryptkeeper-providers-v${{ env.PROVIDERS_VERSION }}.zip" "cryptkeeper-providers-checksum-v${{ env.PROVIDERS_VERSION }}.txt" "cryptkeeper-providers-v${{ env.PROVIDERS_VERSION }}.zip.asc"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           pnpm run release
         env:
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
## Explanation

Use PAT instead of GITHUB_TOKEN in release workflow

## More Information

Related to #675

## Screenshots/Screencaps

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
