### PR TITLE
feat: add connection service

### DIFF
--- a/packages/app/src/background/services/approval/index.ts
+++ b/packages/app/src/background/services/approval/index.ts
@@ -73,7 +73,13 @@ export default class ApprovalService extends BaseService implements IBackupable 
     return true;
   };
 
-  lock = (): Promise<boolean> => this.onLock();
+  lock = async (): Promise<boolean> => this.onLock(this.onClean);
+
+  private onClean = (): boolean => {
+    this.allowedHosts.clear();
+
+    return true;
+  };
 
   getPermission = (urlOrigin: string): IHostPermission => ({
     urlOrigin,

--- a/packages/app/src/background/services/base/Base.ts
+++ b/packages/app/src/background/services/base/Base.ts
@@ -30,7 +30,7 @@ export abstract class BaseService {
     });
   };
 
-  onLock = async (internalLock?: () => Promise<unknown>): Promise<boolean> => {
+  onLock = async (internalLock?: () => Promise<unknown> | boolean): Promise<boolean> => {
     this.isUnlocked = false;
     this.unlockCB = undefined;
 

--- a/packages/app/src/background/services/connection/ConnectionService.ts
+++ b/packages/app/src/background/services/connection/ConnectionService.ts
@@ -43,7 +43,12 @@ export default class ConnectionService extends BaseService implements IBackupabl
     return ConnectionService.INSTANCE;
   };
 
-  lock = (): Promise<boolean> => this.onLock();
+  lock = async (): Promise<boolean> => this.onLock(this.onClean);
+
+  private onClean = (): boolean => {
+    this.connections.clear();
+    return true;
+  };
 
   unlock = async (): Promise<boolean> => {
     const encryped = await this.connectionsStorage.get<string>();
@@ -64,13 +69,13 @@ export default class ConnectionService extends BaseService implements IBackupabl
       throw new Error("CryptKeeper: origin is not provided");
     }
 
-    const idenity = await this.zkIdenityService.getIdentity(commitment);
+    const identity = this.zkIdenityService.getIdentity(commitment);
 
-    if (!idenity) {
+    if (!identity) {
       throw new Error("CryptKeeper: identity is not found");
     }
 
-    const connection = this.getIdentityConnection(commitment, idenity.metadata);
+    const connection = this.getIdentityConnection(commitment, identity.metadata);
     this.connections.set(urlOrigin, connection);
     await this.save();
 

--- a/packages/app/src/background/services/connection/ConnectionService.ts
+++ b/packages/app/src/background/services/connection/ConnectionService.ts
@@ -1,0 +1,165 @@
+import { EventName } from "@cryptkeeperzk/providers";
+import omit from "lodash/omit";
+import pick from "lodash/pick";
+
+import BrowserUtils from "@src/background/controllers/browserUtils";
+import { type BackupData, IBackupable } from "@src/background/services/backup";
+import BaseService from "@src/background/services/base";
+import CryptoService, { ECryptMode } from "@src/background/services/crypto";
+import SimpleStorage from "@src/background/services/storage";
+import ZkIdentityService from "@src/background/services/zkIdentity";
+
+import type { IIdenityConnection, IZkMetadata, IConnectArgs, IIdentityMetadata } from "@cryptkeeperzk/types";
+
+const CONNECTIONS_STORAGE_KEY = "@@CONNECTIONS@@";
+
+export default class ConnectionService extends BaseService implements IBackupable {
+  private static INSTANCE?: ConnectionService;
+
+  private connections: Map<string, IIdenityConnection>;
+
+  private readonly connectionsStorage: SimpleStorage;
+
+  private readonly cryptoService: CryptoService;
+
+  private readonly browserController: BrowserUtils;
+
+  private readonly zkIdenityService: ZkIdentityService;
+
+  private constructor() {
+    super();
+    this.connections = new Map();
+    this.connectionsStorage = new SimpleStorage(CONNECTIONS_STORAGE_KEY);
+    this.cryptoService = CryptoService.getInstance();
+    this.browserController = BrowserUtils.getInstance();
+    this.zkIdenityService = ZkIdentityService.getInstance();
+  }
+
+  static getInstance = (): ConnectionService => {
+    if (!ConnectionService.INSTANCE) {
+      ConnectionService.INSTANCE = new ConnectionService();
+    }
+
+    return ConnectionService.INSTANCE;
+  };
+
+  lock = (): Promise<boolean> => this.onLock();
+
+  unlock = async (): Promise<boolean> => {
+    const encryped = await this.connectionsStorage.get<string>();
+
+    if (encryped) {
+      const decrypted = this.cryptoService.decrypt(encryped, { mode: ECryptMode.MNEMONIC });
+      this.connections = new Map(JSON.parse(decrypted) as Iterable<[string, IIdenityConnection]>);
+    }
+
+    this.isUnlocked = true;
+    this.onUnlocked();
+
+    return true;
+  };
+
+  connect = async ({ commitment }: IConnectArgs, { urlOrigin }: IZkMetadata): Promise<void> => {
+    if (!urlOrigin) {
+      throw new Error("CryptKeeper: origin is not provided");
+    }
+
+    const idenity = await this.zkIdenityService.getIdentity(commitment);
+
+    if (!idenity) {
+      throw new Error("CryptKeeper: identity is not found");
+    }
+
+    const connection = this.getIdentityConnection(commitment, idenity.metadata);
+    this.connections.set(urlOrigin, connection);
+    await this.save();
+
+    await this.browserController.pushEvent(
+      { type: EventName.CONNECT_IDENTITY, payload: omit(connection, ["commitment"]) },
+      { urlOrigin },
+    );
+  };
+
+  disconnect = async (payload: unknown, { urlOrigin }: IZkMetadata): Promise<void> => {
+    await this.isOriginConnected(payload, { urlOrigin });
+    this.connections.delete(urlOrigin!);
+    await this.save();
+
+    await this.browserController.pushEvent(
+      { type: EventName.DISCONNECT_IDENTITY, payload: { urlOrigin } },
+      { urlOrigin },
+    );
+  };
+
+  isOriginConnected = (payload: unknown, { urlOrigin }: IZkMetadata): unknown => {
+    if (!urlOrigin) {
+      throw new Error("CryptKeeper: origin is not provided");
+    }
+
+    const isConnected = this.connections.has(urlOrigin);
+
+    if (!isConnected) {
+      throw new Error("CryptKeeper: origin is not connected");
+    }
+
+    return payload;
+  };
+
+  getConnections = (): Map<string, IIdenityConnection> => this.connections;
+
+  downloadStorage = (): Promise<string | null> => this.connectionsStorage.get<string>();
+
+  restoreStorage = async (data: BackupData | null): Promise<void> => {
+    if (data && typeof data !== "string") {
+      throw new Error("Incorrect restore format for connections");
+    }
+
+    await this.connectionsStorage.set(data);
+  };
+
+  downloadEncryptedStorage = async (backupPassword: string): Promise<string | null> => {
+    const data = await this.connectionsStorage.get<string>();
+
+    if (!data) {
+      return null;
+    }
+
+    const backup = this.cryptoService.decrypt(data, { mode: ECryptMode.MNEMONIC });
+    const encryptedBackup = this.cryptoService.encrypt(backup, { secret: backupPassword });
+
+    return this.cryptoService.generateEncryptedHmac(encryptedBackup, backupPassword);
+  };
+
+  uploadEncryptedStorage = async (backupEncryptedData: BackupData, backupPassword: string): Promise<void> => {
+    if (!backupEncryptedData) {
+      return;
+    }
+
+    const encryptedBackup = this.cryptoService.getAuthenticBackup(backupEncryptedData, backupPassword);
+
+    if (typeof encryptedBackup !== "string") {
+      throw new Error("Incorrect backup format for connections");
+    }
+
+    const backup = this.cryptoService.decrypt(encryptedBackup, { secret: backupPassword });
+    await this.unlock();
+
+    const backupAllowedHosts = new Map(JSON.parse(backup) as Iterable<[string, IIdenityConnection]>);
+    this.connections = new Map([...this.connections, ...backupAllowedHosts]);
+
+    await this.save();
+  };
+
+  private getIdentityConnection(commitment: string, metadata: IIdentityMetadata): IIdenityConnection {
+    return {
+      ...pick(metadata, ["name", "urlOrigin"]),
+      commitment,
+    };
+  }
+
+  private async save(): Promise<void> {
+    const serialized = JSON.stringify(Array.from(this.connections.entries()));
+    const newData = this.cryptoService.encrypt(serialized, { mode: ECryptMode.MNEMONIC });
+    await this.connectionsStorage.set(newData);
+  }
+}

--- a/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
+++ b/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
@@ -1,0 +1,252 @@
+import SimpleStorage from "@src/background/services/storage";
+import { mockDefaultIdentity } from "@src/config/mock/zk";
+
+import type { IConnectArgs, IZkMetadata } from "@cryptkeeperzk/types";
+
+import ConnectionService from "..";
+
+const mockDefaultHosts = [mockDefaultIdentity.metadata.urlOrigin];
+const mockSerializedConnections = JSON.stringify([
+  [
+    mockDefaultHosts[0],
+    {
+      name: mockDefaultIdentity.metadata.name,
+      urlOrigin: mockDefaultHosts[0],
+      commitment: mockDefaultIdentity.commitment,
+    },
+  ],
+]);
+
+jest.mock("@src/background/services/crypto", (): unknown => ({
+  ...jest.requireActual("@src/background/services/crypto"),
+  getInstance: jest.fn(() => ({
+    encrypt: jest.fn((arg: string) => arg),
+    decrypt: jest.fn(() => mockSerializedConnections),
+    generateEncryptedHmac: jest.fn(() => "encrypted"),
+    getAuthenticBackup: jest.fn((encrypted: string | Record<string, string>) => encrypted),
+  })),
+}));
+
+jest.mock("@src/background/services/zkIdentity", (): unknown => ({
+  getInstance: jest.fn(() => ({
+    getIdentity: jest.fn((arg: string) => (arg !== "unknown" ? Promise.resolve(mockDefaultIdentity) : undefined)),
+  })),
+}));
+
+jest.mock("@src/background/services/storage");
+
+interface MockStorage {
+  get: jest.Mock;
+  set: jest.Mock;
+  clear: jest.Mock;
+}
+
+describe("background/services/connection", () => {
+  const connectionService = ConnectionService.getInstance();
+
+  const defaultMetadata: IZkMetadata = { urlOrigin: mockDefaultHosts[0] };
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+
+    (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+      instance.get.mockResolvedValue(mockSerializedConnections);
+      instance.set.mockResolvedValue(undefined);
+      instance.clear.mockResolvedValue(undefined);
+    });
+  });
+
+  afterEach(async () => {
+    process.env.NODE_ENV = "test";
+    await connectionService.lock();
+
+    (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+      instance.get.mockClear();
+      instance.set.mockClear();
+      instance.clear.mockClear();
+    });
+  });
+
+  describe("unlock", () => {
+    test("should unlock properly without stored data", async () => {
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        instance.get.mockResolvedValue(undefined);
+      });
+
+      const result = await connectionService.unlock();
+
+      expect(result).toBe(true);
+    });
+
+    test("should unlock properly", async () => {
+      const result = await connectionService.unlock();
+
+      expect(result).toBe(true);
+    });
+
+    test("should await unlock properly", async () => {
+      connectionService.awaitUnlock();
+      const isUnlocked = await connectionService.unlock();
+      const isUnlockCompleted = connectionService.onUnlocked();
+
+      expect(isUnlocked).toBe(true);
+      expect(isUnlockCompleted).toBe(true);
+    });
+
+    test("should not unlock twice", async () => {
+      const isUnlockedFirst = await connectionService.unlock();
+      const isUnlockedSecond = await connectionService.unlock();
+
+      expect(isUnlockedFirst).toBe(true);
+      expect(isUnlockedSecond).toBe(true);
+      expect(await connectionService.awaitUnlock()).toBeUndefined();
+    });
+  });
+
+  describe("connect", () => {
+    const defaultArgs: IConnectArgs = {
+      commitment: mockDefaultIdentity.commitment,
+    };
+
+    test("should connect identity properly", async () => {
+      const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
+
+      await connectionService.connect(defaultArgs, defaultMetadata);
+      const connections = connectionService.getConnections();
+
+      expect(storage.set).toBeCalledTimes(1);
+      expect(storage.set).toBeCalledWith(mockSerializedConnections);
+      expect(connections.size).toBe(1);
+    });
+
+    test("should throw error if there is no url origin", async () => {
+      await expect(connectionService.connect(defaultArgs, { urlOrigin: "" })).rejects.toThrowError(
+        "CryptKeeper: origin is not provided",
+      );
+    });
+
+    test("should throw error if there is no idenity found", async () => {
+      await expect(connectionService.connect({ commitment: "unknown" }, defaultMetadata)).rejects.toThrowError(
+        "CryptKeeper: identity is not found",
+      );
+    });
+  });
+
+  describe("disconnect", () => {
+    beforeEach(async () => {
+      await connectionService.unlock();
+    });
+
+    test("should disconnect identity properly", async () => {
+      const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
+
+      await connectionService.disconnect({}, defaultMetadata);
+      const connections = connectionService.getConnections();
+
+      expect(storage.set).toBeCalledTimes(1);
+      expect(storage.set).toBeCalledWith(JSON.stringify([]));
+      expect(connections.size).toBe(0);
+    });
+
+    test("should throw error if there is no url origin", async () => {
+      await expect(connectionService.disconnect({}, { urlOrigin: "" })).rejects.toThrowError(
+        "CryptKeeper: origin is not provided",
+      );
+    });
+
+    test("should throw error if origin is not connected", async () => {
+      await expect(connectionService.disconnect({}, { urlOrigin: "unknown" })).rejects.toThrowError(
+        "CryptKeeper: origin is not connected",
+      );
+    });
+  });
+
+  describe("checks", () => {
+    beforeEach(async () => {
+      await connectionService.unlock();
+    });
+
+    afterEach(async () => {
+      await connectionService.lock();
+    });
+
+    test("should throw error if there is no url origin", () => {
+      expect(() => connectionService.isOriginConnected({}, { urlOrigin: "" })).toThrowError(
+        "CryptKeeper: origin is not provided",
+      );
+    });
+
+    test("should throw error if there is no connection for url origin", () => {
+      expect(() => connectionService.isOriginConnected({}, { urlOrigin: "unknown" })).toThrowError(
+        "CryptKeeper: origin is not connected",
+      );
+    });
+
+    test("should return payload for connected url origin", () => {
+      const result = connectionService.isOriginConnected({}, defaultMetadata);
+
+      expect(result).toStrictEqual({});
+    });
+  });
+
+  describe("backup", () => {
+    test("should download encrypted connections", async () => {
+      const result = await connectionService.downloadEncryptedStorage("password");
+
+      expect(result).toBeDefined();
+    });
+
+    test("should not download encrypted connections if storage is empty", async () => {
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        instance.get.mockReturnValue(undefined);
+      });
+
+      const result = await connectionService.downloadEncryptedStorage("password");
+
+      expect(result).toBeNull();
+    });
+
+    test("should upload encrypted connections", async () => {
+      await connectionService.uploadEncryptedStorage("encrypted", "password");
+
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        expect(instance.set).toBeCalledTimes(1);
+      });
+    });
+
+    test("should not upload encrypted connections if there is no data", async () => {
+      await connectionService.uploadEncryptedStorage("", "");
+
+      (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
+        expect(instance.set).toBeCalledTimes(0);
+      });
+    });
+
+    test("should throw error when trying upload incorrect backup", async () => {
+      await expect(connectionService.uploadEncryptedStorage({}, "password")).rejects.toThrow(
+        "Incorrect backup format for connections",
+      );
+    });
+
+    test("should download storage properly", async () => {
+      const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
+
+      await connectionService.downloadStorage();
+
+      expect(storage.get).toBeCalledTimes(1);
+    });
+
+    test("should restore storage properly", async () => {
+      const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
+
+      await connectionService.restoreStorage("storage");
+
+      expect(storage.set).toBeCalledTimes(1);
+      expect(storage.set).toBeCalledWith("storage");
+    });
+
+    test("should throw error when trying to restore incorrect data", async () => {
+      await expect(connectionService.restoreStorage({})).rejects.toThrow("Incorrect restore format for connections");
+    });
+  });
+});

