### PR TITLE
feat: import identity

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,10 +1,9 @@
 {
   "tasksRunnerOptions": {
     "default": {
-      "runner": "nx-cloud",
+      "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [],
-        "accessToken": ""
+        "cacheableOperations": []
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "husky": "^8.0.3",
     "is-ci": "^3.0.1",
     "nx": "16.10.0",
-    "nx-cloud": "latest",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.0",
     "process": "^0.11.10",

--- a/packages/app/src/background/services/base/Base.ts
+++ b/packages/app/src/background/services/base/Base.ts
@@ -9,11 +9,6 @@ export abstract class BaseService {
 
   abstract unlock(password?: string, notify?: boolean): Promise<boolean>;
 
-  lock(): void {
-    this.isUnlocked = false;
-    this.unlockCB = undefined;
-  }
-
   onUnlocked = (): boolean => {
     if (this.unlockCB) {
       this.unlockCB();

--- a/packages/app/src/background/services/base/Base.ts
+++ b/packages/app/src/background/services/base/Base.ts
@@ -9,6 +9,11 @@ export abstract class BaseService {
 
   abstract unlock(password?: string, notify?: boolean): Promise<boolean>;
 
+  lock(): void {
+    this.isUnlocked = false;
+    this.unlockCB = undefined;
+  }
+
   onUnlocked = (): boolean => {
     if (this.unlockCB) {
       this.unlockCB();

--- a/packages/app/src/background/services/injector/InjectorHandler.ts
+++ b/packages/app/src/background/services/injector/InjectorHandler.ts
@@ -51,8 +51,6 @@ export class InjectorHandler {
 
   getZkProofService = (): ZkProofService => this.zkProofService;
 
-  getLockService = (): LockerService => this.lockerService;
-
   getGroupService = (): GroupService => this.groupService;
 
   connectedIdentityMetadata = async (_: unknown, meta?: IZkMetadata): Promise<ConnectedIdentityMetadata> => {

--- a/packages/app/src/background/services/injector/__tests__/injector.test.ts
+++ b/packages/app/src/background/services/injector/__tests__/injector.test.ts
@@ -61,7 +61,7 @@ const mockIsApproved = jest.fn(
     urlOrigin === "reject-joinGroup",
 );
 const mockCanSkip = jest.fn((urlOrigin) => urlOrigin === mockDefaultUrlOrigin);
-const mockGetStatus = jest.fn(() => Promise.resolve({ isUnlocked: false }));
+const mockGetStatus = jest.fn(() => Promise.resolve({ isUnlocked: false, isInitialized: false }));
 const mockAwaitLockServiceUnlock = jest.fn();
 const mockAwaitZkIdentityServiceUnlock = jest.fn();
 const mockAwaitApprovalServiceUnlock = jest.fn();
@@ -161,7 +161,7 @@ describe("background/services/injector", () => {
 
   describe("get connected identity metadata", () => {
     test("should return connected metadata properly if all checks are passed", async () => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true, isInitialized: true });
       const service = InjectorService.getInstance();
 
       const result = await service.getConnectedIdentityMetadata({}, { urlOrigin: mockDefaultUrlOrigin });
@@ -173,7 +173,7 @@ describe("background/services/injector", () => {
     });
 
     test("should throw error if there is no urlOrigin", async () => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true, isInitialized: true });
 
       const service = InjectorService.getInstance();
 
@@ -183,7 +183,7 @@ describe("background/services/injector", () => {
     });
 
     test("should send undefined if urlOrigin isn't approved", async () => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: false });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: false, isInitialized: true });
 
       const service = InjectorService.getInstance();
 
@@ -193,7 +193,7 @@ describe("background/services/injector", () => {
     });
 
     test("should throw error if no connected identity found", async () => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true, isInitialized: true });
 
       const service = InjectorService.getInstance();
 
@@ -246,7 +246,7 @@ describe("background/services/injector", () => {
 
   describe("generate Semaphore proof", () => {
     beforeEach(() => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true, isInitialized: true });
       (browser.runtime.getURL as jest.Mock).mockImplementation((path: string) => path);
     });
 
@@ -417,7 +417,7 @@ describe("background/services/injector", () => {
 
   describe("generate RLN Proof", () => {
     beforeEach(() => {
-      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true });
+      mockGetStatus.mockResolvedValueOnce({ isUnlocked: true, isInitialized: true });
       (browser.runtime.getURL as jest.Mock).mockImplementation((path: string) => path);
     });
 

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -153,7 +153,6 @@ describe("background/services/zkIdentity", () => {
         instance.get.mockReturnValue(undefined);
       });
 
-      zkIdentityService.lock();
       const result = await zkIdentityService.unlock();
 
       expect(result).toBe(true);

--- a/packages/app/src/config/mock/zk.ts
+++ b/packages/app/src/config/mock/zk.ts
@@ -43,6 +43,7 @@ export const mockDefaultIdentity: IIdentityData & { secret?: string } = {
     isDeterministic: true,
     nonce: 0,
     urlOrigin: "http://localhost:3000",
+    isImported: true,
   },
 };
 

--- a/packages/app/src/types/history/index.ts
+++ b/packages/app/src/types/history/index.ts
@@ -2,6 +2,7 @@ import type { IGroupData, IIdentityData } from "@cryptkeeperzk/types";
 
 export enum OperationType {
   CREATE_IDENTITY = "CREATE_IDENTITY",
+  IMPORT_IDENTITY = "IMPORT_IDENTITY",
   DELETE_IDENTITY = "DELETE_IDENTITY",
   DELETE_ALL_IDENTITIES = "DELETE_ALL_IDENTITIES",
   DOWNLOAD_BACKUP = "DOWNLOAD_BACKUP",

--- a/packages/app/src/ui/components/IdentityList/Item/index.tsx
+++ b/packages/app/src/ui/components/IdentityList/Item/index.tsx
@@ -159,6 +159,12 @@ export const IdentityItem = ({
             Address: {ellipsify(metadata.account)}
           </Typography>
         )}
+
+        {metadata.isImported && (
+          <Typography color="text.secondary" variant="body2">
+            Imported
+          </Typography>
+        )}
       </Box>
 
       {isShowMenu && (

--- a/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -42,15 +42,16 @@ describe("ui/components/IdentityList", () => {
         groups: [],
         urlOrigin: "http://localhost:3000",
         isDeterministic: true,
+        isImported: false,
       },
     },
     {
       commitment: "1",
       metadata: {
-        account: ZERO_ADDRESS,
         name: "Account #1",
         groups: [],
         isDeterministic: true,
+        isImported: true,
       },
     },
   ];

--- a/packages/app/src/ui/ducks/__tests__/identities.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/identities.test.tsx
@@ -53,6 +53,7 @@ describe("ui/ducks/identities", () => {
         groups: [],
         urlOrigin: "http://localhost:3000",
         isDeterministic: true,
+        isImported: false,
       },
     },
     {
@@ -62,6 +63,7 @@ describe("ui/ducks/identities", () => {
         name: "Account #2",
         groups: [],
         isDeterministic: true,
+        isImported: false,
       },
     },
   ];

--- a/packages/app/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
+++ b/packages/app/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
@@ -32,6 +32,7 @@ describe("ui/pages/ConnectIdentity", () => {
           groups: [],
           urlOrigin: "http://localhost:3000",
           isDeterministic: true,
+          isImported: false,
         },
       },
       {
@@ -41,6 +42,7 @@ describe("ui/pages/ConnectIdentity", () => {
           name: "Account #2",
           groups: [],
           isDeterministic: true,
+          isImported: false,
         },
       },
     ],

--- a/packages/app/src/ui/pages/Home/__tests__/useHome.test.ts
+++ b/packages/app/src/ui/pages/Home/__tests__/useHome.test.ts
@@ -55,6 +55,7 @@ describe("ui/pages/Home/useHome", () => {
         groups: [],
         urlOrigin: "http://localhost:3000",
         isDeterministic: true,
+        isImported: false,
       },
     },
     {
@@ -65,6 +66,7 @@ describe("ui/pages/Home/useHome", () => {
         groups: [],
         urlOrigin: "http://localhost:3000",
         isDeterministic: true,
+        isImported: false,
       },
     },
   ];

--- a/packages/app/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/Item/ActivityListItem.tsx
@@ -19,6 +19,7 @@ export interface IActivityItemProps {
 
 const OPERATIONS: Record<OperationType, string> = {
   [OperationType.CREATE_IDENTITY]: "Identity created",
+  [OperationType.IMPORT_IDENTITY]: "Identity imported",
   [OperationType.DELETE_IDENTITY]: "Identity removed",
   [OperationType.DELETE_ALL_IDENTITIES]: "All identities removed",
   [OperationType.DOWNLOAD_BACKUP]: "Backup download",

--- a/packages/app/src/ui/pages/Identity/Identity.tsx
+++ b/packages/app/src/ui/pages/Identity/Identity.tsx
@@ -124,14 +124,23 @@ const Identity = (): JSX.Element | null => {
 
             {renderRow("Name", !isUpdating ? metadata.name : renderRenameForm())}
 
-            {renderRow(
-              "Owner account",
-              <Tooltip title={metadata.account}>
+            {metadata.account &&
+              renderRow(
+                "Owner account",
+                <Tooltip title={metadata.account}>
+                  <Typography component="span" variant="h6">
+                    {ellipsify(metadata.account)}
+                  </Typography>
+                </Tooltip>,
+              )}
+
+            {metadata.isImported &&
+              renderRow(
+                "Imported",
                 <Typography component="span" variant="h6">
-                  {ellipsify(metadata.account)}
-                </Typography>
-              </Tooltip>,
-            )}
+                  Yes
+                </Typography>,
+              )}
 
             {metadata.isDeterministic &&
               !isNil(metadata.nonce) &&

--- a/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
+++ b/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
@@ -166,7 +166,7 @@ describe("ui/pages/Identity", () => {
       isConfirmModalOpen: true,
     });
 
-    const { container, findByText } = render(
+    const { container, findByTestId } = render(
       <Suspense>
         <Identity />
       </Suspense>,
@@ -174,11 +174,11 @@ describe("ui/pages/Identity", () => {
 
     await waitFor(() => container.firstChild !== null);
 
-    const noButton = await findByText("No");
+    const noButton = await findByTestId("danger-modal-reject");
     await act(() => Promise.resolve(noButton.click()));
     expect(defaultHookData.onConfirmDeleteIdentity).toBeCalledTimes(1);
 
-    const yesButton = await findByText("Yes");
+    const yesButton = await findByTestId("danger-modal-accept");
     await act(() => Promise.resolve(yesButton.click()));
     expect(defaultHookData.onDeleteIdentity).toBeCalledTimes(1);
   });

--- a/packages/app/src/ui/pages/RevealIdentityCommitment/RevealIdentityCommitment.tsx
+++ b/packages/app/src/ui/pages/RevealIdentityCommitment/RevealIdentityCommitment.tsx
@@ -99,14 +99,23 @@ const RevealIdentityCommitment = (): JSX.Element => {
 
                 {renderRow("Name", connectedIdentity.metadata.name)}
 
-                {renderRow(
-                  "Owner account",
-                  <Tooltip title={connectedIdentity.metadata.account}>
+                {connectedIdentity.metadata.account &&
+                  renderRow(
+                    "Owner account",
+                    <Tooltip title={connectedIdentity.metadata.account}>
+                      <Typography component="span" variant="h6">
+                        {ellipsify(connectedIdentity.metadata.account)}
+                      </Typography>
+                    </Tooltip>,
+                  )}
+
+                {connectedIdentity.metadata.isImported &&
+                  renderRow(
+                    "Imported",
                     <Typography component="span" variant="h6">
-                      {ellipsify(connectedIdentity.metadata.account)}
-                    </Typography>
-                  </Tooltip>,
-                )}
+                      Yes
+                    </Typography>,
+                  )}
               </Box>
 
               <Box component="hr" sx={{ my: 2 }} />

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -22,16 +22,24 @@ export interface INewIdentityRequest {
   messageSignature?: string;
 }
 
+export interface IImportIdentityArgs {
+  name: string;
+  trapdoor: string;
+  nullifier: string;
+  urlOrigin?: string;
+}
+
 export enum EWallet {
   ETH_WALLET,
   CRYPTKEEPER_WALLET,
 }
 
 export interface IIdentityMetadata {
-  account: string;
   name: string;
   groups: IGroupData[];
   isDeterministic: boolean;
+  isImported: boolean;
+  account?: string;
   nonce?: number;
   urlOrigin?: string;
 }
@@ -74,10 +82,12 @@ export interface ISerializedIdentity {
 
 export interface ICreateIdentityArgs {
   name: string;
-  account: string;
   groups: IGroupData[];
   isDeterministic: boolean;
+  account?: string;
   messageSignature?: string;
   nonce?: number;
   urlOrigin?: string;
+  trapdoor?: string;
+  nullifier?: string;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,6 +21,7 @@ export type {
   IConnectIdentityArgs,
   ISerializedIdentity,
   ConnectedIdentityMetadata,
+  IImportIdentityArgs,
 } from "./identity";
 export { EWallet } from "./identity";
 export type {

--- a/packages/zk/src/identity/factory/__tests__/factory.test.ts
+++ b/packages/zk/src/identity/factory/__tests__/factory.test.ts
@@ -12,10 +12,29 @@ describe("identity/factory", () => {
       urlOrigin: "http://localhost:3000",
       isDeterministic: true,
       nonce: 0,
+      isImported: false,
     };
 
     const identity = createNewIdentity(defaultArgs);
 
     expect(identity.metadata).toStrictEqual(omit(defaultArgs, ["messageSignature"]));
+  });
+
+  test("should create imported identity properly ", () => {
+    const defaultArgs = {
+      account: undefined,
+      nonce: undefined,
+      name: "name",
+      groups: [],
+      urlOrigin: "http://localhost:3000",
+      nullifier: "12578821460373135693013277026392552769801800051254682675996381598033497431909",
+      trapdoor: "8599172605644748803815316525430713607475871751016594621440814664229873275229",
+      isDeterministic: false,
+      isImported: true,
+    };
+
+    const identity = createNewIdentity(defaultArgs);
+
+    expect(identity.metadata).toStrictEqual(omit(defaultArgs, ["trapdoor", "nullifier"]));
   });
 });

--- a/packages/zk/src/identity/factory/index.ts
+++ b/packages/zk/src/identity/factory/index.ts
@@ -4,9 +4,10 @@ import { ICreateIdentityArgs } from "@cryptkeeperzk/types";
 import { ZkIdentitySemaphore } from "../protocols";
 
 export function createNewIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphore {
-  const { name, messageSignature, account, groups, urlOrigin, isDeterministic, nonce } = config;
+  const { name, messageSignature, account, groups, urlOrigin, isDeterministic, nonce, trapdoor, nullifier } = config;
+  const serialized = trapdoor && nullifier ? JSON.stringify([trapdoor, nullifier]) : undefined;
 
-  const identity = new Identity(messageSignature);
+  const identity = new Identity(serialized || messageSignature);
 
   return new ZkIdentitySemaphore(identity, {
     account,
@@ -15,5 +16,6 @@ export function createNewIdentity(config: ICreateIdentityArgs): ZkIdentitySemaph
     nonce,
     urlOrigin,
     isDeterministic,
+    isImported: Boolean(serialized),
   });
 }

--- a/packages/zk/src/identity/protocols/__tests__/zkIdentitySemaphore.test.ts
+++ b/packages/zk/src/identity/protocols/__tests__/zkIdentitySemaphore.test.ts
@@ -13,6 +13,7 @@ describe("protocols/ZkIdentitySemaphore", () => {
     groups: [],
     urlOrigin: "http://localhost:3000",
     isDeterministic: true,
+    isImported: false,
   };
 
   test("should decorate identity properly", () => {

--- a/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
+++ b/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
@@ -45,6 +45,7 @@ describe("background/services/protocols", () => {
     groups: [],
     urlOrigin: "http://localhost:3000",
     isDeterministic: true,
+    isImported: false,
   };
 
   const defaultMerkleProof: MerkleProof = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       nx:
         specifier: 16.10.0
         version: 16.10.0(@swc/core@1.3.82)
-      nx-cloud:
-        specifier: latest
-        version: 16.4.0
       os-browserify:
         specifier: ^0.3.0
         version: 0.3.0
@@ -848,7 +845,7 @@ packages:
       '@babel/traverse': 7.22.10
       '@babel/types': 7.22.10
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -939,7 +936,7 @@ packages:
       '@babel/core': 7.22.10
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.2
     transitivePeerDependencies:
@@ -2091,7 +2088,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.10
       '@babel/types': 7.22.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3798,14 +3795,6 @@ packages:
       - supports-color
       - typescript
       - verdaccio
-    dev: true
-
-  /@nrwl/nx-cloud@16.4.0:
-    resolution: {integrity: sha512-QitrYK6z9ceagetBlgLMZnC0T85k2JTk+oK0MxZ5p/woclqeYN7SiGNZgMzDq8TjJwt8Fm/MDnsSo3xtufmLBg==}
-    dependencies:
-      nx-cloud: 16.4.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /@nrwl/tao@16.10.0(@swc/core@1.3.82):
@@ -6538,16 +6527,6 @@ packages:
       - debug
     dev: true
 
-  /axios@1.1.3:
-    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
-    dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
   /axios@1.2.2(debug@4.3.4):
     resolution: {integrity: sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==}
     dependencies:
@@ -6571,7 +6550,7 @@ packages:
   /axios@1.5.0:
     resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -7443,11 +7422,6 @@ packages:
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  /chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-    dev: true
 
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
@@ -8498,6 +8472,17 @@ packages:
       ms: 2.1.3
       supports-color: 8.1.1
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -8789,7 +8774,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8976,11 +8961,6 @@ packages:
     dependencies:
       dotenv-defaults: 2.0.2
       webpack: 5.88.2(@swc/core@1.3.82)(webpack-cli@5.1.4)
-    dev: true
-
-  /dotenv@10.0.0:
-    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
-    engines: {node: '>=10'}
     dev: true
 
   /dotenv@16.3.1:
@@ -10288,6 +10268,15 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -10298,6 +10287,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -10397,13 +10387,6 @@ packages:
     dependencies:
       minipass: 2.9.0
     dev: false
-
-  /fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
 
   /fs-monkey@1.0.4:
     resolution: {integrity: sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==}
@@ -11944,7 +11927,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -13389,26 +13372,11 @@ packages:
       yallist: 3.1.1
     dev: false
 
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
   /minizlib@1.3.3:
     resolution: {integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==}
     dependencies:
       minipass: 2.9.0
     dev: false
-
-  /minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    dev: true
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -13428,12 +13396,6 @@ packages:
     dependencies:
       minimist: 1.2.8
     dev: false
-
-  /mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
 
   /mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -13770,24 +13732,6 @@ packages:
 
   /nwsapi@2.2.5:
     resolution: {integrity: sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==}
-    dev: true
-
-  /nx-cloud@16.4.0:
-    resolution: {integrity: sha512-jbq4hWvDwRlJVpxgMgbmNSkue+6XZSn53R6Vo6qmCAWODJ9KY1BZdZ/9VRL8IX/BRKebVFiXp3SapFB1qPhH8A==}
-    hasBin: true
-    dependencies:
-      '@nrwl/nx-cloud': 16.4.0
-      axios: 1.1.3
-      chalk: 4.1.2
-      dotenv: 10.0.0
-      fs-extra: 11.1.1
-      node-machine-id: 1.1.12
-      open: 8.4.2
-      strip-json-comments: 3.1.1
-      tar: 6.1.11
-      yargs-parser: 21.1.1
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /nx@16.10.0(@swc/core@1.3.82):
@@ -16442,18 +16386,6 @@ packages:
       safe-buffer: 5.2.1
       yallist: 3.1.1
     dev: false
-
-  /tar@6.1.11:
-    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
-    engines: {node: '>= 10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 3.3.6
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: true
 
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}


### PR DESCRIPTION
## Explanation

This PR adds support for adding new identities from background script side.

Details are below:
- [x] Add method for import and save identity
- [x] Update identity list to support imported identities
- [x] Update history and notification for imported identities

## Related Issues

Blocked by #975 
Related to #906 

## Screenshots

N/A

## Manual Testing Steps

N/A

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

> PR template source from [github.com/MetaMask](https://github.com/MetaMask)
