### PR TITLE
fix: docs path

### DIFF
--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -48,16 +48,20 @@ jobs:
       - name: Build with mdBook
         run: mdbook build
 
+      - name: List Working Directory Contents
+        run: ls -R
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: ./book
+          path: ./docs/book
 
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+      
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Explanation

Fixing `deployDocs` doc path. 

## Related Issues

N/A

## Screenshots

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] Pre-commit and pre-push hook checks are passed
- [ ] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
