### PR TITLE
feat: derive import identities from seed phrase 

### DIFF
--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { EventName } from "@cryptkeeperzk/providers";
-import { EWallet, ConnectedIdentityMetadata, ICreateIdentityOptions, IImportIdentityArgs } from "@cryptkeeperzk/types";
+import {
+  EWallet,
+  type ConnectedIdentityMetadata,
+  type ICreateIdentityOptions,
+  type IImportIdentityArgs,
+} from "@cryptkeeperzk/types";
 import { createNewIdentity } from "@cryptkeeperzk/zk";
 import pick from "lodash/pick";
 import browser from "webextension-polyfill";
@@ -643,6 +648,7 @@ describe("background/services/zkIdentity", () => {
       name: "Name",
       nullifier: mockDefaultNullifier,
       trapdoor: mockDefaultTrapdoor,
+      messageSignature: "signature",
       urlOrigin: "http://localhost:3000",
     };
 

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -343,7 +343,8 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
   };
 
   import = async (args: IImportIdentityArgs): Promise<string> => {
-    const identity = createNewIdentity({ ...args, groups: [], isDeterministic: false });
+    const identity = createNewIdentity({ ...args, groups: [], isDeterministic: false, isImported: true });
+
     const status = await this.insertIdentity(identity);
 
     if (!status) {
@@ -369,6 +370,7 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
       urlOrigin,
       isDeterministic,
       nonce: isDeterministic ? options.nonce : undefined,
+      isImported: false,
       name: options.name || `Account # ${numOfIdentities}`,
       messageSignature,
     };

--- a/packages/app/src/config/mock/wallet.ts
+++ b/packages/app/src/config/mock/wallet.ts
@@ -1,8 +1,9 @@
 import BigNumber from "bignumber.js";
 
 import { mockConnector } from "@src/connectors/mock";
-import { ConnectorNames, IUseWalletData } from "@src/types";
+import { ConnectorNames, type IUseWalletData } from "@src/types";
 
+import type { IUseSignatureOptionsData } from "@src/ui/hooks/wallet/useSignatureOptions";
 import type { BrowserProvider } from "ethers";
 
 import { ZERO_ADDRESS } from "../const";
@@ -28,4 +29,15 @@ export const defaultWalletHookData: IUseWalletData = {
   onConnectEagerly: jest.fn(() => Promise.resolve()),
   onDisconnect: jest.fn(),
   onLock: jest.fn(),
+};
+
+export const mockSignatureOptions: IUseSignatureOptionsData = {
+  options: [
+    { id: "ck", title: "Sign with CryptKeeper", checkDisabledItem: () => false },
+    {
+      id: "eth",
+      title: "Sign with MetaMask",
+      checkDisabledItem: () => false,
+    },
+  ],
 };

--- a/packages/app/src/ui/components/DropdownButton/DropdownButton.tsx
+++ b/packages/app/src/ui/components/DropdownButton/DropdownButton.tsx
@@ -1,6 +1,6 @@
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
+import ButtonGroup, { type ButtonGroupProps } from "@mui/material/ButtonGroup";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grow from "@mui/material/Grow";
 import MenuItem from "@mui/material/MenuItem";
@@ -11,27 +11,34 @@ import Typography from "@mui/material/Typography";
 
 import { useDropdownButton } from "./useDropdownButton";
 
-export interface IDropdownButtonProps {
-  menuOptions: IDropdownButtonMenuItem[];
+export interface IDropdownButtonProps extends Omit<ButtonGroupProps, "onClick"> {
+  options: IDropdownButtonOption[];
+  disabled?: boolean;
   onClick: (index: number) => void;
 }
 
-export interface IDropdownButtonMenuItem {
+export interface IDropdownButtonOption {
   id: string;
   title: string;
   checkDisabledItem?: (index: number) => boolean;
 }
 
-const DropdownButton = ({ menuOptions, onClick }: IDropdownButtonProps): JSX.Element => {
+const DropdownButton = ({ disabled = false, options, onClick, ...rest }: IDropdownButtonProps): JSX.Element => {
   const { isMenuOpen, menuRef, selectedIndex, onToggleMenu, onMenuItemClick, onSubmit } = useDropdownButton({
     onClick,
   });
 
   return (
     <>
-      <ButtonGroup ref={menuRef} sx={{ ml: 1, width: "70%" }} variant="contained">
-        <Button data-testid="dropdown-button" size="small" sx={{ textTransform: "none", flex: 1 }} onClick={onSubmit}>
-          {menuOptions[selectedIndex].title}
+      <ButtonGroup ref={menuRef} variant="contained" {...rest} sx={{ ml: 1, width: "70%", ...rest.sx }}>
+        <Button
+          data-testid="dropdown-button"
+          disabled={disabled}
+          size="small"
+          sx={{ textTransform: "none", flex: 1 }}
+          onClick={onSubmit}
+        >
+          {options[selectedIndex].title}
         </Button>
 
         <Button data-testid="dropdown-menu-button" size="small" sx={{ width: 5 }} onClick={onToggleMenu}>
@@ -64,7 +71,7 @@ const DropdownButton = ({ menuOptions, onClick }: IDropdownButtonProps): JSX.Ele
             >
               <ClickAwayListener onClickAway={onToggleMenu}>
                 <MenuList autoFocusItem id="split-button-menu">
-                  {menuOptions.map((option, index) => (
+                  {options.map((option, index) => (
                     <MenuItem
                       key={option.id}
                       data-testid={`dropdown-menu-item-${index}`}

--- a/packages/app/src/ui/components/DropdownButton/__tests__/DropdownButton.test.tsx
+++ b/packages/app/src/ui/components/DropdownButton/__tests__/DropdownButton.test.tsx
@@ -8,7 +8,7 @@ import { DropdownButton, IDropdownButtonProps } from "..";
 
 describe("ui/components/DropdownButton", () => {
   const defaultProps: IDropdownButtonProps = {
-    menuOptions: [
+    options: [
       {
         id: "metamask",
         title: "Connect to MetaMask",
@@ -60,7 +60,7 @@ describe("ui/components/DropdownButton", () => {
     const menuItem = await findByTestId("dropdown-menu-item-1");
     act(() => fireEvent.click(menuItem));
 
-    const selectedItem = await findByText(defaultProps.menuOptions[1].title);
+    const selectedItem = await findByText(defaultProps.options[1].title);
     expect(selectedItem).toBeInTheDocument();
   });
 });

--- a/packages/app/src/ui/components/DropdownButton/index.ts
+++ b/packages/app/src/ui/components/DropdownButton/index.ts
@@ -1,2 +1,2 @@
-export type { IDropdownButtonMenuItem, IDropdownButtonProps } from "./DropdownButton";
+export type { IDropdownButtonOption, IDropdownButtonProps } from "./DropdownButton";
 export { default as DropdownButton } from "./DropdownButton";

--- a/packages/app/src/ui/ducks/__tests__/identities.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/identities.test.tsx
@@ -245,6 +245,7 @@ describe("ui/ducks/identities", () => {
       nullifier: "nullifier",
       trapdoor: "trapdoor",
       urlOrigin: "http://localhost:3000",
+      messageSignature: "signature",
     };
 
     await Promise.resolve(store.dispatch(importIdentity(args)));

--- a/packages/app/src/ui/hooks/wallet/__tests__/useSignatureOptions.test.ts
+++ b/packages/app/src/ui/hooks/wallet/__tests__/useSignatureOptions.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+
+import { defaultWalletHookData } from "@src/config/mock/wallet";
+
+import { useSignatureOptions } from "..";
+import { useEthWallet } from "../useEthWallet";
+
+jest.mock("../useEthWallet", (): unknown => ({
+  useEthWallet: jest.fn(),
+}));
+
+describe("ui/hooks/useSignatureOptions", () => {
+  const defaultHookArgs = {
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return cryptkeeper and eth wallet options", () => {
+    const { result } = renderHook(() => useSignatureOptions(defaultHookArgs));
+
+    expect(result.current.options[0].id).toBe("ck");
+    expect(result.current.options[0].title).toBe("Sign with CryptKeeper");
+    expect(result.current.options[0].checkDisabledItem()).toBe(defaultHookArgs.isLoading);
+    expect(result.current.options[1].id).toBe("eth");
+    expect(result.current.options[1].title).toBe("Sign with MetaMask");
+    expect(result.current.options[1].checkDisabledItem()).toBe(defaultHookArgs.isLoading);
+  });
+
+  test("should return cryptkeeper and connect eth wallet options", () => {
+    (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: false });
+
+    const { result } = renderHook(() => useSignatureOptions(defaultHookArgs));
+
+    expect(result.current.options[0].id).toBe("ck");
+    expect(result.current.options[0].title).toBe("Sign with CryptKeeper");
+    expect(result.current.options[0].checkDisabledItem()).toBe(defaultHookArgs.isLoading);
+    expect(result.current.options[1].id).toBe("eth");
+    expect(result.current.options[1].title).toBe("Connect to MetaMask");
+    expect(result.current.options[1].checkDisabledItem()).toBe(defaultHookArgs.isLoading);
+  });
+
+  test("should return cryptkeeper and install eth wallet options", () => {
+    (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: false, isInjectedWallet: false });
+
+    const { result } = renderHook(() => useSignatureOptions(defaultHookArgs));
+
+    expect(result.current.options[0].id).toBe("ck");
+    expect(result.current.options[0].title).toBe("Sign with CryptKeeper");
+    expect(result.current.options[0].checkDisabledItem()).toBe(defaultHookArgs.isLoading);
+    expect(result.current.options[1].id).toBe("eth");
+    expect(result.current.options[1].title).toBe("Install MetaMask");
+    expect(result.current.options[1].checkDisabledItem()).toBe(true);
+  });
+});

--- a/packages/app/src/ui/hooks/wallet/index.ts
+++ b/packages/app/src/ui/hooks/wallet/index.ts
@@ -1,2 +1,3 @@
 export { useCryptKeeperWallet } from "./useCryptKeeper";
 export { useEthWallet } from "./useEthWallet";
+export { useSignatureOptions } from "./useSignatureOptions";

--- a/packages/app/src/ui/hooks/wallet/useSignatureOptions.ts
+++ b/packages/app/src/ui/hooks/wallet/useSignatureOptions.ts
@@ -1,0 +1,33 @@
+import { useEthWallet } from "./useEthWallet";
+
+export interface IUseSignatureOptionsArgs {
+  isLoading: boolean;
+}
+
+export interface IUseSignatureOptionsData {
+  options: ISignatureOption[];
+}
+
+export interface ISignatureOption {
+  id: string;
+  title: string;
+  checkDisabledItem: () => boolean;
+}
+
+export const useSignatureOptions = ({ isLoading }: IUseSignatureOptionsArgs): IUseSignatureOptionsData => {
+  const ethWallet = useEthWallet();
+
+  const { isActive: isWalletConnected, isInjectedWallet: isWalletInstalled } = ethWallet;
+  const ethWalletTitle = isWalletConnected ? "Sign with MetaMask" : "Connect to MetaMask";
+
+  const options = [
+    { id: "ck", title: "Sign with CryptKeeper", checkDisabledItem: () => isLoading },
+    {
+      id: "eth",
+      title: isWalletInstalled ? ethWalletTitle : "Install MetaMask",
+      checkDisabledItem: () => isLoading || !isWalletInstalled,
+    },
+  ];
+
+  return { options };
+};

--- a/packages/app/src/ui/pages/CreateIdentity/CreateIdentity.tsx
+++ b/packages/app/src/ui/pages/CreateIdentity/CreateIdentity.tsx
@@ -9,31 +9,14 @@ import { Checkbox } from "@src/ui/components/Checkbox";
 import { DropdownButton } from "@src/ui/components/DropdownButton";
 import { FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
 import { Input } from "@src/ui/components/Input";
+import { useSignatureOptions } from "@src/ui/hooks/wallet";
 
 import { useCreateIdentity } from "./useCreateIdentity";
 
 const CreateIdentity = (): JSX.Element => {
-  const {
-    isLoading,
-    isWalletInstalled,
-    isWalletConnected,
-    errors,
-    control,
-    onCloseModal,
-    onSign,
-    onGoToImportIdentity,
-  } = useCreateIdentity();
+  const { isLoading, errors, control, onCloseModal, onSign, onGoToImportIdentity } = useCreateIdentity();
 
-  const ethWalletTitle = isWalletConnected ? "Sign with MetaMask" : "Connect to MetaMask";
-
-  const menuOptions = [
-    { id: "ck", title: "Sign with CryptKeeper", checkDisabledItem: () => isLoading },
-    {
-      id: "eth",
-      title: isWalletInstalled ? ethWalletTitle : "Install metamask",
-      checkDisabledItem: () => isLoading || !isWalletInstalled,
-    },
-  ];
+  const { options } = useSignatureOptions({ isLoading });
 
   return (
     <Box data-testid="create-identity-page" sx={{ height: "100%" }}>
@@ -130,7 +113,7 @@ const CreateIdentity = (): JSX.Element => {
                 Reject
               </Button>
 
-              <DropdownButton menuOptions={menuOptions} onClick={onSign} />
+              <DropdownButton options={options} onClick={onSign} />
             </Box>
 
             <Button

--- a/packages/app/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/packages/app/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -8,12 +8,12 @@ import { Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ZERO_ADDRESS } from "@src/config/const";
-import { defaultWalletHookData } from "@src/config/mock/wallet";
+import { defaultWalletHookData, mockSignatureOptions } from "@src/config/mock/wallet";
 import { Paths } from "@src/constants";
 import { closePopup } from "@src/ui/ducks/app";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentity } from "@src/ui/ducks/identities";
-import { useCryptKeeperWallet, useEthWallet } from "@src/ui/hooks/wallet";
+import { useCryptKeeperWallet, useEthWallet, useSignatureOptions } from "@src/ui/hooks/wallet";
 import { signWithSigner, getMessageTemplate } from "@src/ui/services/identity";
 
 import CreateIdentity from "..";
@@ -42,6 +42,7 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
 jest.mock("@src/ui/hooks/wallet", (): unknown => ({
   useEthWallet: jest.fn(),
   useCryptKeeperWallet: jest.fn(),
+  useSignatureOptions: jest.fn(),
 }));
 
 describe("ui/pages/CreateIdentity", () => {
@@ -63,6 +64,8 @@ describe("ui/pages/CreateIdentity", () => {
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
 
     (useCryptKeeperWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: true });
+
+    (useSignatureOptions as jest.Mock).mockReturnValue(mockSignatureOptions);
 
     (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
 
@@ -100,6 +103,17 @@ describe("ui/pages/CreateIdentity", () => {
 
   test("should connect properly to eth wallet", async () => {
     (useEthWallet as jest.Mock).mockReturnValue({ ...defaultWalletHookData, isActive: false });
+    (useSignatureOptions as jest.Mock).mockReturnValue({
+      ...mockSignatureOptions,
+      options: [
+        ...mockSignatureOptions.options.filter(({ id }) => id === "eth"),
+        {
+          id: "eth",
+          title: "Connect to MetaMask",
+          checkDisabledItem: () => false,
+        },
+      ],
+    });
 
     const { container } = render(
       <Suspense>

--- a/packages/app/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/packages/app/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -83,8 +83,6 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     const { result } = renderHook(() => useCreateIdentity());
 
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.isWalletConnected).toBe(true);
-    expect(result.current.isWalletInstalled).toBe(true);
     expect(result.current.control).toBeDefined();
     expect(result.current.errors).toStrictEqual({
       root: undefined,

--- a/packages/app/src/ui/pages/CreateIdentity/useCreateIdentity.ts
+++ b/packages/app/src/ui/pages/CreateIdentity/useCreateIdentity.ts
@@ -12,8 +12,6 @@ import { getMessageTemplate, signWithSigner } from "@src/ui/services/identity";
 
 export interface IUseCreateIdentityData {
   isLoading: boolean;
-  isWalletConnected: boolean;
-  isWalletInstalled: boolean;
   errors: Partial<{
     root: string;
     nonce: string;
@@ -110,7 +108,16 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
         setError("root", { type: "submit", message: (err as Error).message });
       }
     },
-    [ethWallet.address, ethWallet.provider, cryptKeeperWallet.address, redirectUrl, urlOrigin, dispatch, navigate],
+    [
+      ethWallet.address,
+      ethWallet.provider,
+      cryptKeeperWallet.address,
+      redirectUrl,
+      urlOrigin,
+      dispatch,
+      navigate,
+      setError,
+    ],
   );
 
   const onCreateIdentityWithEthWallet = useCallback(
@@ -164,8 +171,6 @@ export const useCreateIdentity = (): IUseCreateIdentityData => {
 
   return {
     isLoading: ethWallet.isActivating || cryptKeeperWallet.isActivating || isLoading || isSubmitting,
-    isWalletInstalled: ethWallet.isInjectedWallet,
-    isWalletConnected: ethWallet.isActive,
     errors: {
       nonce: errors.nonce?.message,
       root: errors.root?.message,

--- a/packages/app/src/ui/pages/ImportIdentity/ImportIdentity.tsx
+++ b/packages/app/src/ui/pages/ImportIdentity/ImportIdentity.tsx
@@ -3,15 +3,19 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 
 import { BigNumberInput } from "@src/ui/components/BigNumberInput";
+import { DropdownButton } from "@src/ui/components/DropdownButton";
 import { FullModalContent, FullModalFooter, FullModalHeader } from "@src/ui/components/FullModal";
 import { Input } from "@src/ui/components/Input";
 import { UploadButton } from "@src/ui/components/UploadButton";
+import { useSignatureOptions } from "@src/ui/hooks/wallet";
 
 import { useImportIdentity } from "./useImportIdentity";
 
 const ImportIdentity = (): JSX.Element => {
   const { isLoading, urlOrigin, errors, trapdoor, nullifier, register, onGoBack, onGoToHost, onDrop, onSubmit } =
     useImportIdentity();
+
+  const { options } = useSignatureOptions({ isLoading });
 
   return (
     <Box
@@ -116,20 +120,11 @@ const ImportIdentity = (): JSX.Element => {
       </FullModalContent>
 
       <FullModalFooter>
-        <Button sx={{ mr: 1, width: "100%" }} variant="outlined" onClick={onGoBack}>
+        <Button sx={{ mr: 1, width: "30%" }} variant="outlined" onClick={onGoBack}>
           Reject
         </Button>
 
-        <Button
-          data-testid="import-identity"
-          disabled={isLoading}
-          sx={{ ml: 1, width: "100%" }}
-          type="submit"
-          variant="contained"
-          onClick={onSubmit}
-        >
-          Accept
-        </Button>
+        <DropdownButton disabled={isLoading} options={options} sx={{ ml: 1, width: "70%" }} onClick={onSubmit} />
       </FullModalFooter>
     </Box>
   );

--- a/packages/app/src/ui/pages/ImportIdentity/__tests__/ImportIdentity.test.tsx
+++ b/packages/app/src/ui/pages/ImportIdentity/__tests__/ImportIdentity.test.tsx
@@ -5,13 +5,19 @@
 import { render, waitFor } from "@testing-library/react";
 import { Suspense } from "react";
 
+import { mockSignatureOptions } from "@src/config/mock/wallet";
 import { mockDefaultIdentity, mockDefaultIdentityCommitment, mockDefaultIdentitySecret } from "@src/config/mock/zk";
+import { useSignatureOptions } from "@src/ui/hooks/wallet";
 
 import ImportIdentity from "..";
 import { IUseImportIdentityData, useImportIdentity } from "../useImportIdentity";
 
 jest.mock("bigint-conversion", (): unknown => ({
   bigintToHex: jest.fn(),
+}));
+
+jest.mock("@src/ui/hooks/wallet", (): unknown => ({
+  useSignatureOptions: jest.fn(),
 }));
 
 jest.mock("../useImportIdentity", (): unknown => ({
@@ -36,6 +42,8 @@ describe("ui/pages/ImportIdentity", () => {
 
   beforeEach(() => {
     (useImportIdentity as jest.Mock).mockReturnValue(defaultHookData);
+
+    (useSignatureOptions as jest.Mock).mockReturnValue(mockSignatureOptions);
   });
 
   afterEach(() => {

--- a/packages/app/src/ui/pages/PresentVerifiableCredential/PresentVerifiableCredential.tsx
+++ b/packages/app/src/ui/pages/PresentVerifiableCredential/PresentVerifiableCredential.tsx
@@ -102,7 +102,7 @@ const PresentVerifiableCredential = (): JSX.Element => {
             Reject
           </Button>
 
-          <DropdownButton menuOptions={menuOptions} onClick={onSubmitVerifiablePresentation} />
+          <DropdownButton options={menuOptions} onClick={onSubmitVerifiablePresentation} />
         </Box>
       </FullModalFooter>
     </Box>

--- a/packages/app/src/ui/services/identity/__tests__/identity.test.ts
+++ b/packages/app/src/ui/services/identity/__tests__/identity.test.ts
@@ -1,8 +1,9 @@
 import { ZERO_ADDRESS } from "@src/config/const";
+import { mockDefaultNullifier, mockDefaultTrapdoor } from "@src/config/mock/zk";
 
 import type { JsonRpcSigner } from "ethers";
 
-import { getMessageTemplate, signWithSigner } from "..";
+import { getImportMessageTemplate, getMessageTemplate, signWithSigner } from "..";
 
 describe("ui/services/identity", () => {
   test("should sign message properly", async () => {
@@ -22,6 +23,28 @@ describe("ui/services/identity", () => {
     expect(mockSigner.signMessage).toBeCalledTimes(1);
     expect(mockSigner.signMessage).toBeCalledWith(
       `Sign this message with account ${ZERO_ADDRESS} to generate your Semaphore identity with key nonce: 0`,
+    );
+    expect(result).toBe("signed");
+  });
+
+  test("should sign import message properly", async () => {
+    const mockSigner = {
+      signMessage: jest.fn().mockResolvedValue("signed"),
+    };
+
+    const message = getImportMessageTemplate({
+      account: ZERO_ADDRESS,
+      trapdoor: mockDefaultTrapdoor,
+      nullifier: mockDefaultNullifier,
+    });
+    const result = await signWithSigner({
+      message,
+      signer: mockSigner as unknown as JsonRpcSigner,
+    });
+
+    expect(mockSigner.signMessage).toBeCalledTimes(1);
+    expect(mockSigner.signMessage).toBeCalledWith(
+      `Sign this message with account ${ZERO_ADDRESS} to import your Semaphore identity with trapdoor: ${mockDefaultTrapdoor}, nullifier: ${mockDefaultNullifier}`,
     );
     expect(result).toBe("signed");
   });

--- a/packages/app/src/ui/services/identity/index.ts
+++ b/packages/app/src/ui/services/identity/index.ts
@@ -26,3 +26,14 @@ export function getMessageTemplate({ account, nonce }: IGetMessageTemplateArgs):
   const nonceEnd = `with key nonce: ${nonce}`;
   return `Sign this message with account ${account} to generate your Semaphore identity ${nonceEnd}`.trim();
 }
+
+export interface IGetImportMessageTemplateArgs {
+  account: string;
+  trapdoor: string;
+  nullifier: string;
+}
+
+export function getImportMessageTemplate({ account, trapdoor, nullifier }: IGetImportMessageTemplateArgs): string {
+  const end = `with trapdoor: ${trapdoor}, nullifier: ${nullifier}`;
+  return `Sign this message with account ${account} to import your Semaphore identity ${end}`.trim();
+}

--- a/packages/e2e/tests/importExternalIdentity.test.ts
+++ b/packages/e2e/tests/importExternalIdentity.test.ts
@@ -103,6 +103,7 @@ test.describe("import external identity", () => {
       await cryptKeeper.identities.importIdentityWithFile({
         name: "Test",
         filepath: backupFilePath,
+        walletType: "eth",
       });
     }
     /* eslint-enable no-await-in-loop */

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -31,12 +31,13 @@ export interface IImportIdentityArgs {
   name: string;
   trapdoor: string;
   nullifier: string;
+  messageSignature: string;
   urlOrigin?: string;
 }
 
 export enum EWallet {
-  ETH_WALLET,
   CRYPTKEEPER_WALLET,
+  ETH_WALLET,
 }
 
 export interface IIdentityMetadata {
@@ -89,6 +90,7 @@ export interface ICreateIdentityArgs {
   name: string;
   groups: IGroupData[];
   isDeterministic: boolean;
+  isImported: boolean;
   account?: string;
   messageSignature?: string;
   nonce?: number;

--- a/packages/zk/src/identity/factory/index.ts
+++ b/packages/zk/src/identity/factory/index.ts
@@ -4,7 +4,18 @@ import { ICreateIdentityArgs } from "@cryptkeeperzk/types";
 import { ZkIdentitySemaphore } from "../protocols";
 
 export function createNewIdentity(config: ICreateIdentityArgs): ZkIdentitySemaphore {
-  const { name, messageSignature, account, groups, urlOrigin, isDeterministic, nonce, trapdoor, nullifier } = config;
+  const {
+    name,
+    messageSignature,
+    account,
+    groups,
+    urlOrigin,
+    isDeterministic,
+    isImported,
+    nonce,
+    trapdoor,
+    nullifier,
+  } = config;
   const serialized = trapdoor && nullifier ? JSON.stringify([trapdoor, nullifier]) : undefined;
 
   const identity = new Identity(serialized || messageSignature);
@@ -16,6 +27,6 @@ export function createNewIdentity(config: ICreateIdentityArgs): ZkIdentitySemaph
     nonce,
     urlOrigin,
     isDeterministic,
-    isImported: Boolean(serialized),
+    isImported,
   });
 }

--- a/packages/zk/src/proof/protocols/__tests__/utils.test.ts
+++ b/packages/zk/src/proof/protocols/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { Identity } from "@cryptkeeperzk/semaphore-identity";
 import { MerkleProof } from "@zk-kit/incremental-merkle-tree";
-import { poseidon1, poseidon2 } from "poseidon-lite";
+import { poseidon1 } from "poseidon-lite/poseidon1";
+import { poseidon2 } from "poseidon-lite/poseidon2";
 
 import {
   deserializeMerkleProof,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,7 +332,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.8.8)(ts-node@10.9.1)
+        version: 29.7.0
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -365,7 +365,7 @@ importers:
         version: 3.0.2
       terser-webpack-plugin:
         specifier: ^5.3.9
-        version: 5.3.9(@swc/core@1.3.95)(webpack@5.89.0)
+        version: 5.3.9(webpack@5.89.0)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.22.10)(jest@29.7.0)(typescript@5.2.2)
@@ -377,7 +377,7 @@ importers:
         version: 5.2.2
       webpack:
         specifier: ^5.89.0
-        version: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+        version: 5.89.0(webpack-cli@5.1.4)
       webpack-bundle-analyzer:
         specifier: ^4.9.1
         version: 4.9.1
@@ -845,7 +845,7 @@ packages:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.22.10
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2104,7 +2104,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2646,7 +2646,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.23.0
       ignore: 5.2.4
@@ -3029,7 +3029,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3094,6 +3094,49 @@ packages:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
+    dev: true
+
+  /@jest/core@29.7.0:
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.8.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.8.8)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.5
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
     dev: true
 
   /@jest/core@29.7.0(ts-node@10.9.1):
@@ -3501,7 +3544,7 @@ packages:
       '@ethereumjs/tx': 4.2.0
       '@noble/hashes': 1.3.2
       '@types/debug': 4.1.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       semver: 7.5.4
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -5133,7 +5176,7 @@ packages:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.5.16
-      jest: 29.7.0(@types/node@20.8.8)(ts-node@10.9.1)
+      jest: 29.7.0
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
@@ -5986,7 +6029,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.1)(webpack@5.89.0)
     dev: true
 
@@ -5997,7 +6040,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.1)(webpack@5.89.0)
     dev: true
 
@@ -6012,7 +6055,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.1)(webpack@5.89.0)
     dev: true
 
@@ -6156,7 +6199,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6595,7 +6638,7 @@ packages:
   /axios@1.5.0:
     resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8097,7 +8140,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /core-js-compat@3.31.0:
@@ -8216,6 +8259,25 @@ packages:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
+  /create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.8.8)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /create-jest@29.7.0(@types/node@20.8.8)(ts-node@10.9.1):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -8305,7 +8367,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.24)
       postcss-value-parser: 4.2.0
       semver: 7.5.2
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /css-select@4.3.0:
@@ -8535,6 +8597,17 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -9013,7 +9086,7 @@ packages:
       webpack: ^4 || ^5
     dependencies:
       dotenv-defaults: 2.0.2
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /dotenv@16.3.1:
@@ -9643,7 +9716,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -10175,7 +10248,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /file-selector@0.6.0:
@@ -10337,6 +10410,16 @@ packages:
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -11104,7 +11187,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /htmlescape@1.1.1:
@@ -11220,7 +11303,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11298,7 +11381,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11386,7 +11469,7 @@ packages:
       serialize-javascript: 6.0.1
       sharp: 0.32.6
       svgo: 3.0.2
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /imagemin-svgo@10.0.1:
@@ -12016,7 +12099,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -12097,6 +12180,34 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.8.8)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-cli@29.7.0(@types/node@20.8.8)(ts-node@10.9.1):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -12123,6 +12234,46 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config@29.7.0(@types/node@20.8.8):
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.10
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.8.8
+      babel-jest: 29.7.0(@babel/core@7.22.10)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
     dev: true
 
   /jest-config@29.7.0(@types/node@20.8.8)(ts-node@10.9.1):
@@ -12489,6 +12640,27 @@ packages:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
+
+  /jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
     dev: true
 
   /jest@29.7.0(@types/node@20.8.8)(ts-node@10.9.1):
@@ -12911,7 +13083,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       lilconfig: 2.1.0
       listr2: 7.0.2
@@ -15584,7 +15756,7 @@ packages:
     dependencies:
       neo-async: 2.6.2
       sass: 1.69.4
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /sass@1.69.4:
@@ -16328,7 +16500,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /stylis@4.2.0:
@@ -16535,6 +16707,30 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.18.1
       webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+    dev: true
+
+  /terser-webpack-plugin@5.3.9(webpack@5.89.0):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.18.1
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /terser@4.8.1:
@@ -16762,7 +16958,7 @@ packages:
       '@babel/core': 7.22.10
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.8.8)(ts-node@10.9.1)
+      jest: 29.7.0
       jest-util: 29.6.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -16785,7 +16981,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.2.2
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /ts-node@10.9.1(@swc/core@1.3.95)(@types/node@18.15.13)(typescript@5.2.2):
@@ -17746,7 +17942,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.89.0(@swc/core@1.3.95)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.9.1
       webpack-merge: 5.10.0
     dev: true
@@ -17862,6 +18058,47 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.95)(webpack@5.89.0)
+      watchpack: 2.4.0
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.1)(webpack@5.89.0)
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.89.0(webpack-cli@5.1.4):
+    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.9.0
+      acorn-import-assertions: 1.9.0(acorn@8.9.0)
+      browserslist: 4.21.9
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.1)(webpack@5.89.0)
       webpack-sources: 3.2.3


### PR DESCRIPTION
## Explanation

This PR adds support for importing identities and derive them from user's seed phrase.

Details are below:
- [x] Add signature options for identity import
- [x] Minor refactoring

## Related Issues

Blocked by #1040 
Related to #906

## Screenshots

<details>
<summary>Expand</summary>

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/2c93e4c3-4701-41bf-aef3-f9c9cd007579)

</details>

## Manual Testing Steps

1. Try to import identity from demo, connect, create identity screens.
2. Check cryptkeeper sign
3. Check metamask sign with and without connect

## Pre-Merge Checklist

### Assignees Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### Reviewers Checklist

- [x] Manual testing checked and passed.