--- a/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
+++ b/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
@@ -29,7 +29,7 @@ jest.mock("@src/background/services/crypto", (): unknown => ({
 
 jest.mock("@src/background/services/zkIdentity", (): unknown => ({
   getInstance: jest.fn(() => ({
-    getIdentity: jest.fn((arg: string) => (arg !== "unknown" ? Promise.resolve(mockDefaultIdentity) : undefined)),
+    getIdentity: jest.fn((arg: string) => (arg !== "unknown" ? mockDefaultIdentity : undefined)),
   })),
 }));
 
@@ -108,6 +108,10 @@ describe("background/services/connection", () => {
       commitment: mockDefaultIdentity.commitment,
     };
 
+    beforeEach(async () => {
+      await connectionService.unlock();
+    });
+
     test("should connect identity properly", async () => {
       const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
 
@@ -164,10 +168,6 @@ describe("background/services/connection", () => {
   describe("checks", () => {
     beforeEach(async () => {
       await connectionService.unlock();
-    });
-
-    afterEach(async () => {
-      await connectionService.lock();
     });
 
     test("should throw error if there is no url origin", () => {

--- a/packages/app/src/background/services/connection/index.ts
+++ b/packages/app/src/background/services/connection/index.ts
@@ -1,0 +1,3 @@
+import ConnectionService from "./ConnectionService";
+
+export default ConnectionService;

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -515,6 +515,21 @@ describe("background/services/zkIdentity", () => {
       expect(identities).toHaveLength(mockDefaultIdentities.length);
     });
 
+    test("should get identity properly", async () => {
+      const identity = await zkIdentityService.getIdentity(mockDefaultIdentityCommitment);
+
+      expect(identity).toStrictEqual({
+        commitment: mockDefaultIdentityCommitment,
+        metadata: mockDefaultIdentity.metadata,
+      });
+    });
+
+    test("should return undefined if there is no such identity", async () => {
+      const identity = await zkIdentityService.getIdentity("unknown");
+
+      expect(identity).toBeUndefined();
+    });
+
     test("should get number of identities properly", async () => {
       const result = await zkIdentityService.getNumOfIdentities();
 

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -118,7 +118,9 @@ describe("background/services/zkIdentity", () => {
     (createNewIdentity as jest.Mock).mockReturnValue(defaultNewIdentity);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await zkIdentityService.lock();
+
     (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
       instance.get.mockClear();
       instance.set.mockClear();
@@ -189,6 +191,10 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("set connected identity", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should set connected identity properly", async () => {
       const expectConnectIdentityAction = setConnectedIdentity(
         pick(mockDefaultIdentity.metadata, ["name", "urlOrigin"]),
@@ -218,6 +224,9 @@ describe("background/services/zkIdentity", () => {
         instance.get.mockReturnValue(undefined);
       });
 
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
+
       const result = await zkIdentityService.connectIdentity({
         identityCommitment: mockDefaultIdentityCommitment,
         urlOrigin: "http://localhost:3000",
@@ -230,6 +239,10 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("set identity name", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should set identity name properly", async () => {
       const result = await zkIdentityService.setIdentityName({
         identityCommitment: mockDefaultIdentityCommitment,
@@ -249,8 +262,12 @@ describe("background/services/zkIdentity", () => {
     });
   });
 
-  describe("set identity urlOrigin", () => {
-    test("should set identity urlOrigin properly", async () => {
+  describe("set identity url origin", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
+    test("should set identity url origin properly", async () => {
       const result = await zkIdentityService.setIdentityHost({
         identityCommitment: mockDefaultIdentityCommitment,
         urlOrigin: "http://localhost:3000",
@@ -259,7 +276,7 @@ describe("background/services/zkIdentity", () => {
       expect(result).toBe(true);
     });
 
-    test("should not set identity urlOrigin if there is no such identity", async () => {
+    test("should not set identity url origin if there is no such identity", async () => {
       const result = await zkIdentityService.setIdentityHost({
         identityCommitment: "unknown",
         urlOrigin: "http://localhost:3000",
@@ -270,6 +287,10 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("delete identity", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should delete identity properly", async () => {
       const [identityStorage, connectedIdentityStorage] = (SimpleStorage as jest.Mock).mock.instances as [
         MockStorage,
@@ -290,6 +311,9 @@ describe("background/services/zkIdentity", () => {
         instance.get.mockReturnValue(undefined);
       });
 
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
+
       const result = await zkIdentityService.deleteIdentity({ identityCommitment: mockDefaultIdentityCommitment });
 
       expect(result).toBe(false);
@@ -297,6 +321,10 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("delete all identities", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should delete all identities properly", async () => {
       const isIdentitySet = await zkIdentityService.connectIdentity({
         identityCommitment: mockDefaultIdentityCommitment,
@@ -323,6 +351,9 @@ describe("background/services/zkIdentity", () => {
         instance.get.mockReturnValue(undefined);
       });
 
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
+
       const result = await zkIdentityService.deleteAllIdentities();
 
       expect(result).toBe(false);
@@ -330,6 +361,10 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("get connected identity", () => {
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should get connected identity properly", async () => {
       const [identityStorage, connectedIdentityStorage] = (SimpleStorage as jest.Mock).mock.instances as [
         MockStorage,
@@ -416,6 +451,9 @@ describe("background/services/zkIdentity", () => {
       identityStorage.get.mockReturnValue(undefined);
       connectedIdentityStorage.get.mockReturnValue(mockDefaultIdentityCommitment);
 
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
+
       const result = await zkIdentityService.getConnectedIdentity();
 
       expect(result).toBeUndefined();
@@ -429,6 +467,9 @@ describe("background/services/zkIdentity", () => {
       identityStorage.get.mockReturnValue(undefined);
       connectedIdentityStorage.get.mockReturnValue(mockDefaultIdentityCommitment);
 
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
+
       const result = await zkIdentityService.getConnectedIdentityData({}, {});
 
       expect(result).toBeUndefined();
@@ -441,6 +482,9 @@ describe("background/services/zkIdentity", () => {
       ];
       identityStorage.get.mockReturnValue(undefined);
       connectedIdentityStorage.get.mockReturnValue(mockDefaultIdentityCommitment);
+
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
 
       const result = await zkIdentityService.getConnectedIdentityCommitment();
 
@@ -502,21 +546,24 @@ describe("background/services/zkIdentity", () => {
   });
 
   describe("get identities", () => {
-    test("should get identity commitments properly", async () => {
-      const { commitments, identities } = await zkIdentityService.getIdentityCommitments();
-
-      expect(commitments).toStrictEqual([mockDefaultIdentityCommitment]);
-      expect(identities.size).toBe(mockDefaultIdentities.length);
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
     });
 
-    test("should get identities properly", async () => {
-      const identities = await zkIdentityService.getIdentities();
+    test("should get identity commitments properly", () => {
+      const { commitments } = zkIdentityService.getIdentityCommitments();
+
+      expect(commitments).toStrictEqual([mockDefaultIdentityCommitment]);
+    });
+
+    test("should get identities properly", () => {
+      const identities = zkIdentityService.getIdentities();
 
       expect(identities).toHaveLength(mockDefaultIdentities.length);
     });
 
-    test("should get identity properly", async () => {
-      const identity = await zkIdentityService.getIdentity(mockDefaultIdentityCommitment);
+    test("should get identity properly", () => {
+      const identity = zkIdentityService.getIdentity(mockDefaultIdentityCommitment);
 
       expect(identity).toStrictEqual({
         commitment: mockDefaultIdentityCommitment,
@@ -524,14 +571,14 @@ describe("background/services/zkIdentity", () => {
       });
     });
 
-    test("should return undefined if there is no such identity", async () => {
-      const identity = await zkIdentityService.getIdentity("unknown");
+    test("should return undefined if there is no such identity", () => {
+      const identity = zkIdentityService.getIdentity("unknown");
 
       expect(identity).toBeUndefined();
     });
 
-    test("should get number of identities properly", async () => {
-      const result = await zkIdentityService.getNumOfIdentities();
+    test("should get number of identities properly", () => {
+      const result = zkIdentityService.getNumOfIdentities();
 
       expect(result).toBe(mockDefaultIdentities.length);
     });
@@ -631,8 +678,13 @@ describe("background/services/zkIdentity", () => {
       expect(successResult).toBeDefined();
 
       (createNewIdentity as jest.Mock).mockReturnValue({
+        serialize: () => JSON.stringify({ secret: "1234", metadata: mockDefaultIdentity.metadata }),
         genIdentityCommitment: () => mockDefaultIdentityCommitment,
+        metadata: mockDefaultIdentity.metadata,
       });
+
+      await zkIdentityService.lock();
+      await zkIdentityService.unlock();
 
       await expect(
         zkIdentityService.createIdentity({
@@ -667,6 +719,10 @@ describe("background/services/zkIdentity", () => {
       urlOrigin: "http://localhost:3000",
     };
 
+    beforeEach(async () => {
+      await zkIdentityService.unlock();
+    });
+
     test("should import new identity properly", async () => {
       (createNewIdentity as jest.Mock).mockReturnValue({
         ...defaultNewIdentity,
@@ -680,6 +736,7 @@ describe("background/services/zkIdentity", () => {
 
     test("should not import new identity if there is the same identity in the store", async () => {
       (createNewIdentity as jest.Mock).mockReturnValue({
+        serialize: () => JSON.stringify({ secret: "1234", metadata: mockDefaultIdentity.metadata }),
         genIdentityCommitment: () => mockDefaultIdentityCommitment,
       });
 

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -164,6 +164,24 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
       });
   };
 
+  getIdentity = async (
+    commitment: string,
+  ): Promise<{ commitment: string; metadata: IIdentityMetadata } | undefined> => {
+    const identities = await this.getIdentitiesFromStore();
+    const serializedIdentity = identities.get(commitment);
+
+    if (!serializedIdentity) {
+      return undefined;
+    }
+
+    const identity = ZkIdentitySemaphore.genFromSerialized(serializedIdentity);
+
+    return {
+      commitment,
+      metadata: identity.metadata,
+    };
+  };
+
   getNumOfIdentities = async (): Promise<number> => {
     const identities = await this.getIdentitiesFromStore();
     return identities.size;

--- a/packages/app/src/background/services/zkIdentity/index.ts
+++ b/packages/app/src/background/services/zkIdentity/index.ts
@@ -42,27 +42,30 @@ const CONNECTED_IDENTITY_KEY = "@@CONNECTED-IDENTITY@@";
 export default class ZkIdentityService extends BaseService implements IBackupable {
   private static INSTANCE?: ZkIdentityService;
 
-  private identitiesStore: SimpleStorage;
+  private readonly identitiesStore: SimpleStorage;
 
-  private connectedIdentityStore: SimpleStorage;
+  private readonly connectedIdentityStore: SimpleStorage;
 
-  private notificationService: NotificationService;
+  private readonly notificationService: NotificationService;
 
-  private historyService: HistoryService;
+  private readonly historyService: HistoryService;
 
-  private browserController: BrowserUtils;
+  private readonly browserController: BrowserUtils;
 
-  private walletService: WalletService;
+  private readonly walletService: WalletService;
 
-  private cryptoService: CryptoService;
+  private readonly cryptoService: CryptoService;
 
-  private lockService: LockerService;
+  private readonly lockService: LockerService;
+
+  private identities: Map<string, string>;
 
   private connectedIdentity?: ZkIdentitySemaphore;
 
   private constructor() {
     super();
     this.connectedIdentity = undefined;
+    this.identities = new Map();
     this.identitiesStore = new SimpleStorage(IDENTITY_KEY);
     this.connectedIdentityStore = new SimpleStorage(CONNECTED_IDENTITY_KEY);
     this.notificationService = NotificationService.getInstance();
@@ -101,11 +104,8 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     return this.getConnectedIdentityMetadata(identity.metadata);
   };
 
-  getConnectedIdentity = async (): Promise<ZkIdentitySemaphore | undefined> => {
-    const identities = await this.getIdentitiesFromStore();
-
-    return this.readConnectedIdentity(identities);
-  };
+  getConnectedIdentity = async (): Promise<ZkIdentitySemaphore | undefined> =>
+    this.readConnectedIdentity(this.identities);
 
   private readConnectedIdentity = async (identities: Map<string, string>) => {
     const connectedIdentityCommitmentCipher = await this.connectedIdentityStore.get<string>();
@@ -128,33 +128,19 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     return this.connectedIdentity;
   };
 
-  private getIdentitiesFromStore = async (): Promise<Map<string, string>> => {
-    const ciphertext = await this.identitiesStore.get<string>();
+  getIdentityCommitments = (): { commitments: string[] } => {
+    const commitments = [...this.identities.keys()];
 
-    if (!ciphertext) {
-      return new Map();
-    }
-
-    const identitiesDecrypted = this.cryptoService.decrypt(ciphertext, { mode: ECryptMode.MNEMONIC });
-    const iterableIdentities = JSON.parse(identitiesDecrypted) as Iterable<readonly [string, string]>;
-
-    return new Map(iterableIdentities);
+    return { commitments };
   };
 
-  getIdentityCommitments = async (): Promise<{ commitments: string[]; identities: Map<string, string> }> => {
-    const identities = await this.getIdentitiesFromStore();
-    const commitments = [...identities.keys()];
-
-    return { commitments, identities };
-  };
-
-  getIdentities = async (): Promise<{ commitment: string; metadata: IIdentityMetadata }[]> => {
-    const { commitments, identities } = await this.getIdentityCommitments();
+  getIdentities = (): { commitment: string; metadata: IIdentityMetadata }[] => {
+    const { commitments } = this.getIdentityCommitments();
 
     return commitments
-      .filter((commitment) => identities.has(commitment))
+      .filter((commitment) => this.identities.has(commitment))
       .map((commitment) => {
-        const serializedIdentity = identities.get(commitment)!;
+        const serializedIdentity = this.identities.get(commitment)!;
         const identity = ZkIdentitySemaphore.genFromSerialized(serializedIdentity);
 
         return {
@@ -164,11 +150,8 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
       });
   };
 
-  getIdentity = async (
-    commitment: string,
-  ): Promise<{ commitment: string; metadata: IIdentityMetadata } | undefined> => {
-    const identities = await this.getIdentitiesFromStore();
-    const serializedIdentity = identities.get(commitment);
+  getIdentity = (commitment: string): { commitment: string; metadata: IIdentityMetadata } | undefined => {
+    const serializedIdentity = this.identities.get(commitment);
 
     if (!serializedIdentity) {
       return undefined;
@@ -182,15 +165,10 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     };
   };
 
-  getNumOfIdentities = async (): Promise<number> => {
-    const identities = await this.getIdentitiesFromStore();
-    return identities.size;
-  };
+  getNumOfIdentities = (): number => this.identities.size;
 
   connectIdentity = async ({ urlOrigin, identityCommitment }: IConnectIdentityArgs): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
-
-    const result = await this.updateConnectedIdentity({ identities, identityCommitment, urlOrigin });
+    const result = await this.updateConnectedIdentity({ identities: this.identities, identityCommitment, urlOrigin });
 
     if (result) {
       const status = await this.lockService.getStatus();
@@ -250,8 +228,7 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
   }
 
   setIdentityName = async ({ identityCommitment, name }: ISetIdentityNameArgs): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
-    const rawIdentity = identities.get(identityCommitment);
+    const rawIdentity = this.identities.get(identityCommitment);
 
     if (!rawIdentity) {
       return false;
@@ -259,16 +236,15 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
 
     const identity = ZkIdentitySemaphore.genFromSerialized(rawIdentity);
     identity.updateMetadata({ name });
-    identities.set(identityCommitment, identity.serialize());
-    await this.writeIdentities(identities);
+    this.identities.set(identityCommitment, identity.serialize());
+    await this.writeIdentities(this.identities);
     await this.refresh();
 
     return true;
   };
 
   setIdentityHost = async ({ identityCommitment, urlOrigin }: ISetIdentityHostArgs): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
-    const rawIdentity = identities.get(identityCommitment);
+    const rawIdentity = this.identities.get(identityCommitment);
 
     if (!rawIdentity) {
       return false;
@@ -276,27 +252,23 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
 
     const identity = ZkIdentitySemaphore.genFromSerialized(rawIdentity);
     identity.updateMetadata({ urlOrigin });
-    identities.set(identityCommitment, identity.serialize());
-    await this.writeIdentities(identities);
+    this.identities.set(identityCommitment, identity.serialize());
+    await this.writeIdentities(this.identities);
     await this.refresh();
 
     return true;
   };
 
   unlock = async (): Promise<boolean> => {
-    if (this.isUnlocked) {
-      return true;
-    }
+    await this.loadIdentities();
 
-    const identities = await this.getIdentitiesFromStore();
-
-    if (identities.size !== 0) {
-      const identity = await this.readConnectedIdentity(identities);
+    if (this.identities.size !== 0) {
+      const identity = await this.readConnectedIdentity(this.identities);
       const identityCommitment = identity ? bigintToHex(identity.genIdentityCommitment()) : undefined;
 
       if (identityCommitment) {
         await this.updateConnectedIdentity({
-          identities,
+          identities: this.identities,
           identityCommitment,
           urlOrigin: identity?.metadata.urlOrigin,
         });
@@ -309,7 +281,22 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     return true;
   };
 
-  lock = (): Promise<boolean> => this.onLock();
+  lock = async (): Promise<boolean> => this.onLock(this.onClean);
+
+  private onClean = (): boolean => {
+    this.identities.clear();
+    return true;
+  };
+
+  private loadIdentities = async () => {
+    const encryped = await this.identitiesStore.get<string>();
+
+    if (encryped) {
+      const identitiesDecrypted = this.cryptoService.decrypt(encryped, { mode: ECryptMode.MNEMONIC });
+      const iterableIdentities = JSON.parse(identitiesDecrypted) as Iterable<readonly [string, string]>;
+      this.identities = new Map(iterableIdentities);
+    }
+  };
 
   private clearConnectedIdentity = async (): Promise<void> => {
     if (!this.connectedIdentity) {
@@ -380,7 +367,7 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     urlOrigin,
     options,
   }: INewIdentityRequest): Promise<string | undefined> => {
-    const numOfIdentities = await this.getNumOfIdentities();
+    const numOfIdentities = this.getNumOfIdentities();
 
     const config = {
       ...options,
@@ -411,15 +398,14 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
   };
 
   private insertIdentity = async (newIdentity: ZkIdentitySemaphore): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
     const identityCommitment = bigintToHex(newIdentity.genIdentityCommitment());
 
-    if (identities.has(identityCommitment)) {
+    if (this.identities.has(identityCommitment)) {
       return false;
     }
 
-    identities.set(identityCommitment, newIdentity.serialize());
-    await this.writeIdentities(identities);
+    this.identities.set(identityCommitment, newIdentity.serialize());
+    await this.writeIdentities(this.identities);
     await this.refresh();
     await this.historyService.trackOperation(
       newIdentity.metadata.isImported ? OperationType.IMPORT_IDENTITY : OperationType.CREATE_IDENTITY,
@@ -453,21 +439,20 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
   };
 
   private refresh = async (): Promise<void> => {
-    const identities = await this.getIdentities();
+    const identities = this.getIdentities();
     await pushMessage(setIdentities(identities));
   };
 
   deleteIdentity = async (payload: { identityCommitment: string }): Promise<boolean> => {
     const { identityCommitment } = payload;
-    const identities = await this.getIdentitiesFromStore();
-    const identity = identities.get(identityCommitment);
+    const identity = this.identities.get(identityCommitment);
 
     if (!identity) {
       return false;
     }
 
-    identities.delete(identityCommitment);
-    await this.writeIdentities(identities);
+    this.identities.delete(identityCommitment);
+    await this.writeIdentities(this.identities);
     await this.historyService.trackOperation(OperationType.DELETE_IDENTITY, {
       identity: {
         commitment: identityCommitment,
@@ -481,12 +466,11 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
   };
 
   deleteAllIdentities = async (): Promise<boolean> => {
-    const identities = await this.getIdentitiesFromStore();
-
-    if (!identities.size) {
+    if (!this.identities.size) {
       return false;
     }
 
+    this.identities.clear();
     await Promise.all([this.clearConnectedIdentity(), this.identitiesStore.clear(), pushMessage(setIdentities([]))]);
     await this.historyService.trackOperation(OperationType.DELETE_ALL_IDENTITIES, {});
 
@@ -537,11 +521,13 @@ export default class ZkIdentityService extends BaseService implements IBackupabl
     }
 
     const backup = this.cryptoService.decrypt(encryptedBackup, { secret: backupPassword });
+    await this.loadIdentities();
 
     const backupIdentities = new Map(JSON.parse(backup) as Iterable<readonly [string, string]>);
-    const identities = await this.getIdentitiesFromStore();
-    const mergedIdentities = new Map([...identities, ...backupIdentities]);
+    const mergedIdentities = new Map([...this.identities, ...backupIdentities]);
 
     await this.writeIdentities(mergedIdentities);
+    await this.unlock();
+    await this.refresh();
   };
 }

--- a/packages/providers/src/services/event/types.ts
+++ b/packages/providers/src/services/event/types.ts
@@ -15,6 +15,7 @@ export type EventHandler = (data: unknown) => void;
  * @property {string} LOGIN - "login"
  * @property {string} IDENTITY_CHANGED - "identityChanged"
  * @property {string} LOGOUT - "logout"
+ * @property {string} APPROVAL - "approval"
  * @property {string} ADD_VERIFIABLE_CREDENTIAL - "addVerifiableCredential"
  * @property {string} VERIFIABLE_PRESENTATION_REQUEST - "verifiablePresentationRequest"
  * @property {string} GENERATE_VERIFIABLE_PRESENTATION - "generateVerifiablePresentation"
@@ -22,6 +23,9 @@ export type EventHandler = (data: unknown) => void;
  * @property {string} JOIN_GROUP - "joinGroup"
  * @property {string} GROUP_MERKLE_PROOF - "groupMerkleProof"
  * @property {string} IMPORT_IDENTITY - "importIdentity"
+ * @property {string} CREATE_IDENTITY - "createIdentity"
+ * @property {string} CONNECT_IDENTITY - "connectIdentity"
+ * @property {string} DISCONNECT_IDENTITY - "disconnectIdentity"
  * @property {string} USER_REJECT - "userReject"
  */
 export enum EventName {
@@ -37,6 +41,8 @@ export enum EventName {
   GROUP_MERKLE_PROOF = "groupMerkleProof",
   IMPORT_IDENTITY = "importIdentity",
   CREATE_IDENTITY = "createIdentity",
+  CONNECT_IDENTITY = "connectIdenity",
+  DISCONNECT_IDENTITY = "disconnectIdentity",
   USER_REJECT = "userReject",
 }
 

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -98,3 +98,11 @@ export interface ICreateIdentityArgs {
   trapdoor?: string;
   nullifier?: string;
 }
+
+export interface IIdenityConnection extends ConnectedIdentityMetadata {
+  commitment: string;
+}
+
+export interface IConnectArgs {
+  commitment: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,6 +23,8 @@ export type {
   ConnectedIdentityMetadata,
   IImportIdentityArgs,
   IImportIdentityRequestArgs,
+  IIdenityConnection,
+  IConnectArgs,
 } from "./identity";
 export { EWallet } from "./identity";
 export type {


### PR DESCRIPTION
## Explanation

This PR adds support for new connection service.

Details are below:
- [x] Add connect/disconnect events
- [x] Add connection service
- [x] Use cached identities instead of store ones 

## Related Issues

Blocked by #1046
Related to #945 

## Screenshots

N/A

## Manual Testing Steps

Check identities are loaded properly for backup, after delete, add and update.

## Pre-Merge Checklist

### Assignees Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### Reviewers Checklist

- [x] Manual testing checked and passed.
