### PR TITLE
fix: protect external bandada apis

### DIFF
--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -13,7 +13,7 @@ import ApprovalService from "./services/approval";
 import BackupService from "./services/backup";
 import VerifiableCredentialsService from "./services/credentials";
 import { validateSerializedVerifiableCredential } from "./services/credentials/utils";
-import { GroupService } from "./services/group";
+import GroupService from "./services/group";
 import HistoryService from "./services/history";
 import { InjectorService } from "./services/injector";
 import LockerService from "./services/lock";
@@ -28,15 +28,15 @@ const defaultMap = Object.values(RPCExternalAction).reduce(
 
 const RPC_METHOD_ACCESS: Record<RPCExternalAction, boolean> = {
   ...defaultMap,
-  [RPCExternalAction.INJECTOR_CONNECT]: true,
-  [RPCExternalAction.INJECTOR_GENERATE_SEMAPHORE_PROOF]: true,
-  [RPCExternalAction.INJECTOR_GENERATE_RLN_PROOF]: true,
-  [RPCExternalAction.INJECTOR_GET_CONNECTED_IDENTITY_DATA]: true,
+  [RPCExternalAction.GET_CONNECTED_IDENTITY_DATA]: true,
+  [RPCExternalAction.CONNECT]: true,
+  [RPCExternalAction.GENERATE_SEMAPHORE_PROOF]: true,
+  [RPCExternalAction.GENERATE_RLN_PROOF]: true,
+  [RPCExternalAction.JOIN_GROUP_REQUEST]: true,
+  [RPCExternalAction.GENERATE_GROUP_MERKLE_PROOF_REQUEST]: true,
   // TODO: Please note that the following 4 actions will be refactored in another PR
   [RPCExternalAction.ADD_VERIFIABLE_CREDENTIAL_REQUEST]: true,
   [RPCExternalAction.REVEAL_CONNECTED_IDENTITY_COMMITMENT_REQUEST]: true,
-  [RPCExternalAction.JOIN_GROUP_REQUEST]: true,
-  [RPCExternalAction.GENERATE_GROUP_MERKLE_PROOF_REQUEST]: true,
   [RPCExternalAction.GENERATE_VERIFIABLE_PRESENTATION_REQUEST]: true,
 };
 
@@ -97,13 +97,15 @@ export default class CryptKeeperController {
   initialize = (): this => {
     // Handling RPC EXTERNAL ACTIONS
     // Injector
+    this.handler.add(RPCExternalAction.GET_CONNECTED_IDENTITY_DATA, this.injectorService.getConnectedIdentityMetadata);
+    this.handler.add(RPCExternalAction.CONNECT, this.injectorService.connect);
+    this.handler.add(RPCExternalAction.GENERATE_SEMAPHORE_PROOF, this.injectorService.generateSemaphoreProof);
+    this.handler.add(RPCExternalAction.GENERATE_RLN_PROOF, this.injectorService.generateRLNProof);
+    this.handler.add(RPCExternalAction.JOIN_GROUP_REQUEST, this.injectorService.joinGroup);
     this.handler.add(
-      RPCExternalAction.INJECTOR_GET_CONNECTED_IDENTITY_DATA,
-      this.injectorService.getConnectedIdentityMetadata,
+      RPCExternalAction.GENERATE_GROUP_MERKLE_PROOF_REQUEST,
+      this.injectorService.generateGroupMerkleProof,
     );
-    this.handler.add(RPCExternalAction.INJECTOR_CONNECT, this.injectorService.connect);
-    this.handler.add(RPCExternalAction.INJECTOR_GENERATE_SEMAPHORE_PROOF, this.injectorService.generateSemaphoreProof);
-    this.handler.add(RPCExternalAction.INJECTOR_GENERATE_RLN_PROOF, this.injectorService.generateRLNProof);
 
     // Handling RPC INTERNAL ACTIONS
     // common
@@ -190,9 +192,9 @@ export default class CryptKeeperController {
     );
 
     // Groups
-    this.handler.add(RPCExternalAction.JOIN_GROUP_REQUEST, this.lockService.ensure, this.groupService.joinGroupRequest);
+    this.handler.add(RPCInternalAction.JOIN_GROUP_REQUEST, this.lockService.ensure, this.groupService.joinGroupRequest);
     this.handler.add(
-      RPCExternalAction.GENERATE_GROUP_MERKLE_PROOF_REQUEST,
+      RPCInternalAction.GENERATE_GROUP_MERKLE_PROOF_REQUEST,
       this.lockService.ensure,
       this.groupService.generateGroupMerkleProofRequest,
     );

--- a/packages/app/src/background/services/group/GroupService.ts
+++ b/packages/app/src/background/services/group/GroupService.ts
@@ -17,7 +17,7 @@ import type {
   IMerkleProof,
 } from "@cryptkeeperzk/types";
 
-export class GroupService {
+export default class GroupService {
   private static INSTANCE?: GroupService;
 
   private bandadaSevice: BandadaService;

--- a/packages/app/src/background/services/group/__tests__/GroupService.test.ts
+++ b/packages/app/src/background/services/group/__tests__/GroupService.test.ts
@@ -9,7 +9,7 @@ import type {
   IJoinGroupMemberArgs,
 } from "@cryptkeeperzk/types";
 
-import { GroupService } from "..";
+import GroupService from "..";
 
 const mockGetConnectedIdentityCommitment = jest.fn(() => Promise.resolve(mockDefaultIdentityCommitment));
 const mockGetConnectedIdentity = jest.fn(() => Promise.resolve(mockDefaultIdentity));

--- a/packages/app/src/background/services/group/index.ts
+++ b/packages/app/src/background/services/group/index.ts
@@ -1,1 +1,3 @@
-export { GroupService } from "./GroupService";
+import GroupService from "./GroupService";
+
+export default GroupService;

--- a/packages/app/src/background/services/injector/Injector.ts
+++ b/packages/app/src/background/services/injector/Injector.ts
@@ -7,6 +7,8 @@ import {
   IRLNFullProof,
   ConnectedIdentityMetadata,
   IHostPermission,
+  IJoinGroupMemberArgs,
+  IGenerateGroupMerkleProofArgs,
 } from "@cryptkeeperzk/types";
 import { identity } from "webextension-polyfill";
 
@@ -98,7 +100,6 @@ export class InjectorService {
 
     try {
       await createChromeOffscreen();
-
       const fullProof = await pushMessage({
         method: RPCInternalAction.GENERATE_SEMAPHORE_PROOF_OFFSCREEN,
         payload: checkedSemaphoreProofRequest,
@@ -139,7 +140,6 @@ export class InjectorService {
 
     try {
       await createChromeOffscreen();
-
       const rlnFullProof = await pushMessage({
         method: RPCInternalAction.GENERATE_RLN_PROOF_OFFSCREEN,
         payload: checkedRLNProofRequest,
@@ -152,6 +152,30 @@ export class InjectorService {
       throw new Error(`CryptKeeper: Error in generating RLN proof on Chrome ${(error as Error).message}`);
     } finally {
       await closeChromeOffscreen();
+    }
+  };
+
+  joinGroup = async (
+    { groupId, apiKey, inviteCode }: IJoinGroupMemberArgs,
+    { urlOrigin }: IZkMetadata,
+  ): Promise<void> => {
+    try {
+      await this.injectorHandler.requiredApproval({ urlOrigin });
+      await this.injectorHandler.getGroupService().joinGroupRequest({ groupId, apiKey, inviteCode });
+    } catch (error) {
+      throw new Error(`CryptKeeper: joining a group via Bandada service ${(error as Error).message}`);
+    }
+  };
+
+  generateGroupMerkleProof = async (
+    { groupId }: IGenerateGroupMerkleProofArgs,
+    { urlOrigin }: IZkMetadata,
+  ): Promise<void> => {
+    try {
+      await this.injectorHandler.requiredApproval({ urlOrigin });
+      await this.injectorHandler.getGroupService().generateGroupMerkleProofRequest({ groupId });
+    } catch (error) {
+      throw new Error(`CryptKeeper: generate Merkle Proof via Bandada service ${(error as Error).message}`);
     }
   };
 }

--- a/packages/app/src/background/services/injector/InjectorHandler.ts
+++ b/packages/app/src/background/services/injector/InjectorHandler.ts
@@ -18,6 +18,8 @@ import LockerService from "@src/background/services/lock";
 import { validateMerkleProofSource } from "@src/background/services/validation";
 import ZkIdentityService from "@src/background/services/zkIdentity";
 
+import GroupService from "../group";
+
 export class InjectorHandler {
   private readonly lockerService: LockerService;
 
@@ -31,12 +33,15 @@ export class InjectorHandler {
 
   private readonly zkIdentityService: ZkIdentityService;
 
+  private readonly groupService: GroupService;
+
   constructor() {
     this.approvalService = ApprovalService.getInstance();
     this.browserService = BrowserUtils.getInstance();
     this.lockerService = LockerService.getInstance();
     this.requestManager = RequestManager.getInstance();
     this.zkIdentityService = ZkIdentityService.getInstance();
+    this.groupService = GroupService.getInstance();
     this.zkProofService = new ZkProofService();
   }
 
@@ -47,6 +52,8 @@ export class InjectorHandler {
   getZkProofService = (): ZkProofService => this.zkProofService;
 
   getLockService = (): LockerService => this.lockerService;
+  
+  getGroupService = (): GroupService => this.groupService;
 
   connectedIdentityMetadata = async (_: unknown, meta?: IZkMetadata): Promise<ConnectedIdentityMetadata> => {
     const connectedIdentityMetadata = await this.zkIdentityService.getConnectedIdentityData({}, meta);

--- a/packages/app/src/background/services/injector/InjectorHandler.ts
+++ b/packages/app/src/background/services/injector/InjectorHandler.ts
@@ -52,7 +52,7 @@ export class InjectorHandler {
   getZkProofService = (): ZkProofService => this.zkProofService;
 
   getLockService = (): LockerService => this.lockerService;
-  
+
   getGroupService = (): GroupService => this.groupService;
 
   connectedIdentityMetadata = async (_: unknown, meta?: IZkMetadata): Promise<ConnectedIdentityMetadata> => {

--- a/packages/app/src/background/services/injector/__tests__/injector.test.ts
+++ b/packages/app/src/background/services/injector/__tests__/injector.test.ts
@@ -130,8 +130,9 @@ jest.mock("@src/background/services/zkIdentity", (): unknown => ({
   getInstance: jest.fn(() => ({
     getConnectedIdentity: mockGetConnectedIdentity,
     getConnectedIdentityData: mockGetConnectedIdentityData,
-    connectIdentityRequest: mockConnectIdentityRequest,
+    connectRequest: mockConnectIdentityRequest,
     awaitUnlock: mockAwaitZkIdentityServiceUnlock,
+    connectIdentityRequest: jest.fn(),
   })),
 }));
 
@@ -607,10 +608,10 @@ describe("background/services/injector", () => {
       const service = InjectorService.getInstance();
 
       await expect(service.joinGroup(defaultArgs, { urlOrigin: "new-urlOrigin" })).rejects.toThrow(
-        "CryptKeeper: new-urlOrigin is not approved, please call 'connectIdentity()' request first.",
+        "CryptKeeper: new-urlOrigin is not approved, please call 'connect()' request first.",
       );
       await expect(service.joinGroup({ groupId: defaultArgs.groupId }, { urlOrigin: "new-urlOrigin" })).rejects.toThrow(
-        "CryptKeeper: new-urlOrigin is not approved, please call 'connectIdentity()' request first.",
+        "CryptKeeper: new-urlOrigin is not approved, please call 'connect()' request first.",
       );
     });
 
@@ -655,11 +656,11 @@ describe("background/services/injector", () => {
       const service = InjectorService.getInstance();
 
       await expect(service.generateGroupMerkleProof(defaultArgs, { urlOrigin: "new-urlOrigin" })).rejects.toThrow(
-        "CryptKeeper: new-urlOrigin is not approved, please call 'connectIdentity()' request first.",
+        "CryptKeeper: new-urlOrigin is not approved, please call 'connect()' request first.",
       );
       await expect(
         service.generateGroupMerkleProof({ groupId: defaultArgs.groupId }, { urlOrigin: "new-urlOrigin" }),
-      ).rejects.toThrow("CryptKeeper: new-urlOrigin is not approved, please call 'connectIdentity()' request first.");
+      ).rejects.toThrow("CryptKeeper: new-urlOrigin is not approved, please call 'connect()' request first.");
     });
 
     test("should reject connect request from the approve connection page properly", async () => {

--- a/packages/app/src/constants/rpcInternalActions.ts
+++ b/packages/app/src/constants/rpcInternalActions.ts
@@ -67,6 +67,8 @@ export enum RPCInternalAction {
   GENERATE_RLN_PROOF_OFFSCREEN = "rpc/proofs/generate-rln-proof-offscreen",
   RLN_PROOF_RESULT = "rpc/proofs/rln-proof-result",
   PUSH_EVENT = "rpc/browser/tabs/pushEvent",
+  JOIN_GROUP_REQUEST = "rpc/group/joinRequest",
+  GENERATE_GROUP_MERKLE_PROOF_REQUEST = "rpc/groups/generateGroupMerkleProofRequest",
   // DEV RPCS
   CLEAR_APPROVED_HOSTS = "rpc/hosts/clear",
   CLEAR_STORAGE = "rpc/browser/clear",

--- a/packages/providers/src/constants/rpcExternalAction.ts
+++ b/packages/providers/src/constants/rpcExternalAction.ts
@@ -1,12 +1,12 @@
 export enum RPCExternalAction {
   // EXTERNAL
-  INJECTOR_GENERATE_SEMAPHORE_PROOF = "rpc/injector/proofs/generate-semaphore-proof",
-  INJECTOR_GENERATE_RLN_PROOF = "rpc/injector/proofs/generate-rln-proof",
-  INJECTOR_CONNECT = "rpc/injector/approve-connect",
-  INJECTOR_GET_CONNECTED_IDENTITY_DATA = "rpc/injector/identity/getConnectedIdentityData",
+  GENERATE_SEMAPHORE_PROOF = "rpc/injector/proofs/generate-semaphore-proof",
+  GENERATE_RLN_PROOF = "rpc/injector/proofs/generate-rln-proof",
+  CONNECT = "rpc/injector/approve-connect",
+  GET_CONNECTED_IDENTITY_DATA = "rpc/injector/identity/getConnectedIdentityData",
+  JOIN_GROUP_REQUEST = "rpc/injector/group/joinRequest",
+  GENERATE_GROUP_MERKLE_PROOF_REQUEST = "rpc/injector/groups/generateGroupMerkleProofRequest",
   // TODO: the following 4 RPC calls will be refactored in another PR
-  JOIN_GROUP_REQUEST = "rpc/group/joinRequest",
-  GENERATE_GROUP_MERKLE_PROOF_REQUEST = "rpc/groups/generateGroupMerkleProofRequest",
   GENERATE_VERIFIABLE_PRESENTATION_REQUEST = "rpc/credentials/generateVerifiablePresentationRequest",
   ADD_VERIFIABLE_CREDENTIAL_REQUEST = "rpc/credentials/addVerifiableCredentialRequest",
   REVEAL_CONNECTED_IDENTITY_COMMITMENT_REQUEST = "rpc/identity/revealConnectedIdentityCommitmentRequest",

--- a/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
+++ b/packages/providers/src/sdk/CryptKeeperInjectedProvider.ts
@@ -36,17 +36,17 @@ export class CryptKeeperInjectedProvider extends Handler implements ICryptKeeper
     super(connectedOrigin);
   }
 
-  async connect(): Promise<void> {
-    await this.post({
-      method: RPCExternalAction.INJECTOR_CONNECT,
-      payload: { urlOrigin: this.connectedOrigin },
-    });
-  }
-
   async getConnectedIdentity(): Promise<ConnectedIdentityMetadata | undefined> {
     return this.post({
-      method: RPCExternalAction.INJECTOR_GET_CONNECTED_IDENTITY_DATA,
+      method: RPCExternalAction.GET_CONNECTED_IDENTITY_DATA,
     }) as Promise<ConnectedIdentityMetadata | undefined>;
+  }
+
+  async connect(): Promise<void> {
+    await this.post({
+      method: RPCExternalAction.CONNECT,
+      payload: { urlOrigin: this.connectedOrigin },
+    });
   }
 
   async generateSemaphoreProof({
@@ -55,7 +55,7 @@ export class CryptKeeperInjectedProvider extends Handler implements ICryptKeeper
     merkleProofSource,
   }: ISemaphoreProofRequiredArgs): Promise<ISemaphoreFullProof> {
     return this.post({
-      method: RPCExternalAction.INJECTOR_GENERATE_SEMAPHORE_PROOF,
+      method: RPCExternalAction.GENERATE_SEMAPHORE_PROOF,
       payload: {
         externalNullifier,
         signal,
@@ -73,7 +73,7 @@ export class CryptKeeperInjectedProvider extends Handler implements ICryptKeeper
     merkleProofSource,
   }: IRLNProofRequiredArgs): Promise<IRLNFullProof> {
     return this.post({
-      method: RPCExternalAction.INJECTOR_GENERATE_RLN_PROOF,
+      method: RPCExternalAction.GENERATE_RLN_PROOF,
       payload: {
         rlnIdentifier,
         message,


### PR DESCRIPTION
## Explanation

In this PR changes includes protecting the group Bandada APIs. 

## Related Issues

- Fixes #899 

## Screenshots

N/A

## Manual Testing Steps

- Please check Bandada function from the Demo.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
