### PR TITLE
fix: unlock approval and identity services

### DIFF
--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -112,9 +112,11 @@ export default class CryptKeeperController {
     this.handler.add(
       RPCInternalAction.UNLOCK,
       this.lockService.unlock,
-      this.zkIdentityService.unlock,
       this.approvalService.unlock,
+      this.zkIdentityService.unlock,
       this.lockService.onUnlocked,
+      this.approvalService.onUnlocked,
+      this.zkIdentityService.onUnlocked,
     );
 
     this.handler.add(

--- a/packages/app/src/background/services/base/Base.ts
+++ b/packages/app/src/background/services/base/Base.ts
@@ -9,11 +9,11 @@ export abstract class BaseService {
 
   abstract unlock(password?: string, notify?: boolean): Promise<boolean>;
 
+  abstract lock(): Promise<boolean>;
+
   onUnlocked = (): boolean => {
-    if (this.unlockCB) {
-      this.unlockCB();
-      this.unlockCB = undefined;
-    }
+    this.unlockCB?.();
+    this.unlockCB = undefined;
 
     return true;
   };
@@ -30,15 +30,11 @@ export abstract class BaseService {
     });
   };
 
-  abstract lock(): Promise<boolean>;
-
   onLock = async (internalLock?: () => Promise<unknown>): Promise<boolean> => {
     this.isUnlocked = false;
     this.unlockCB = undefined;
 
-    if (internalLock) {
-      await internalLock();
-    }
+    await internalLock?.();
 
     return true;
   };

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -155,9 +155,10 @@ describe("background/services/zkIdentity", () => {
 
     test("should unlock properly with empty store", async () => {
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        instance.get.mockReturnValue(undefined);
+        instance.get.mockResolvedValueOnce(mockSerializedDefaultIdentities).mockResolvedValue(undefined);
       });
 
+      await zkIdentityService.lock();
       const result = await zkIdentityService.unlock();
 
       expect(result).toBe(true);

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -415,7 +415,7 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     await this.browserController.pushEvent(
       {
         type: newIdentity.metadata.isImported ? EventName.IMPORT_IDENTITY : EventName.CREATE_IDENTITY,
-        payload: this.getConnectedIdentityMetadata(),
+        payload: this.getConnectedIdentityMetadata(newIdentity.metadata),
       },
       { urlOrigin: newIdentity.metadata.urlOrigin! },
     );


### PR DESCRIPTION
## Explanation

This PR unlocks approval and identity services when user login

## Related Issues

Related to #963

## Screenshots

N/A

## Manual Testing Steps

Check login/logout for different cases: onboarding, login (with approval, with connect, with only one or without any).

## Pre-Merge Checklist

### Assignees Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### Reviewers Checklist
- [ ] Manual testing checked and passed.
