### PR TITLE
fix: check connected identity on `connect()`

### DIFF
--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -117,7 +117,12 @@ export default class CryptKeeperController {
       this.lockService.onUnlocked,
     );
 
-    this.handler.add(RPCInternalAction.LOCK, this.lockService.logout);
+    this.handler.add(
+      RPCInternalAction.LOCK,
+      this.lockService.lock,
+      this.zkIdentityService.lock,
+      this.approvalService.lock,
+    );
 
     /**
      *  Return status of background process

--- a/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
+++ b/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
@@ -38,6 +38,7 @@ describe("background/services/approval", () => {
 
   afterEach(async () => {
     process.env.NODE_ENV = "test";
+    await approvalService.lock();
     await approvalService.clear();
 
     (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {

--- a/packages/app/src/background/services/approval/index.ts
+++ b/packages/app/src/background/services/approval/index.ts
@@ -53,6 +53,8 @@ export default class ApprovalService extends BaseService implements IBackupable 
     return true;
   };
 
+  lock = (): Promise<boolean> => this.onLock();
+
   getPermission = (urlOrigin: string): IHostPermission => ({
     urlOrigin,
     canSkipApprove: Boolean(this.allowedHosts.get(urlOrigin)?.canSkipApprove),

--- a/packages/app/src/background/services/base/Base.ts
+++ b/packages/app/src/background/services/base/Base.ts
@@ -29,4 +29,17 @@ export abstract class BaseService {
       };
     });
   };
+
+  abstract lock(): Promise<boolean>;
+
+  onLock = async (internalLock?: () => Promise<unknown>): Promise<boolean> => {
+    this.isUnlocked = false;
+    this.unlockCB = undefined;
+
+    if (internalLock) {
+      await internalLock();
+    }
+
+    return true;
+  };
 }

--- a/packages/app/src/background/services/injector/Injector.ts
+++ b/packages/app/src/background/services/injector/Injector.ts
@@ -65,7 +65,11 @@ export class InjectorService {
         });
       }
 
-      await this.injectorHandler.getZkIdentityService().connectIdentityRequest({ urlOrigin: urlOrigin! });
+      const connectedIdentity = await this.injectorHandler.getZkIdentityService().getConnectedIdentity();
+
+      if (!connectedIdentity || !isApproved) {
+        await this.injectorHandler.getZkIdentityService().connectIdentityRequest({ urlOrigin: urlOrigin! });
+      }
     } catch (error) {
       throw new Error(`CryptKeeper: error in the connect request, ${(error as Error).message}`);
     }

--- a/packages/app/src/background/services/injector/Injector.ts
+++ b/packages/app/src/background/services/injector/Injector.ts
@@ -67,7 +67,7 @@ export class InjectorService {
 
       const connectedIdentity = await this.injectorHandler.getZkIdentityService().getConnectedIdentity();
 
-      if (!connectedIdentity || !isApproved) {
+      if (connectedIdentity?.metadata.urlOrigin !== urlOrigin) {
         await this.injectorHandler.getZkIdentityService().connectIdentityRequest({ urlOrigin: urlOrigin! });
       }
     } catch (error) {

--- a/packages/app/src/background/services/injector/InjectorHandler.ts
+++ b/packages/app/src/background/services/injector/InjectorHandler.ts
@@ -114,9 +114,8 @@ export class InjectorHandler {
       if (isInitialized) {
         await this.approvalService.awaitUnlock();
         await this.zkIdentityService.awaitUnlock();
+        await this.browserService.closePopup();
       }
-
-      await this.browserService.closePopup();
     }
   };
 

--- a/packages/app/src/background/services/injector/InjectorHandler.ts
+++ b/packages/app/src/background/services/injector/InjectorHandler.ts
@@ -112,9 +112,11 @@ export class InjectorHandler {
       await this.lockerService.awaitUnlock();
 
       if (isInitialized) {
-        await this.zkIdentityService.awaitUnlock();
         await this.approvalService.awaitUnlock();
+        await this.zkIdentityService.awaitUnlock();
       }
+
+      await this.browserService.closePopup();
     }
   };
 

--- a/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
+++ b/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
@@ -71,7 +71,7 @@ describe("background/services/locker", () => {
   beforeEach(async () => {
     (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
 
-    await lockService.logout();
+    await lockService.lock();
 
     (browser.tabs.sendMessage as jest.Mock).mockClear();
     (pushMessage as jest.Mock).mockReset();

--- a/packages/app/src/background/services/lock/index.ts
+++ b/packages/app/src/background/services/lock/index.ts
@@ -218,17 +218,10 @@ export default class LockerService extends BaseService implements IBackupable {
     return payload;
   };
 
-  logout = async (): Promise<boolean> => {
-    await this.internalLogout();
+  lock = async (): Promise<boolean> => this.onLock(this.internalLock);
 
-    return true;
-  };
-
-  private internalLogout = async (): Promise<LockStatus> => {
-    this.isUnlocked = false;
+  private internalLock = async (): Promise<LockStatus> => {
     this.cryptoService.clear();
-    this.unlockCB = undefined;
-
     return this.notifyStatusChange();
   };
 

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -289,6 +289,8 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     return true;
   };
 
+  lock = (): Promise<boolean> => this.onLock();
+
   private clearConnectedIdentity = async (): Promise<void> => {
     if (!this.connectedIdentity) {
       return;

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -269,15 +269,18 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     }
 
     const identities = await this.getIdentitiesFromStore();
-    const identity = await this.readConnectedIdentity(identities);
-    const identityCommitment = identity ? bigintToHex(identity.genIdentityCommitment()) : undefined;
 
-    if (identityCommitment) {
-      await this.updateConnectedIdentity({
-        identities,
-        identityCommitment,
-        urlOrigin: identity?.metadata.urlOrigin,
-      });
+    if (identities.size !== 0) {
+      const identity = await this.readConnectedIdentity(identities);
+      const identityCommitment = identity ? bigintToHex(identity.genIdentityCommitment()) : undefined;
+
+      if (identityCommitment) {
+        await this.updateConnectedIdentity({
+          identities,
+          identityCommitment,
+          urlOrigin: identity?.metadata.urlOrigin,
+        });
+      }
     }
 
     this.isUnlocked = true;

--- a/packages/app/src/ui/ducks/app.ts
+++ b/packages/app/src/ui/ducks/app.ts
@@ -74,9 +74,11 @@ export const resetPassword =
   async (): Promise<void> =>
     postMessage({ method: RPCInternalAction.RESET_PASSWORD, payload: { password, mnemonic } });
 
-export const fetchStatus = (): TypedThunk<Promise<void>> => async (dispatch) => {
+export const fetchStatus = (): TypedThunk<Promise<IAppState>> => async (dispatch) => {
   const status = await postMessage<IAppState>({ method: RPCInternalAction.GET_STATUS });
   dispatch(setStatus(status));
+
+  return status;
 };
 
 export const setWalletConnection =

--- a/packages/app/src/ui/ducks/requests.ts
+++ b/packages/app/src/ui/ducks/requests.ts
@@ -31,9 +31,11 @@ const requestsSlice = createSlice({
 
 export const { setPendingRequests } = requestsSlice.actions;
 
-export const fetchPendingRequests = (): TypedThunk<Promise<void>> => async (dispatch) => {
+export const fetchPendingRequests = (): TypedThunk<Promise<IPendingRequest[]>> => async (dispatch) => {
   const pendingRequests = await postMessage<IPendingRequest[]>({ method: RPCInternalAction.GET_PENDING_REQUESTS });
   dispatch(setPendingRequests(pendingRequests));
+
+  return pendingRequests;
 };
 
 export const finalizeRequest =

--- a/packages/app/src/ui/pages/Login/__tests__/Login.test.tsx
+++ b/packages/app/src/ui/pages/Login/__tests__/Login.test.tsx
@@ -6,9 +6,9 @@ import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import { Suspense } from "react";
 import { MemoryRouter, useNavigate } from "react-router-dom";
 
-import { fetchStatus, unlock, useAppStatus } from "@src/ui/ducks/app";
+import { Paths } from "@src/constants";
+import { closePopup, unlock } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { fetchPendingRequests, usePendingRequests } from "@src/ui/ducks/requests";
 
 import Login from "..";
 
@@ -25,16 +25,9 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
 }));
 
-jest.mock("@src/ui/ducks/requests", (): unknown => ({
-  fetchPendingRequests: jest.fn(),
-  usePendingRequests: jest.fn(),
-}));
-
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   closePopup: jest.fn(),
-  fetchStatus: jest.fn(),
   unlock: jest.fn(),
-  useAppStatus: jest.fn(),
 }));
 
 describe("ui/pages/Login", () => {
@@ -45,10 +38,6 @@ describe("ui/pages/Login", () => {
     mockDispatch.mockResolvedValue(undefined);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
-
-    (useAppStatus as jest.Mock).mockReturnValue({ isUnlocked: false });
-
-    (usePendingRequests as jest.Mock).mockReturnValue([]);
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
 
@@ -144,10 +133,11 @@ describe("ui/pages/Login", () => {
     const button = await screen.findByTestId("unlock-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(mockDispatch).toBeCalledTimes(3);
+    expect(mockDispatch).toBeCalledTimes(2);
     expect(unlock).toBeCalledTimes(1);
     expect(unlock).toBeCalledWith("password");
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(fetchPendingRequests).toBeCalledTimes(1);
+    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });
 });

--- a/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
+++ b/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
@@ -6,9 +6,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
-import { useAppStatus } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { usePendingRequests } from "@src/ui/ducks/requests";
 
 import type { ChangeEvent, FormEvent } from "react";
 
@@ -22,16 +20,9 @@ jest.mock("@src/ui/ducks/hooks", (): unknown => ({
   useAppDispatch: jest.fn(),
 }));
 
-jest.mock("@src/ui/ducks/requests", (): unknown => ({
-  fetchPendingRequests: jest.fn(),
-  usePendingRequests: jest.fn(),
-}));
-
 jest.mock("@src/ui/ducks/app", (): unknown => ({
   closePopup: jest.fn(),
-  fetchStatus: jest.fn(),
   unlock: jest.fn(),
-  useAppStatus: jest.fn(),
 }));
 
 describe("ui/pages/Login/useLogin", () => {
@@ -43,10 +34,6 @@ describe("ui/pages/Login/useLogin", () => {
     mockDispatch.mockResolvedValue(undefined);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
-
-    (useAppStatus as jest.Mock).mockReturnValue({ isUnlocked: false });
-
-    (usePendingRequests as jest.Mock).mockReturnValue([]);
 
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
   });
@@ -64,7 +51,7 @@ describe("ui/pages/Login/useLogin", () => {
   });
 
   test("should submit form properly", async () => {
-    const { result, rerender } = renderHook(() => useLogin());
+    const { result } = renderHook(() => useLogin());
 
     await act(() =>
       result.current.register("password").onChange({ target: { value: "password" } } as ChangeEvent<HTMLInputElement>),
@@ -73,12 +60,8 @@ describe("ui/pages/Login/useLogin", () => {
     await act(() => result.current.onSubmit({ preventDefault: jest.fn() } as unknown as FormEvent<HTMLFormElement>));
     await waitFor(() => !result.current.isLoading);
 
-    (useAppStatus as jest.Mock).mockReturnValue({ isUnlocked: true });
-
-    rerender();
-
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(3);
+    expect(mockDispatch).toBeCalledTimes(2);
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });

--- a/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
+++ b/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
@@ -78,7 +78,7 @@ describe("ui/pages/Login/useLogin", () => {
     rerender();
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(4);
+    expect(mockDispatch).toBeCalledTimes(3);
     expect(mockNavigate).toBeCalledTimes(1);
     expect(mockNavigate).toBeCalledWith(Paths.HOME);
   });

--- a/packages/app/src/ui/pages/Login/useLogin.ts
+++ b/packages/app/src/ui/pages/Login/useLogin.ts
@@ -4,9 +4,8 @@ import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { PasswordFormFields } from "@src/types";
-import { closePopup, fetchStatus, unlock } from "@src/ui/ducks/app";
+import { closePopup, unlock } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
-import { fetchPendingRequests } from "@src/ui/ducks/requests";
 
 export interface IUseLoginData {
   isLoading: boolean;
@@ -37,19 +36,16 @@ export const useLogin = (): IUseLoginData => {
 
   const onSubmit = useCallback(
     async (data: LoginFields) => {
-      try {
-        await dispatch(unlock(data.password));
-        const requests = await dispatch(fetchPendingRequests());
-        await dispatch(fetchStatus());
-
-        if (requests.length === 0) {
+      await dispatch(unlock(data.password))
+        .then(() => {
+          navigate(Paths.HOME);
+        })
+        .then(() => {
           dispatch(closePopup());
-        }
-
-        navigate(Paths.HOME);
-      } catch (error) {
-        setError("password", { message: (error as Error).message });
-      }
+        })
+        .catch((error: Error) => {
+          setError("password", { message: error.message });
+        });
     },
     [dispatch, setError],
   );

--- a/packages/app/src/ui/pages/Login/useLogin.ts
+++ b/packages/app/src/ui/pages/Login/useLogin.ts
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { PasswordFormFields } from "@src/types";
-import { closePopup, fetchStatus, unlock, useAppStatus } from "@src/ui/ducks/app";
+import { fetchStatus, unlock, useAppStatus } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { fetchPendingRequests, usePendingRequests } from "@src/ui/ducks/requests";
 
@@ -43,9 +43,13 @@ export const useLogin = (): IUseLoginData => {
       return;
     }
 
-    if (!isKeepOpen) {
-      dispatch(closePopup());
-    }
+    // TODO: I am not sure yet why is that is the cause for that bug:
+    // (https://github.com/CryptKeeperZK/crypt-keeper-extension/issues/992)
+    // When commented the bug was resolved.
+    // I think because at that scenario described in the bug issue, the pendingRequests would be already zero.
+    // if (!isKeepOpen) {
+    //   dispatch(closePopup());
+    // }
 
     navigate(Paths.HOME);
   }, [isKeepOpen, status.isUnlocked, dispatch]);

--- a/packages/demo/index.tsx
+++ b/packages/demo/index.tsx
@@ -99,6 +99,14 @@ const App = () => {
       <hr />
 
       <div>
+        <h2>Connect identity</h2>
+
+        <button type="button" onClick={connect}>
+          Connect identity
+        </button>
+      </div>
+
+      <div>
         <h2>Get Connected Identity Metadata</h2>
 
         <button type="button" onClick={getConnectedIdentityMetadata}>


### PR DESCRIPTION
## Explanation

This PR changes checks if there is a connected identity before sending a new request to connect identity page.

## Related Issues

* Blocked by #966 
* Fixes #965 
* Fixes #992 

## Screenshots

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
