### PR TITLE
feat: disconnect identity

### DIFF
--- a/packages/app/src/background/backgroundPage.ts
+++ b/packages/app/src/background/backgroundPage.ts
@@ -4,6 +4,7 @@ import browser, { type Runtime } from "webextension-polyfill";
 
 import "@src/background/appInit";
 import CryptKeeperController from "@src/background/cryptKeeper";
+import { sendReadyMessageToTabs } from "@src/background/shared/browser";
 import { createChromeOffscreen, deferredPromise, getBrowserPlatform } from "@src/background/shared/utils";
 import { isDebugMode } from "@src/config/env";
 import { BrowserPlatform } from "@src/constants";
@@ -28,30 +29,36 @@ browser.runtime.onConnect.addListener(async () => {
   log.debug("CryptKeeper onConnect Event, initializing completed...");
 });
 
-try {
-  const browserPlatform = getBrowserPlatform();
-  const app = new CryptKeeperController();
+const initialize = async () => {
+  try {
+    const browserPlatform = getBrowserPlatform();
+    const app = new CryptKeeperController();
 
-  app.initialize();
+    app.initialize();
 
-  browser.runtime.onMessage.addListener(async (request: IRequestHandler, sender: Runtime.MessageSender) => {
-    log.debug("Background: request: ", request);
+    browser.runtime.onMessage.addListener(async (request: IRequestHandler, sender: Runtime.MessageSender) => {
+      log.debug("Background: request: ", request);
 
-    if (browserPlatform !== BrowserPlatform.Firefox && request.source === "offscreen") {
-      await createChromeOffscreen();
-    }
+      if (browserPlatform !== BrowserPlatform.Firefox && request.source === "offscreen") {
+        await createChromeOffscreen();
+      }
 
-    try {
-      const response = await app.handle(request, sender);
-      log.debug("Background: response: ", response);
-      return [null, response];
-    } catch (e) {
-      return [(e as Error).message, null];
-    }
-  });
+      try {
+        const response = await app.handle(request, sender);
+        log.debug("Background: response: ", response);
+        return [null, response];
+      } catch (e) {
+        return [(e as Error).message, null];
+      }
+    });
 
-  log.debug("CryptKeeper initialization complete.");
-  resolveInitialization?.(true);
-} catch (error) {
-  rejectInitialization?.(error);
-}
+    await sendReadyMessageToTabs();
+
+    log.debug("CryptKeeper initialization complete.");
+    resolveInitialization?.(true);
+  } catch (error) {
+    rejectInitialization?.(error);
+  }
+};
+
+initialize();

--- a/packages/app/src/background/controllers/__tests__/browserUtils.test.ts
+++ b/packages/app/src/background/controllers/__tests__/browserUtils.test.ts
@@ -56,8 +56,8 @@ describe("background/controllers/browserUtils", () => {
     browserUtils.addRemoveWindowListener(callback);
     browserUtils.removeRemoveWindowListener(callback);
 
-    expect(browser.windows.onRemoved.addListener).toBeCalledTimes(1);
-    expect(browser.windows.onRemoved.removeListener).toBeCalledTimes(1);
+    expect(browser.windows.onRemoved.addListener).toHaveBeenCalledTimes(1);
+    expect(browser.windows.onRemoved.removeListener).toHaveBeenCalledTimes(1);
   });
 
   test("should clear storage properly", async () => {
@@ -65,7 +65,7 @@ describe("background/controllers/browserUtils", () => {
 
     await browserUtils.clearStorage();
 
-    expect(browser.storage.sync.clear).toBeCalledTimes(1);
+    expect(browser.storage.sync.clear).toHaveBeenCalledTimes(1);
   });
 
   test("should push event properly", async () => {
@@ -73,6 +73,6 @@ describe("background/controllers/browserUtils", () => {
 
     await browserUtils.pushEvent({ type: "type" }, { urlOrigin: "http://localhost:3000" });
 
-    expect(browser.tabs.sendMessage).toBeCalledTimes(2);
+    expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/app/src/background/controllers/__tests__/requestManager.test.ts
+++ b/packages/app/src/background/controllers/__tests__/requestManager.test.ts
@@ -49,8 +49,8 @@ describe("background/controllers/requestManager", () => {
 
     const requests = requestManager.getRequests();
     expect(requests).toHaveLength(1);
-    expect(pushMessage).toBeCalledTimes(1);
-    expect(pushMessage).toBeCalledWith(setPendingRequests(requests));
+    expect(pushMessage).toHaveBeenCalledTimes(1);
+    expect(pushMessage).toHaveBeenCalledWith(setPendingRequests(requests));
 
     const finalized = await requestManager.finalizeRequest({
       id: nonce.toString(),
@@ -75,9 +75,9 @@ describe("background/controllers/requestManager", () => {
 
     expect(finalized).toBe(true);
     expect(requestPromise).resolves.toStrictEqual({ done: true });
-    expect(pushMessage).toBeCalledTimes(2);
-    expect(mockDefaultBrowserUtils.addRemoveWindowListener).toBeCalledTimes(1);
-    expect(mockDefaultBrowserUtils.removeRemoveWindowListener).toBeCalledTimes(1);
+    expect(pushMessage).toHaveBeenCalledTimes(2);
+    expect(mockDefaultBrowserUtils.addRemoveWindowListener).toHaveBeenCalledTimes(1);
+    expect(mockDefaultBrowserUtils.removeRemoveWindowListener).toHaveBeenCalledTimes(1);
   });
 
   test("should reject request properly", async () => {

--- a/packages/app/src/background/cryptKeeper.ts
+++ b/packages/app/src/background/cryptKeeper.ts
@@ -182,6 +182,7 @@ export default class CryptKeeperController {
 
     // Connections
     this.handler.add(RPCInternalAction.CONNECT, this.lockService.ensure, this.connectionService.connect);
+    this.handler.add(RPCInternalAction.DISCONNECT, this.lockService.ensure, this.connectionService.disconnect);
     this.handler.add(
       RPCInternalAction.REVEAL_CONNECTED_IDENTITY_COMMITMENT,
       this.lockService.ensure,

--- a/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
+++ b/packages/app/src/background/services/approval/__tests__/approvalService.test.ts
@@ -135,8 +135,8 @@ describe("background/services/approval", () => {
       expect(canSkipApprove).toBe(true);
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(1);
-        expect(instance.set).toBeCalledWith(mockSerializedApprovals);
+        expect(instance.set).toHaveBeenCalledTimes(1);
+        expect(instance.set).toHaveBeenCalledWith(mockSerializedApprovals);
       });
     });
 
@@ -146,7 +146,7 @@ describe("background/services/approval", () => {
       expect(result).toStrictEqual({ urlOrigin: "unknown", canSkipApprove: false });
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(1);
+        expect(instance.set).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -159,8 +159,8 @@ describe("background/services/approval", () => {
       expect(hosts).toStrictEqual(mockDefaultHosts);
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(1);
-        expect(instance.set).toBeCalledWith(mockSerializedApprovals);
+        expect(instance.set).toHaveBeenCalledTimes(1);
+        expect(instance.set).toHaveBeenCalledWith(mockSerializedApprovals);
       });
     });
 
@@ -184,7 +184,7 @@ describe("background/services/approval", () => {
       expect(hosts).toHaveLength(0);
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(1);
+        expect(instance.set).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -246,7 +246,7 @@ describe("background/services/approval", () => {
       await approvalService.uploadEncryptedStorage("encrypted", "password");
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(1);
+        expect(instance.set).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -254,7 +254,7 @@ describe("background/services/approval", () => {
       await approvalService.uploadEncryptedStorage("", "");
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(0);
+        expect(instance.set).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -269,7 +269,7 @@ describe("background/services/approval", () => {
 
       await approvalService.downloadStorage();
 
-      expect(storage.get).toBeCalledTimes(1);
+      expect(storage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should restore storage properly", async () => {
@@ -277,8 +277,8 @@ describe("background/services/approval", () => {
 
       await approvalService.restoreStorage("storage");
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith("storage");
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith("storage");
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/services/backup/__tests__/BackupService.test.ts
+++ b/packages/app/src/background/services/backup/__tests__/BackupService.test.ts
@@ -156,8 +156,8 @@ describe("background/services/backup/BackupService", () => {
     );
 
     backupService.getBackupables().forEach((service) => {
-      expect(service.downloadStorage).toBeCalledTimes(0);
-      expect(service.restoreStorage).toBeCalledTimes(0);
+      expect(service.downloadStorage).toHaveBeenCalledTimes(0);
+      expect(service.restoreStorage).toHaveBeenCalledTimes(0);
     });
 
     backupService
@@ -191,8 +191,8 @@ describe("background/services/backup/BackupService", () => {
     await expect(backupService.upload({ content: fileContent, ...defaultPasswords })).rejects.toThrow("error");
 
     backupService.getBackupables().forEach((service) => {
-      expect(service.downloadStorage).toBeCalledTimes(1);
-      expect(service.restoreStorage).toBeCalledTimes(1);
+      expect(service.downloadStorage).toHaveBeenCalledTimes(1);
+      expect(service.restoreStorage).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/app/src/background/services/bandada/__tests__/BandadaService.test.ts
+++ b/packages/app/src/background/services/bandada/__tests__/BandadaService.test.ts
@@ -63,7 +63,7 @@ describe("background/services/bandada/BandadaService", () => {
 
     const result = await service.addMember(defaultAddMemberArgs);
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(true);
   });
 
@@ -76,7 +76,7 @@ describe("background/services/bandada/BandadaService", () => {
 
     const result = await service.addMember({ ...defaultAddMemberArgs, apiKey: undefined, inviteCode: "code" });
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(true);
   });
 
@@ -88,7 +88,7 @@ describe("background/services/bandada/BandadaService", () => {
     const service = BandadaService.getInstance();
 
     await expect(service.addMember(defaultAddMemberArgs)).rejects.toThrowError("Error 1,Error 2");
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   test("should throw error if add member is called without required params", async () => {
@@ -114,7 +114,7 @@ describe("background/services/bandada/BandadaService", () => {
 
     const proof = await service.generateMerkleProof(defaultGenerateProofArgs);
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(proof).toStrictEqual(defaultMerkleProof);
   });
 
@@ -126,7 +126,7 @@ describe("background/services/bandada/BandadaService", () => {
     const service = BandadaService.getInstance();
 
     await expect(service.generateMerkleProof(defaultGenerateProofArgs)).rejects.toThrowError("Error");
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   test("should check membership properly", async () => {
@@ -138,7 +138,7 @@ describe("background/services/bandada/BandadaService", () => {
 
     const result = await service.checkGroupMembership(defaultCheckMembershipArgs);
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(true);
   });
 
@@ -151,7 +151,7 @@ describe("background/services/bandada/BandadaService", () => {
 
     const result = await service.checkGroupMembership(defaultCheckMembershipArgs);
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(false);
   });
 
@@ -163,6 +163,6 @@ describe("background/services/bandada/BandadaService", () => {
     const service = BandadaService.getInstance();
 
     await expect(service.checkGroupMembership(defaultCheckMembershipArgs)).rejects.toThrowError("Error");
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
+++ b/packages/app/src/background/services/connection/__tests__/ConnectionService.test.ts
@@ -142,9 +142,9 @@ describe("background/services/connection", () => {
         height: 610,
       };
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.windows.create).toBeCalledTimes(1);
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.windows.create).toHaveBeenCalledTimes(1);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should connect properly", async () => {
@@ -154,8 +154,8 @@ describe("background/services/connection", () => {
       const connections = connectionService.getConnections();
       const identity = connectionService.getConnectedIdentity(defaultMetadata.urlOrigin!);
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith(mockSerializedConnections);
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith(mockSerializedConnections);
       expect(Object.entries(connections)).toHaveLength(1);
       expect(identity?.metadata.name).toBe(mockDefaultIdentity.metadata.name);
     });
@@ -185,8 +185,8 @@ describe("background/services/connection", () => {
       const connections = connectionService.getConnections();
       const identity = connectionService.getConnectedIdentity(defaultMetadata.urlOrigin!);
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith(JSON.stringify([]));
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith(JSON.stringify([]));
       expect(Object.entries(connections)).toHaveLength(0);
       expect(identity).toBeUndefined();
     });
@@ -201,8 +201,8 @@ describe("background/services/connection", () => {
       const connections = connectionService.getConnections();
       const identity = connectionService.getConnectedIdentity(defaultMetadata.urlOrigin!);
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith(JSON.stringify([]));
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith(JSON.stringify([]));
       expect(Object.entries(connections)).toHaveLength(0);
       expect(identity).toBeUndefined();
     });
@@ -241,15 +241,15 @@ describe("background/services/connection", () => {
         height: 610,
       };
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should reveal connected identity commitment", async () => {
       await connectionService.revealConnectedIdentityCommitment({}, defaultMetadata);
 
-      expect(browser.tabs.query).toBeCalledWith({});
-      expect(browser.tabs.sendMessage).toBeCalledTimes(2);
+      expect(browser.tabs.query).toHaveBeenCalledWith({});
+      expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(2);
       expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(1, defaultTabs[0].id, {
         type: EventName.REVEAL_COMMITMENT,
         payload: { commitment: mockDefaultConnection.commitment },
@@ -313,14 +313,14 @@ describe("background/services/connection", () => {
 
       await connectionService.uploadEncryptedStorage("encrypted", "password");
 
-      expect(storage.set).toBeCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledTimes(1);
     });
 
     test("should not upload encrypted connections if there is no data", async () => {
       await connectionService.uploadEncryptedStorage("", "");
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(0);
+        expect(instance.set).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -335,7 +335,7 @@ describe("background/services/connection", () => {
 
       await connectionService.downloadStorage();
 
-      expect(storage.get).toBeCalledTimes(1);
+      expect(storage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should restore storage properly", async () => {
@@ -343,8 +343,8 @@ describe("background/services/connection", () => {
 
       await connectionService.restoreStorage("storage");
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith("storage");
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith("storage");
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/services/credentials/__tests__/credentials.test.ts
+++ b/packages/app/src/background/services/credentials/__tests__/credentials.test.ts
@@ -149,7 +149,7 @@ describe("background/services/credentials", () => {
     test("should successfully create an add verifiable credential request", async () => {
       await verifiableCredentialsService.addVerifiableCredentialRequest(exampleCredentialString);
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
 
       const defaultOptions = {
         tabId: defaultPopupTab.id,
@@ -159,14 +159,14 @@ describe("background/services/credentials", () => {
         height: 610,
       };
 
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should successfully reject a verifiable credential request", async () => {
       await verifiableCredentialsService.rejectVerifiableCredentialRequest();
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.tabs.sendMessage).toBeCalledWith(defaultTabs[0].id, {
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(defaultTabs[0].id, {
         type: EventName.USER_REJECT,
         payload: { type: EventName.ADD_VERIFIABLE_CREDENTIAL },
       });
@@ -201,7 +201,7 @@ describe("background/services/credentials", () => {
       const [storage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage];
       await verifiableCredentialsService.renameVerifiableCredential(defaultArgs);
 
-      expect(storage.set).toBeCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -209,7 +209,7 @@ describe("background/services/credentials", () => {
     test("should successfully create a generate verifiable presentation request", async () => {
       await verifiableCredentialsService.generateVerifiablePresentationRequest(exampleVerifiablePresentationRequest);
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
 
       const defaultOptions = {
         tabId: defaultPopupTab.id,
@@ -219,14 +219,14 @@ describe("background/services/credentials", () => {
         height: 610,
       };
 
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should successfully reject a verifiable presentation request", async () => {
       await verifiableCredentialsService.rejectVerifiablePresentationRequest();
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.tabs.sendMessage).toBeCalledWith(defaultTabs[0].id, {
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(defaultTabs[0].id, {
         type: EventName.USER_REJECT,
         payload: { type: EventName.VERIFIABLE_PRESENTATION_REQUEST },
       });
@@ -235,8 +235,8 @@ describe("background/services/credentials", () => {
     test("should successfully generate a verifiable presentation", async () => {
       await verifiableCredentialsService.generateVerifiablePresentation(exampleVerifiablePresentation);
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.tabs.sendMessage).toBeCalledWith(defaultTabs[0].id, {
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(defaultTabs[0].id, {
         type: EventName.GENERATE_VERIFIABLE_PRESENTATION,
         payload: { verifiablePresentation: exampleVerifiablePresentation },
       });
@@ -267,8 +267,8 @@ describe("background/services/credentials", () => {
         ],
       };
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.tabs.sendMessage).toBeCalledWith(defaultTabs[0].id, {
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(defaultTabs[0].id, {
         type: EventName.GENERATE_VERIFIABLE_PRESENTATION,
         payload: { verifiablePresentation: signedVerifiablePresentation },
       });
@@ -282,8 +282,8 @@ describe("background/services/credentials", () => {
         address: exampleAddress,
       });
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
-      expect(browser.tabs.sendMessage).toBeCalledTimes(1);
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -366,8 +366,8 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.deleteVerifiableCredential(exampleCredentialHash);
 
-      expect(credentialsStorage.set).toBeCalledTimes(1);
-      expect(credentialsStorage.set).toBeCalledWith(JSON.stringify([[...credentialsMap.entries()][1]]));
+      expect(credentialsStorage.set).toHaveBeenCalledTimes(1);
+      expect(credentialsStorage.set).toHaveBeenCalledWith(JSON.stringify([[...credentialsMap.entries()][1]]));
     });
 
     test("should throw error if there is no vc hash", async () => {
@@ -379,7 +379,7 @@ describe("background/services/credentials", () => {
         "Verifiable Credential hash is required.",
       );
 
-      expect(credentialsStorage.set).toBeCalledTimes(0);
+      expect(credentialsStorage.set).toHaveBeenCalledTimes(0);
     });
 
     test("should not delete a verifiable credential if it does not exist", async () => {
@@ -390,7 +390,7 @@ describe("background/services/credentials", () => {
       await expect(verifiableCredentialsService.deleteVerifiableCredential("example hash")).rejects.toThrow(
         "Verifiable Credential does not exist.",
       );
-      expect(credentialsStorage.set).toBeCalledTimes(0);
+      expect(credentialsStorage.set).toHaveBeenCalledTimes(0);
     });
 
     test("should delete all verifiable credentials", async () => {
@@ -400,7 +400,7 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.deleteAllVerifiableCredentials();
 
-      expect(credentialsStorage.clear).toBeCalledTimes(1);
+      expect(credentialsStorage.clear).toHaveBeenCalledTimes(1);
     });
 
     test("should return false when deleting all verifiable credentials from empty storage", async () => {
@@ -411,7 +411,7 @@ describe("background/services/credentials", () => {
       await expect(verifiableCredentialsService.deleteAllVerifiableCredentials()).rejects.toThrow(
         "No Verifiable Credentials to delete.",
       );
-      expect(credentialsStorage.clear).toBeCalledTimes(0);
+      expect(credentialsStorage.clear).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -438,8 +438,8 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.uploadEncryptedStorage(credentialsStorageString, examplePassword);
 
-      expect(credentialsStorage.set).toBeCalledTimes(1);
-      expect(credentialsStorage.set).toBeCalledWith(credentialsStorageString);
+      expect(credentialsStorage.set).toHaveBeenCalledTimes(1);
+      expect(credentialsStorage.set).toHaveBeenCalledWith(credentialsStorageString);
     });
 
     test("should not upload encrypted identities if there is no data", async () => {
@@ -447,7 +447,7 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.uploadEncryptedStorage("", "");
 
-      expect(credentialsStorage.set).toBeCalledTimes(0);
+      expect(credentialsStorage.set).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error when trying upload incorrect backup", async () => {
@@ -461,7 +461,7 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.downloadStorage();
 
-      expect(storage.get).toBeCalledTimes(1);
+      expect(storage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should restore storage properly", async () => {
@@ -469,8 +469,8 @@ describe("background/services/credentials", () => {
 
       await verifiableCredentialsService.restoreStorage("storage");
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith("storage");
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith("storage");
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/services/injector/__tests__/injector.test.ts
+++ b/packages/app/src/background/services/injector/__tests__/injector.test.ts
@@ -123,9 +123,9 @@ describe("background/services/injector", () => {
 
       const result = service.getConnectedIdentityMetadata({}, { urlOrigin: mockDefaultUrlOrigin });
       expect(result).toStrictEqual(mockConnectedIdentity);
-      expect(mockIsApproved).toBeCalledTimes(1);
-      expect(mockCanSkip).toBeCalledTimes(1);
-      expect(mockAwaitLockServiceUnlock).toBeCalledTimes(0);
+      expect(mockIsApproved).toHaveBeenCalledTimes(1);
+      expect(mockCanSkip).toHaveBeenCalledTimes(1);
+      expect(mockAwaitLockServiceUnlock).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error if there is no url origin", () => {

--- a/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
+++ b/packages/app/src/background/services/lock/__tests__/lockerService.test.ts
@@ -123,7 +123,7 @@ describe("background/services/locker", () => {
       await lockService.resetPassword({ mnemonic: defaultMnemonic, password: defaultPassword });
       const status = await lockService.getStatus();
 
-      expect(passwordStorage.set).toBeCalledTimes(1);
+      expect(passwordStorage.set).toHaveBeenCalledTimes(1);
       expect(status).toStrictEqual({
         isInitialized: true,
         isMnemonicGenerated: true,
@@ -148,9 +148,9 @@ describe("background/services/locker", () => {
         isMnemonicGenerated: true,
       });
 
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setStatus(status));
-      expect(browser.tabs.sendMessage).toBeCalledTimes(defaultTabs.length);
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith(setStatus(status));
+      expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(defaultTabs.length);
 
       for (let index = 0; index < defaultTabs.length; index += 1) {
         expect(browser.tabs.sendMessage).toHaveBeenNthCalledWith(index + 1, defaultTabs[index].id, setStatus(status));
@@ -206,7 +206,7 @@ describe("background/services/locker", () => {
 
       expect(result).toBeDefined();
 
-      expect(mockGet).toBeCalledTimes(1);
+      expect(mockGet).toHaveBeenCalledTimes(1);
     });
 
     test("should not download encrypted password storage if storage is empty", async () => {
@@ -225,7 +225,7 @@ describe("background/services/locker", () => {
 
       await lockService.uploadEncryptedStorage("encrypted", defaultPassword);
 
-      expect(mockSet).toBeCalledTimes(0);
+      expect(mockSet).toHaveBeenCalledTimes(0);
     });
 
     test("should upload encrypted password storage if new user", async () => {
@@ -241,7 +241,7 @@ describe("background/services/locker", () => {
 
       await lockService.uploadEncryptedStorage("encrypted", defaultPassword);
 
-      expect(mockSet).toBeCalledTimes(1);
+      expect(mockSet).toHaveBeenCalledTimes(1);
     });
 
     test("should throw error when trying upload incorrect backup", async () => {
@@ -260,7 +260,7 @@ describe("background/services/locker", () => {
 
       await lockService.downloadStorage();
 
-      expect(storage.get).toBeCalledTimes(1);
+      expect(storage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should restore storage properly", async () => {
@@ -269,8 +269,8 @@ describe("background/services/locker", () => {
 
       await lockService.restoreStorage("storage");
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith("storage");
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith("storage");
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/services/misc/__tests__/miscStorageService.test.ts
+++ b/packages/app/src/background/services/misc/__tests__/miscStorageService.test.ts
@@ -32,8 +32,8 @@ describe("background/services/wallet", () => {
 
     await service.setExternalWalletConnection(newStorageValue);
 
-    expect(walletStorage.set).toBeCalledTimes(1);
-    expect(walletStorage.set).toBeCalledWith(newStorageValue);
+    expect(walletStorage.set).toHaveBeenCalledTimes(1);
+    expect(walletStorage.set).toHaveBeenCalledWith(newStorageValue);
   });
 
   test("should get initialization", async () => {
@@ -57,7 +57,7 @@ describe("background/services/wallet", () => {
 
     await service.setInitialization(newStorageValue);
 
-    expect(initializationStorage.set).toBeCalledTimes(1);
-    expect(initializationStorage.set).toBeCalledWith(newStorageValue);
+    expect(initializationStorage.set).toHaveBeenCalledTimes(1);
+    expect(initializationStorage.set).toHaveBeenCalledWith(newStorageValue);
   });
 });

--- a/packages/app/src/background/services/protocol/__tests__/protocol.test.ts
+++ b/packages/app/src/background/services/protocol/__tests__/protocol.test.ts
@@ -143,7 +143,7 @@ describe("background/services/protocol", () => {
       await expect(service.generateSemaphoreProof(defaultProofRequest, defaultMetadata)).rejects.toThrow(
         "CryptKeeper: connected identity is not found",
       );
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error there is no circuit and zkey files", async () => {
@@ -182,7 +182,7 @@ describe("background/services/protocol", () => {
 
       const result = await service.generateSemaphoreProof(defaultProofRequest, defaultMetadata);
       expect(result).toStrictEqual(emptyFullProof);
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error if generate proof is failed on firefox", async () => {
@@ -203,8 +203,8 @@ describe("background/services/protocol", () => {
       const result = await service.generateSemaphoreProof(defaultProofRequest, defaultMetadata);
 
       expect(result).toStrictEqual(emptyFullProof);
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith({
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith({
         method: RPCInternalAction.GENERATE_SEMAPHORE_PROOF_OFFSCREEN,
         payload: {
           ...omit(defaultProofRequest, ["merkleProofSource"]),
@@ -227,8 +227,8 @@ describe("background/services/protocol", () => {
       await expect(service.generateSemaphoreProof(defaultProofRequest, defaultMetadata)).rejects.toThrowError(
         `CryptKeeper: Error in generating Semaphore proof error`,
       );
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith({
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith({
         method: RPCInternalAction.GENERATE_SEMAPHORE_PROOF_OFFSCREEN,
         payload: {
           ...omit(defaultProofRequest, ["merkleProofSource"]),
@@ -253,7 +253,7 @@ describe("background/services/protocol", () => {
         `CryptKeeper: Error in generating Semaphore proof error`,
       );
 
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -277,8 +277,8 @@ describe("background/services/protocol", () => {
       const result = await service.generateRLNProof(defaultProofRequest, defaultMetadata);
 
       expect(result).toStrictEqual(emptyFullProof);
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith({
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith({
         method: RPCInternalAction.GENERATE_RLN_PROOF_OFFSCREEN,
         payload: {
           ...omit(defaultProofRequest, ["merkleProofSource"]),
@@ -301,8 +301,8 @@ describe("background/services/protocol", () => {
       await expect(service.generateRLNProof(defaultProofRequest, defaultMetadata)).rejects.toThrowError(
         `CryptKeeper: Error in generating RLN proof error`,
       );
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith({
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith({
         method: RPCInternalAction.GENERATE_RLN_PROOF_OFFSCREEN,
         payload: {
           ...omit(defaultProofRequest, ["merkleProofSource"]),
@@ -326,7 +326,7 @@ describe("background/services/protocol", () => {
         `CryptKeeper: Error in generating RLN proof error`,
       );
 
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error if there is no origin url in metadata", async () => {
@@ -343,7 +343,7 @@ describe("background/services/protocol", () => {
       await expect(service.generateRLNProof(defaultProofRequest, defaultMetadata)).rejects.toThrow(
         "CryptKeeper: connected identity is not found",
       );
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error if user rejected semaphore approve request", async () => {
@@ -366,7 +366,7 @@ describe("background/services/protocol", () => {
       const result = await service.generateRLNProof(defaultProofRequest, defaultMetadata);
 
       expect(result).toStrictEqual(emptyFullProof);
-      expect(pushMessage).toBeCalledTimes(0);
+      expect(pushMessage).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error if generate proof is failed", async () => {

--- a/packages/app/src/background/services/storage/__tests__/simpleStorage.test.ts
+++ b/packages/app/src/background/services/storage/__tests__/simpleStorage.test.ts
@@ -13,8 +13,8 @@ describe("background/services/simpleStorage", () => {
 
     await storage.set("value");
 
-    expect(browser.storage.sync.set).toBeCalledTimes(1);
-    expect(browser.storage.sync.set).toBeCalledWith({
+    expect(browser.storage.sync.set).toHaveBeenCalledTimes(1);
+    expect(browser.storage.sync.set).toHaveBeenCalledWith({
       key: "value",
     });
   });
@@ -24,8 +24,8 @@ describe("background/services/simpleStorage", () => {
 
     await storage.clear();
 
-    expect(browser.storage.sync.remove).toBeCalledTimes(1);
-    expect(browser.storage.sync.remove).toBeCalledWith("key");
+    expect(browser.storage.sync.remove).toHaveBeenCalledTimes(1);
+    expect(browser.storage.sync.remove).toHaveBeenCalledWith("key");
   });
 
   test("should get data properly", async () => {
@@ -33,8 +33,8 @@ describe("background/services/simpleStorage", () => {
 
     const value = await storage.get();
 
-    expect(browser.storage.sync.get).toBeCalledTimes(1);
-    expect(browser.storage.sync.get).toBeCalledWith("key");
+    expect(browser.storage.sync.get).toHaveBeenCalledTimes(1);
+    expect(browser.storage.sync.get).toHaveBeenCalledWith("key");
     expect(value).toBeNull();
   });
 });

--- a/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
+++ b/packages/app/src/background/services/wallet/__tests__/walletService.test.ts
@@ -101,7 +101,7 @@ describe("background/services/wallet", () => {
 
       await walletService.generateKeyPair();
 
-      expect(keyStorage.set).toBeCalledTimes(1);
+      expect(keyStorage.set).toHaveBeenCalledTimes(1);
     });
 
     test("should generate key pair properly", async () => {
@@ -109,8 +109,8 @@ describe("background/services/wallet", () => {
 
       const [keyStorage, mnemonicStorage] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage, MockStorage];
 
-      expect(keyStorage.set).toBeCalledTimes(1);
-      expect(mnemonicStorage.get).toBeCalledTimes(1);
+      expect(keyStorage.set).toHaveBeenCalledTimes(1);
+      expect(mnemonicStorage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should not generate key pair if there is no mnemonic", async () => {
@@ -249,7 +249,7 @@ describe("background/services/wallet", () => {
 
       await walletService.changeMnemonicPassword({ mnemonic: defaultMnemonic, password: "password" });
 
-      expect(mnemonicStorage.set).toBeCalledTimes(1);
+      expect(mnemonicStorage.set).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -289,9 +289,9 @@ describe("background/services/wallet", () => {
       const selected = await walletService.selectAccount(ZERO_ADDRESS);
 
       expect(selected).toBe(ZERO_ADDRESS);
-      expect(selectedAccountStorage.set).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledTimes(1);
-      expect(pushMessage).toBeCalledWith(setSelectedAccount(ZERO_ADDRESS));
+      expect(selectedAccountStorage.set).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledWith(setSelectedAccount(ZERO_ADDRESS));
     });
 
     test("should get selected account", async () => {
@@ -350,9 +350,9 @@ describe("background/services/wallet", () => {
 
       await walletService.uploadEncryptedStorage(mockBackup, "password");
 
-      expect(accountStorage.set).toBeCalledTimes(1);
-      expect(accountStorage.set).toBeCalledWith(mockSerializedAccounts);
-      expect(mnemonicStorage.set).toBeCalledTimes(0);
+      expect(accountStorage.set).toHaveBeenCalledTimes(1);
+      expect(accountStorage.set).toHaveBeenCalledWith(mockSerializedAccounts);
+      expect(mnemonicStorage.set).toHaveBeenCalledTimes(0);
     });
 
     test("should upload encrypted data with empty storage", async () => {
@@ -365,17 +365,17 @@ describe("background/services/wallet", () => {
 
       await walletService.uploadEncryptedStorage(mockBackup, "password");
 
-      expect(accountStorage.set).toBeCalledTimes(1);
-      expect(accountStorage.set).toBeCalledWith(mockSerializedAccounts);
-      expect(mnemonicStorage.set).toBeCalledTimes(1);
-      expect(mnemonicStorage.set).toBeCalledWith(defaultMnemonic);
+      expect(accountStorage.set).toHaveBeenCalledTimes(1);
+      expect(accountStorage.set).toHaveBeenCalledWith(mockSerializedAccounts);
+      expect(mnemonicStorage.set).toHaveBeenCalledTimes(1);
+      expect(mnemonicStorage.set).toHaveBeenCalledWith(defaultMnemonic);
     });
 
     test("should not upload encrypted keys if there is no data", async () => {
       await walletService.uploadEncryptedStorage("", "");
 
       (SimpleStorage as jest.Mock).mock.instances.forEach((instance: MockStorage) => {
-        expect(instance.set).toBeCalledTimes(0);
+        expect(instance.set).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -393,8 +393,8 @@ describe("background/services/wallet", () => {
 
       await walletService.downloadStorage();
 
-      expect(accountsStorage.get).toBeCalledTimes(1);
-      expect(mnemonicStorage.get).toBeCalledTimes(1);
+      expect(accountsStorage.get).toHaveBeenCalledTimes(1);
+      expect(mnemonicStorage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should return null if storage is empty", async () => {
@@ -418,10 +418,10 @@ describe("background/services/wallet", () => {
 
       await walletService.restoreStorage({ accounts: "accounts", mnemonic: "mnemonic" });
 
-      expect(mnemonicStorage.set).toBeCalledTimes(1);
-      expect(mnemonicStorage.set).toBeCalledWith("mnemonic");
-      expect(accountStorage.set).toBeCalledTimes(1);
-      expect(accountStorage.set).toBeCalledWith("accounts");
+      expect(mnemonicStorage.set).toHaveBeenCalledTimes(1);
+      expect(mnemonicStorage.set).toHaveBeenCalledWith("mnemonic");
+      expect(accountStorage.set).toHaveBeenCalledTimes(1);
+      expect(accountStorage.set).toHaveBeenCalledWith("accounts");
     });
 
     test("should restore empty storage properly", async () => {
@@ -432,10 +432,10 @@ describe("background/services/wallet", () => {
 
       await walletService.restoreStorage(null);
 
-      expect(mnemonicStorage.set).toBeCalledTimes(1);
-      expect(mnemonicStorage.set).toBeCalledWith(null);
-      expect(accountStorage.set).toBeCalledTimes(1);
-      expect(accountStorage.set).toBeCalledWith(null);
+      expect(mnemonicStorage.set).toHaveBeenCalledTimes(1);
+      expect(mnemonicStorage.set).toHaveBeenCalledWith(null);
+      expect(accountStorage.set).toHaveBeenCalledTimes(1);
+      expect(accountStorage.set).toHaveBeenCalledWith(null);
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
+++ b/packages/app/src/background/services/zkIdentity/__tests__/zkIdentity.test.ts
@@ -234,7 +234,7 @@ describe("background/services/zkIdentity", () => {
       const result = await zkIdentityService.deleteAllIdentities();
 
       expect(result).toBe(true);
-      expect(pushMessage).toBeCalledTimes(1);
+      expect(pushMessage).toHaveBeenCalledTimes(1);
     });
 
     test("should not delete all identities if there is no any identity", async () => {
@@ -291,7 +291,7 @@ describe("background/services/zkIdentity", () => {
     test("should request a create identity modal properly", async () => {
       await zkIdentityService.createIdentityRequest({ urlOrigin: "http://localhost:3000" });
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
 
       const defaultOptions = {
         tabId: defaultPopupTab.id,
@@ -301,7 +301,7 @@ describe("background/services/zkIdentity", () => {
         height: 610,
       };
 
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should create a new identity with ethereum wallet properly", async () => {
@@ -436,7 +436,7 @@ describe("background/services/zkIdentity", () => {
         { urlOrigin: "http://localhost:3000" },
       );
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
 
       const defaultOptions = {
         tabId: defaultPopupTab.id,
@@ -446,13 +446,13 @@ describe("background/services/zkIdentity", () => {
         height: 610,
       };
 
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
 
     test("should request an import identity modal without origin properly", async () => {
       await zkIdentityService.importRequest({ trapdoor: defaultArgs.trapdoor, nullifier: defaultArgs.nullifier }, {});
 
-      expect(browser.tabs.query).toBeCalledWith({ lastFocusedWindow: true });
+      expect(browser.tabs.query).toHaveBeenCalledWith({ lastFocusedWindow: true });
 
       const defaultOptions = {
         tabId: defaultPopupTab.id,
@@ -462,7 +462,7 @@ describe("background/services/zkIdentity", () => {
         height: 610,
       };
 
-      expect(browser.windows.create).toBeCalledWith(defaultOptions);
+      expect(browser.windows.create).toHaveBeenCalledWith(defaultOptions);
     });
   });
 
@@ -486,14 +486,14 @@ describe("background/services/zkIdentity", () => {
       await zkIdentityService.uploadEncryptedStorage("encrypted", "password");
 
       const [instance] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage, MockStorage];
-      expect(instance.set).toBeCalledTimes(1);
+      expect(instance.set).toHaveBeenCalledTimes(1);
     });
 
     test("should not upload encrypted identities if there is no data", async () => {
       await zkIdentityService.uploadEncryptedStorage("", "");
 
       const [instance] = (SimpleStorage as jest.Mock).mock.instances as [MockStorage, MockStorage];
-      expect(instance.set).toBeCalledTimes(0);
+      expect(instance.set).toHaveBeenCalledTimes(0);
     });
 
     test("should throw error when trying upload incorrect backup", async () => {
@@ -507,7 +507,7 @@ describe("background/services/zkIdentity", () => {
 
       await zkIdentityService.downloadStorage();
 
-      expect(storage.get).toBeCalledTimes(1);
+      expect(storage.get).toHaveBeenCalledTimes(1);
     });
 
     test("should restore storage properly", async () => {
@@ -515,8 +515,8 @@ describe("background/services/zkIdentity", () => {
 
       await zkIdentityService.restoreStorage("storage");
 
-      expect(storage.set).toBeCalledTimes(1);
-      expect(storage.set).toBeCalledWith("storage");
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledWith("storage");
     });
 
     test("should throw error when trying to restore incorrect data", async () => {

--- a/packages/app/src/background/shared/__tests__/browser.test.ts
+++ b/packages/app/src/background/shared/__tests__/browser.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import browser from "webextension-polyfill";
+
+import { checkForLastError, checkForLastErrorAndLog, sendReadyMessageToTabs } from "../browser";
+
+describe("background/shared/browser", () => {
+  const defaultTabs = [{ id: 1 }, {}];
+  const logSpy = jest.spyOn(console, "error").mockImplementation(() => null);
+
+  beforeEach(() => {
+    (browser.tabs.query as jest.Mock).mockResolvedValue(defaultTabs);
+  });
+
+  afterEach(() => {
+    browser.runtime.lastError = undefined;
+    jest.clearAllMocks();
+  });
+
+  test("should check for last error and log properly", () => {
+    browser.runtime.lastError = new Error("error");
+
+    const error = checkForLastErrorAndLog();
+
+    expect(error).toStrictEqual(browser.runtime.lastError);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(error);
+  });
+
+  test("should not check for last error if there is no error", () => {
+    browser.runtime.lastError = undefined;
+
+    const error = checkForLastErrorAndLog();
+
+    expect(error).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("should check for last error properly", () => {
+    browser.runtime.lastError = { message: "error" };
+
+    const error = checkForLastError();
+
+    expect(error).toStrictEqual(new Error(browser.runtime.lastError.message));
+  });
+
+  test("should send messages to all the tabs", async () => {
+    await sendReadyMessageToTabs();
+
+    expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("should handle error while sending messages to all the tabs", async () => {
+    const error = new Error("error");
+    browser.runtime.lastError = error;
+    (browser.tabs.query as jest.Mock).mockRejectedValue(error);
+
+    await sendReadyMessageToTabs();
+
+    expect(browser.tabs.sendMessage).toHaveBeenCalledTimes(0);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/app/src/background/shared/__tests__/utils.test.ts
+++ b/packages/app/src/background/shared/__tests__/utils.test.ts
@@ -99,8 +99,8 @@ describe("background/shared/utils", () => {
   test("should create a chrome offscreen properly", async () => {
     await createChromeOffscreen();
 
-    expect(global.chrome.offscreen.hasDocument).toBeCalledTimes(1);
-    expect(global.chrome.offscreen.createDocument).toBeCalledTimes(1);
+    expect(global.chrome.offscreen.hasDocument).toHaveBeenCalledTimes(1);
+    expect(global.chrome.offscreen.createDocument).toHaveBeenCalledTimes(1);
     expect(global.chrome.offscreen.createDocument).toHaveBeenCalledWith({
       url: "offscreen.html",
       reasons: [global.chrome.offscreen.Reason.DOM_SCRAPING],
@@ -112,8 +112,8 @@ describe("background/shared/utils", () => {
     (global.chrome.offscreen.hasDocument as jest.Mock).mockReturnValueOnce(true);
     await createChromeOffscreen();
 
-    expect(global.chrome.offscreen.hasDocument).toBeCalledTimes(1);
-    expect(global.chrome.offscreen.createDocument).toBeCalledTimes(0);
+    expect(global.chrome.offscreen.hasDocument).toHaveBeenCalledTimes(1);
+    expect(global.chrome.offscreen.createDocument).toHaveBeenCalledTimes(0);
   });
 
   test("should throw an error if it's not possible to create offscreen", async () => {

--- a/packages/app/src/background/shared/browser.ts
+++ b/packages/app/src/background/shared/browser.ts
@@ -1,0 +1,52 @@
+import has from "lodash/has";
+import browser, { type Runtime } from "webextension-polyfill";
+
+const ACTION_TYPE = "CRYPTKEEPER_READY";
+
+export async function sendReadyMessageToTabs(): Promise<void> {
+  const tabs = await browser.tabs
+    .query({ url: "<all_urls>", windowType: "normal" })
+    .then((tab) => {
+      checkForLastErrorAndLog();
+      return tab;
+    })
+    .catch(() => {
+      checkForLastErrorAndLog();
+    });
+
+  tabs?.forEach((tab) => {
+    if (tab.id === undefined) {
+      return;
+    }
+
+    browser.tabs
+      .sendMessage(tab.id, { type: ACTION_TYPE })
+      .then(checkForLastErrorAndLog)
+      .catch(checkForLastErrorAndLog);
+  });
+}
+
+export function checkForLastErrorAndLog(): Runtime.PropertyLastErrorType | Error | undefined {
+  const error = checkForLastError();
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+
+  return error;
+}
+
+export function checkForLastError(): Runtime.PropertyLastErrorType | Error | undefined {
+  const { lastError } = browser.runtime;
+
+  if (!lastError) {
+    return undefined;
+  }
+
+  if (has(lastError, "stack") && lastError.message) {
+    return lastError;
+  }
+
+  return new Error(lastError.message);
+}

--- a/packages/app/src/connectors/__tests__/cryptKeeper.test.ts
+++ b/packages/app/src/connectors/__tests__/cryptKeeper.test.ts
@@ -55,8 +55,8 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.activate();
 
-    expect(mockActions.update).toBeCalledTimes(1);
-    expect(mockActions.update).toBeCalledWith({ accounts: mockAddresses });
+    expect(mockActions.update).toHaveBeenCalledTimes(1);
+    expect(mockActions.update).toHaveBeenCalledWith({ accounts: mockAddresses });
   });
 
   test("should activate connector twice properly", async () => {
@@ -65,7 +65,7 @@ describe("connectors/cryptKeeper", () => {
     await connector.activate();
     await connector.activate();
 
-    expect(mockActions.update).toBeCalledTimes(2);
+    expect(mockActions.update).toHaveBeenCalledTimes(2);
   });
 
   test("should start activation properly", async () => {
@@ -78,7 +78,7 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.activate();
 
-    expect(mockActions.startActivation).toBeCalledTimes(1);
+    expect(mockActions.startActivation).toHaveBeenCalledTimes(1);
   });
 
   test("should throw error if there is no provider", async () => {
@@ -87,8 +87,8 @@ describe("connectors/cryptKeeper", () => {
     const connector = new CryptkeeperConnector(mockActions);
 
     await expect(connector.activate()).rejects.toThrow("No CryptKeeper extension installed");
-    expect(mockActions.startActivation).toBeCalledTimes(1);
-    expect(cancelActivation).toBeCalledTimes(1);
+    expect(mockActions.startActivation).toHaveBeenCalledTimes(1);
+    expect(cancelActivation).toHaveBeenCalledTimes(1);
   });
 
   test("should handle incomming events properly", async () => {
@@ -97,12 +97,12 @@ describe("connectors/cryptKeeper", () => {
     const connector = new CryptkeeperConnector(mockActions);
 
     await connector.activate();
-    await waitFor(() => expect(mockActions.update).toBeCalledTimes(1));
-    await waitFor(() => expect(mockActions.update).toBeCalledWith({ accounts: mockAddresses }));
+    await waitFor(() => expect(mockActions.update).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockActions.update).toHaveBeenCalledWith({ accounts: mockAddresses }));
 
     await Promise.resolve(mockProvider.emit(EventName.LOGOUT));
 
-    expect(mockActions.resetState).toBeCalledTimes(1);
+    expect(mockActions.resetState).toHaveBeenCalledTimes(1);
   });
 
   test("should not connect eagerly if there is no provider", async () => {
@@ -111,8 +111,8 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.connectEagerly();
 
-    expect(mockActions.startActivation).toBeCalledTimes(1);
-    expect(cancelActivation).toBeCalledTimes(1);
+    expect(mockActions.startActivation).toHaveBeenCalledTimes(1);
+    expect(cancelActivation).toHaveBeenCalledTimes(1);
   });
 
   test("should reset state when connecting eagerly throws an error", async () => {
@@ -123,9 +123,9 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.connectEagerly();
 
-    expect(mockActions.startActivation).toBeCalledTimes(1);
-    expect(mockActions.resetState).toBeCalledTimes(1);
-    expect(cancelActivation).toBeCalledTimes(1);
+    expect(mockActions.startActivation).toHaveBeenCalledTimes(1);
+    expect(mockActions.resetState).toHaveBeenCalledTimes(1);
+    expect(cancelActivation).toHaveBeenCalledTimes(1);
   });
 
   test("should connect eagerly and set accounts properly", async () => {
@@ -135,8 +135,8 @@ describe("connectors/cryptKeeper", () => {
 
     await connector.connectEagerly();
 
-    expect(mockActions.startActivation).toBeCalledTimes(1);
-    expect(mockActions.update).toBeCalledTimes(1);
-    expect(mockActions.update).toBeCalledWith({ accounts: mockAddresses });
+    expect(mockActions.startActivation).toHaveBeenCalledTimes(1);
+    expect(mockActions.update).toHaveBeenCalledTimes(1);
+    expect(mockActions.update).toHaveBeenCalledWith({ accounts: mockAddresses });
   });
 });

--- a/packages/app/src/constants/rpcInternalActions.ts
+++ b/packages/app/src/constants/rpcInternalActions.ts
@@ -12,6 +12,7 @@ export enum RPCInternalAction {
   CREATE_IDENTITY_REQUEST = "rpc/identity/createRequest",
   IMPORT_IDENTITY = "rpc/identity/import",
   CONNECT = "rpc/connection/connect",
+  DISCONNECT = "rpc/connection/disconnect",
   GET_CONNECTIONS = "rpc/connection/get",
   SET_IDENTITY_NAME = "rpc/identity/setIdentityName",
   DELETE_IDENTITY = "rpc/identity/deleteIdentity",

--- a/packages/app/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/packages/app/src/ui/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -66,7 +66,7 @@ describe("ui/components/Header", () => {
     const item = await findByText("Connect MetaMask");
     await act(async () => Promise.resolve(item.click()));
 
-    expect(defaultHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should render properly activating state", async () => {
@@ -90,7 +90,7 @@ describe("ui/components/Header", () => {
     const metamaskInstall = await findByText("Install MetaMask");
     await act(async () => Promise.resolve(metamaskInstall.click()));
 
-    expect(defaultHookData.onGoToMetamaskPage).toBeCalledTimes(1);
+    expect(defaultHookData.onGoToMetamaskPage).toHaveBeenCalledTimes(1);
   });
 
   test("should go to settings page", async () => {
@@ -99,7 +99,7 @@ describe("ui/components/Header", () => {
     const settings = await findByText("Settings");
     await act(async () => Promise.resolve(settings.click()));
 
-    expect(defaultHookData.onGoToSettings).toBeCalledTimes(1);
+    expect(defaultHookData.onGoToSettings).toHaveBeenCalledTimes(1);
   });
 
   test("should lock app properly", async () => {
@@ -108,7 +108,7 @@ describe("ui/components/Header", () => {
     const lock = await findByText("Lock");
     await act(async () => Promise.resolve(lock.click()));
 
-    expect(defaultHookData.onLock).toBeCalledTimes(1);
+    expect(defaultHookData.onLock).toHaveBeenCalledTimes(1);
   });
 
   test("should disconnect metamask properly", async () => {
@@ -119,7 +119,7 @@ describe("ui/components/Header", () => {
     const disconnect = await findByText("Disconnect MetaMask");
     await act(async () => Promise.resolve(disconnect.click()));
 
-    expect(defaultHookData.onDisconnect).toBeCalledTimes(1);
+    expect(defaultHookData.onDisconnect).toHaveBeenCalledTimes(1);
   });
 
   test("should select account properly", async () => {
@@ -129,7 +129,7 @@ describe("ui/components/Header", () => {
     const account = await findByTestId(`${cryptKeeperAccount.type}-${cryptKeeperAccount.address}`);
     await act(async () => Promise.resolve(account.click()));
 
-    expect(defaultHookData.onSelectAccount).toBeCalledTimes(1);
-    expect(defaultHookData.onSelectAccount).toBeCalledWith(cryptKeeperAccount.address);
+    expect(defaultHookData.onSelectAccount).toHaveBeenCalledTimes(1);
+    expect(defaultHookData.onSelectAccount).toHaveBeenCalledWith(cryptKeeperAccount.address);
   });
 });

--- a/packages/app/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
+++ b/packages/app/src/ui/components/AccountMenu/__tests__/useAccountMenu.test.ts
@@ -81,8 +81,8 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(() => Promise.resolve(result.current.onGoToMetamaskPage()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith("https://metamask.io/");
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith("https://metamask.io/");
   });
 
   test("should go to settings page", async () => {
@@ -90,8 +90,8 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onGoToSettings()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should open and close menu properly", async () => {
@@ -117,7 +117,7 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onLock()));
 
-    expect(defaultWalletHookData.onLock).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onLock).toHaveBeenCalledTimes(1);
   });
 
   test("should connect properly", async () => {
@@ -125,7 +125,7 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onConnect()));
 
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should disconnect properly", async () => {
@@ -133,7 +133,7 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onDisconnect()));
 
-    expect(defaultWalletHookData.onDisconnect).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onDisconnect).toHaveBeenCalledTimes(1);
   });
 
   test("should select account properly", async () => {
@@ -141,9 +141,9 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onSelectAccount(ZERO_ADDRESS)));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(selectAccount).toBeCalledTimes(1);
-    expect(selectAccount).toBeCalledWith(ZERO_ADDRESS);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(selectAccount).toHaveBeenCalledTimes(1);
+    expect(selectAccount).toHaveBeenCalledWith(ZERO_ADDRESS);
   });
 
   test("should open extension in new tab properly", async () => {
@@ -151,7 +151,7 @@ describe("ui/components/AccountMenu/useAccountMenu", () => {
 
     await act(async () => Promise.resolve(result.current.onOpenInNewTab()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(`${window.location.pathname}${window.location.hash}`);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(`${window.location.pathname}${window.location.hash}`);
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/__tests__/useConfirmRequestModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/__tests__/useConfirmRequestModal.test.ts
@@ -64,14 +64,14 @@ describe("ui/components/ConfirmRequestModal/useConfirmRequestModal", () => {
     await act(async () => Promise.resolve(result.current.accept()));
     await waitFor(() => !result.current.loading);
 
-    expect(finalizeRequest).toBeCalledTimes(1);
-    expect(finalizeRequest).toBeCalledWith({
+    expect(finalizeRequest).toHaveBeenCalledTimes(1);
+    expect(finalizeRequest).toHaveBeenCalledWith({
       id: "1",
       status: RequestResolutionStatus.ACCEPT,
       data: undefined,
     });
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should handle accept error", async () => {
@@ -93,14 +93,14 @@ describe("ui/components/ConfirmRequestModal/useConfirmRequestModal", () => {
     await act(async () => Promise.resolve(result.current.reject()));
     await waitFor(() => !result.current.loading);
 
-    expect(finalizeRequest).toBeCalledTimes(1);
-    expect(finalizeRequest).toBeCalledWith({
+    expect(finalizeRequest).toHaveBeenCalledTimes(1);
+    expect(finalizeRequest).toHaveBeenCalledWith({
       id: "1",
       status: "reject",
       data: undefined,
     });
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should close popup if trying to reject empty request", async () => {
@@ -111,9 +111,9 @@ describe("ui/components/ConfirmRequestModal/useConfirmRequestModal", () => {
     await act(async () => Promise.resolve(result.current.reject()));
     await waitFor(() => !result.current.loading);
 
-    expect(finalizeRequest).toBeCalledTimes(0);
-    expect(fetchPendingRequests).toBeCalledTimes(0);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(finalizeRequest).toHaveBeenCalledTimes(0);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(0);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should handle reject error", async () => {

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/ConnectionApprovalModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/ConnectionApprovalModal.test.tsx
@@ -71,7 +71,7 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal",
       button.click();
     });
 
-    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+    expect(defaultHookData.onAccept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject approval properly", async () => {
@@ -82,7 +82,7 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal",
       button.click();
     });
 
-    expect(defaultHookData.onReject).toBeCalledTimes(1);
+    expect(defaultHookData.onReject).toHaveBeenCalledTimes(1);
   });
 
   test("should select permanent approval properly", async () => {
@@ -93,6 +93,6 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal",
       label.click();
     });
 
-    expect(defaultHookData.onSetApproval).toBeCalledTimes(1);
+    expect(defaultHookData.onSetApproval).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/useConnectionApprovalModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/__tests__/useConnectionApprovalModal.test.ts
@@ -84,7 +84,7 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/u
       result.current.onAccept();
     });
 
-    expect(defaultArgs.accept).toBeCalledTimes(1);
+    expect(defaultArgs.accept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject approval properly", async () => {
@@ -95,7 +95,7 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/u
       result.current.onReject();
     });
 
-    expect(defaultArgs.reject).toBeCalledTimes(1);
+    expect(defaultArgs.reject).toHaveBeenCalledTimes(1);
   });
 
   test("should set approval properly", async () => {
@@ -108,10 +108,10 @@ describe("ui/components/ConfirmRequestModal/components/ConnectionApprovalModal/u
     });
     await waitFor(() => !result.current.checked);
 
-    expect(fetchHostPermissions).toBeCalledTimes(1);
-    expect(fetchHostPermissions).toBeCalledWith(defaultArgs.pendingRequest.payload?.urlOrigin);
-    expect(setHostPermissions).toBeCalledTimes(1);
-    expect(setHostPermissions).toBeCalledWith({
+    expect(fetchHostPermissions).toHaveBeenCalledTimes(1);
+    expect(fetchHostPermissions).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.urlOrigin);
+    expect(setHostPermissions).toHaveBeenCalledTimes(1);
+    expect(setHostPermissions).toHaveBeenCalledWith({
       urlOrigin: defaultArgs.pendingRequest.payload?.urlOrigin,
       canSkipApprove: false,
     });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/__tests__/DefaultApprovalModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/DefaultApprovalModal/__tests__/DefaultApprovalModal.test.tsx
@@ -65,6 +65,6 @@ describe("ui/components/ConfirmRequestModal/components/DefaultApprovalModal", ()
       button.click();
     });
 
-    expect(defaultProps.reject).toBeCalledTimes(1);
+    expect(defaultProps.reject).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/RlnProofModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/RlnProofModal.test.tsx
@@ -83,7 +83,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+    expect(defaultHookData.onAccept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject proof generation properly", async () => {
@@ -94,7 +94,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onReject).toBeCalledTimes(1);
+    expect(defaultHookData.onReject).toHaveBeenCalledTimes(1);
   });
 
   test("should open circuit file properly", async () => {
@@ -105,7 +105,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenCircuitFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenCircuitFile).toHaveBeenCalledTimes(1);
   });
 
   test("should open zkey file properly", async () => {
@@ -116,7 +116,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenZkeyFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenZkeyFile).toHaveBeenCalledTimes(1);
   });
 
   test("should open verification key file properly", async () => {
@@ -127,6 +127,6 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenVerificationKeyFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenVerificationKeyFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/useRlnProofModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/RlnProofModal/__tests__/useRlnProofModal.test.ts
@@ -81,7 +81,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
       result.current.onAccept();
     });
 
-    expect(defaultArgs.accept).toBeCalledTimes(1);
+    expect(defaultArgs.accept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject proof generation properly", async () => {
@@ -92,7 +92,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
       result.current.onReject();
     });
 
-    expect(defaultArgs.reject).toBeCalledTimes(1);
+    expect(defaultArgs.reject).toHaveBeenCalledTimes(1);
   });
 
   test("should open circuit file properly", async () => {
@@ -104,8 +104,8 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
       result.current.onOpenCircuitFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
   });
 
   test("should open zkey file properly", async () => {
@@ -117,8 +117,8 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
       result.current.onOpenZkeyFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
   });
 
   test("should open verification key file properly", async () => {
@@ -130,7 +130,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useProofModal"
       result.current.onOpenVerificationKeyFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/SemaphoreProofModal.test.tsx
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/SemaphoreProofModal.test.tsx
@@ -81,7 +81,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onAccept).toBeCalledTimes(1);
+    expect(defaultHookData.onAccept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject proof generation properly", async () => {
@@ -92,7 +92,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onReject).toBeCalledTimes(1);
+    expect(defaultHookData.onReject).toHaveBeenCalledTimes(1);
   });
 
   test("should open circuit file properly", async () => {
@@ -103,7 +103,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenCircuitFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenCircuitFile).toHaveBeenCalledTimes(1);
   });
 
   test("should open zkey file properly", async () => {
@@ -114,7 +114,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenZkeyFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenZkeyFile).toHaveBeenCalledTimes(1);
   });
 
   test("should open verification key file properly", async () => {
@@ -125,6 +125,6 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal", () => {
       link.click();
     });
 
-    expect(defaultHookData.onOpenVerificationKeyFile).toBeCalledTimes(1);
+    expect(defaultHookData.onOpenVerificationKeyFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/useSemaphoreProofModal.test.ts
+++ b/packages/app/src/ui/components/ConfirmRequestModal/components/SemaphoreProofModal/__tests__/useSemaphoreProofModal.test.ts
@@ -84,7 +84,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphorePr
       result.current.onAccept();
     });
 
-    expect(defaultArgs.accept).toBeCalledTimes(1);
+    expect(defaultArgs.accept).toHaveBeenCalledTimes(1);
   });
 
   test("should reject proof generation properly", async () => {
@@ -95,7 +95,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphorePr
       result.current.onReject();
     });
 
-    expect(defaultArgs.reject).toBeCalledTimes(1);
+    expect(defaultArgs.reject).toHaveBeenCalledTimes(1);
   });
 
   test("should open circuit file properly", async () => {
@@ -107,8 +107,8 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphorePr
       result.current.onOpenCircuitFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.circuitFilePath, "_blank");
   });
 
   test("should open zkey file properly", async () => {
@@ -120,8 +120,8 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphorePr
       result.current.onOpenZkeyFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.zkeyFilePath, "_blank");
   });
 
   test("should open verification key file properly", async () => {
@@ -133,7 +133,7 @@ describe("ui/components/ConfirmRequestModal/components/ProofModal/useSemaphorePr
       result.current.onOpenVerificationKeyFile();
     });
 
-    expect(openSpy).toBeCalledTimes(1);
-    expect(openSpy).toBeCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(defaultArgs.pendingRequest.payload?.verificationKey, "_blank");
   });
 });

--- a/packages/app/src/ui/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/app/src/ui/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -47,8 +47,8 @@ describe("ui/components/Dropdown", () => {
     const select = await screen.findByLabelText(defaultProps.label);
     await selectEvent.select(select, defaultProps.options[1].label);
 
-    expect(defaultProps.onChange).toBeCalledTimes(1);
-    expect(defaultProps.onChange).toBeCalledWith(defaultProps.options[1], {
+    expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onChange).toHaveBeenCalledWith(defaultProps.options[1], {
       action: "select-option",
     });
   });

--- a/packages/app/src/ui/components/DropdownButton/__tests__/useDropdownButton.test.ts
+++ b/packages/app/src/ui/components/DropdownButton/__tests__/useDropdownButton.test.ts
@@ -74,7 +74,7 @@ describe("ui/components/DropdownButton/useDropdownButton", () => {
     expect(result.current.selectedIndex).toBe(1);
 
     act(() => result.current.onSubmit());
-    expect(defaultArgs.onClick).toBeCalledTimes(1);
-    expect(defaultArgs.onClick).toBeCalledWith(1);
+    expect(defaultArgs.onClick).toHaveBeenCalledTimes(1);
+    expect(defaultArgs.onClick).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/app/src/ui/components/Header/__tests__/Header.test.tsx
+++ b/packages/app/src/ui/components/Header/__tests__/Header.test.tsx
@@ -97,8 +97,8 @@ describe("ui/components/Header", () => {
     const metamaskInstall = await findByText("Install MetaMask");
     await act(async () => Promise.resolve(metamaskInstall.click()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith("https://metamask.io/");
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith("https://metamask.io/");
   });
 
   test("should redirect to options page", async () => {
@@ -110,8 +110,8 @@ describe("ui/components/Header", () => {
     const options = await findByText("Settings");
     await act(async () => Promise.resolve(options.click()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should redirect to home page", async () => {
@@ -120,7 +120,7 @@ describe("ui/components/Header", () => {
     const logo = await findByTestId("logo");
     await act(async () => Promise.resolve(logo.click()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 });

--- a/packages/app/src/ui/components/IdentityList/IdentityList.tsx
+++ b/packages/app/src/ui/components/IdentityList/IdentityList.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Paths } from "@src/constants";
 import { Icon } from "@src/ui/components/Icon";
+import { disconnect } from "@src/ui/ducks/connections";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { createIdentityRequest, deleteIdentity, setIdentityName } from "@src/ui/ducks/identities";
 import { isExtensionPopupOpen } from "@src/util/browser";
@@ -49,6 +50,13 @@ export const IdentityList = ({
     [dispatch],
   );
 
+  const onDisconnectIdentity = useCallback(
+    async (identityCommitment: string) => {
+      await dispatch(disconnect(identityCommitment));
+    },
+    [dispatch],
+  );
+
   const onCreateIdentityRequest = useCallback(() => {
     if (isExtensionPopupOpen()) {
       dispatch(createIdentityRequest({ urlOrigin: "" }));
@@ -87,6 +95,7 @@ export const IdentityList = ({
             metadata={metadata}
             selected={selectedCommitment}
             onDeleteIdentity={onDeleteIdentity}
+            onDisconnectIdentity={onDisconnectIdentity}
             onSelectIdentity={onSelect}
             onUpdateIdentityName={onUpdateIdentityName}
           />

--- a/packages/app/src/ui/components/IdentityList/Item/index.tsx
+++ b/packages/app/src/ui/components/IdentityList/Item/index.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import classNames from "classnames";
+import compact from "lodash/compact";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 
 import { Icon } from "@src/ui/components/Icon";
@@ -21,6 +22,7 @@ export interface IdentityItemProps {
   selected?: string;
   onDeleteIdentity: (commitment: string) => Promise<void>;
   onUpdateIdentityName: (commitment: string, name: string) => Promise<void>;
+  onDisconnectIdentity: (commitment: string) => Promise<void>;
   onSelectIdentity?: (commitment: string) => void;
 }
 
@@ -32,6 +34,7 @@ export const IdentityItem = ({
   connectedOrigin = "",
   onDeleteIdentity,
   onUpdateIdentityName,
+  onDisconnectIdentity,
   onSelectIdentity = undefined,
 }: IdentityItemProps): JSX.Element => {
   const {
@@ -44,6 +47,7 @@ export const IdentityItem = ({
     onToggleRenaming,
     onDeleteIdentity: onDelete,
     onSelectIdentity: onSelect,
+    onDisconnectIdentity: onDisconnect,
   } = useIdentityItem({
     commitment,
     metadata,
@@ -51,13 +55,15 @@ export const IdentityItem = ({
     onDelete: onDeleteIdentity,
     onUpdate: onUpdateIdentityName,
     onSelect: onSelectIdentity,
+    onDisconnect: onDisconnectIdentity,
   });
 
-  const menuItems = [
+  const menuItems = compact([
     { label: "View", isDangerItem: false, onClick: onGoToIdentity },
     { label: "Rename", isDangerItem: false, onClick: onToggleRenaming },
+    connectedOrigin && { label: "Disconnect", isDangerItem: true, onClick: onDisconnect },
     { label: "Delete", isDangerItem: true, onClick: onDelete },
-  ];
+  ]);
 
   return (
     <Box

--- a/packages/app/src/ui/components/IdentityList/Item/useIdentityItem.ts
+++ b/packages/app/src/ui/components/IdentityList/Item/useIdentityItem.ts
@@ -12,6 +12,7 @@ export interface IUseIdentityItemArgs {
   connectedOrigin?: string;
   onDelete: (commitment: string) => Promise<void>;
   onUpdate: (commitment: string, name: string) => Promise<void>;
+  onDisconnect: (commitment: string) => Promise<void>;
   onSelect?: (commitment: string) => void;
 }
 
@@ -22,6 +23,7 @@ export interface IUseIdentityItemData {
   onDeleteIdentity: () => void;
   onSelectIdentity: () => void;
   onToggleRenaming: () => void;
+  onDisconnectIdentity: () => void;
   onGoToHost: () => void;
   onGoToIdentity: () => void;
   onUpdateName: (event: FormEvent | ReactMouseEvent) => void;
@@ -38,6 +40,7 @@ export const useIdentityItem = ({
   onDelete,
   onUpdate,
   onSelect,
+  onDisconnect,
 }: IUseIdentityItemArgs): IUseIdentityItemData => {
   const [isRenaming, setIsRenaming] = useState(false);
   const navigate = useNavigate();
@@ -56,6 +59,10 @@ export const useIdentityItem = ({
   const onDeleteIdentity = useCallback(() => {
     onDelete(commitment);
   }, [commitment, onDelete]);
+
+  const onDisconnectIdentity = useCallback(() => {
+    onDisconnect(commitment);
+  }, [commitment, onDisconnect]);
 
   const onSelectIdentity = useCallback(() => {
     onSelect?.(commitment);
@@ -94,6 +101,7 @@ export const useIdentityItem = ({
     },
     register,
     onDeleteIdentity,
+    onDisconnectIdentity,
     onSelectIdentity,
     onToggleRenaming,
     onGoToHost,

--- a/packages/app/src/ui/components/IdentityList/__tests__/IdentityItem.test.tsx
+++ b/packages/app/src/ui/components/IdentityList/__tests__/IdentityItem.test.tsx
@@ -24,6 +24,7 @@ describe("ui/components/IdentityList/Item", () => {
     metadata: mockDefaultIdentity.metadata,
     onDeleteIdentity: jest.fn(),
     onSelectIdentity: jest.fn(),
+    onDisconnectIdentity: jest.fn(),
     onUpdateIdentityName: jest.fn(),
   };
 
@@ -65,8 +66,8 @@ describe("ui/components/IdentityList/Item", () => {
     const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
     await act(async () => Promise.resolve(dangerModalAccept.click()));
 
-    expect(defaultProps.onDeleteIdentity).toBeCalledTimes(1);
-    expect(defaultProps.onDeleteIdentity).toBeCalledWith(defaultProps.commitment);
+    expect(defaultProps.onDeleteIdentity).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDeleteIdentity).toHaveBeenCalledWith(defaultProps.commitment);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -90,7 +91,7 @@ describe("ui/components/IdentityList/Item", () => {
     const dangerModalReject = await screen.findByTestId("danger-modal-reject");
     await act(async () => Promise.resolve(dangerModalReject.click()));
 
-    expect(defaultProps.onDeleteIdentity).toBeCalledTimes(0);
+    expect(defaultProps.onDeleteIdentity).toHaveBeenCalledTimes(0);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -102,8 +103,8 @@ describe("ui/components/IdentityList/Item", () => {
       selectIcon.click();
     });
 
-    expect(defaultProps.onSelectIdentity).toBeCalledTimes(1);
-    expect(defaultProps.onSelectIdentity).toBeCalledWith(defaultProps.commitment);
+    expect(defaultProps.onSelectIdentity).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onSelectIdentity).toHaveBeenCalledWith(defaultProps.commitment);
   });
 
   test("should rename identity properly", async () => {
@@ -127,8 +128,8 @@ describe("ui/components/IdentityList/Item", () => {
     const renameIcon = await screen.findByTestId(`identity-rename-${defaultProps.commitment}`);
     await act(async () => Promise.resolve(renameIcon.click()));
 
-    expect(defaultProps.onUpdateIdentityName).toBeCalledTimes(1);
-    expect(defaultProps.onUpdateIdentityName).toBeCalledWith(defaultProps.commitment, "Account #1");
+    expect(defaultProps.onUpdateIdentityName).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onUpdateIdentityName).toHaveBeenCalledWith(defaultProps.commitment, "Account #1");
   });
 
   test("should go to identity page properly", async () => {
@@ -144,8 +145,32 @@ describe("ui/components/IdentityList/Item", () => {
       button.click();
     });
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(replaceUrlParams(Paths.IDENTITY, { id: defaultProps.commitment }));
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(replaceUrlParams(Paths.IDENTITY, { id: defaultProps.commitment }));
+  });
+
+  test("should disconnect identity properly", async () => {
+    render(<IdentityItem {...defaultProps} />);
+
+    const menu = await screen.findByTestId("menu");
+    act(() => {
+      menu.click();
+    });
+
+    const button = await screen.findByText("Disconnect");
+    act(() => {
+      button.click();
+    });
+
+    const dangerModal = await screen.findByTestId("danger-modal");
+    expect(dangerModal).toBeInTheDocument();
+
+    const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
+    await act(async () => Promise.resolve(dangerModalAccept.click()));
+
+    expect(defaultProps.onDisconnectIdentity).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDisconnectIdentity).toHaveBeenCalledWith(defaultProps.commitment);
+    expect(dangerModal).not.toBeInTheDocument();
   });
 
   test("should go to host properly", async () => {
@@ -154,7 +179,7 @@ describe("ui/components/IdentityList/Item", () => {
     const icon = await screen.findByTestId("urlOrigin-icon");
     await act(() => Promise.resolve(icon.click()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 });

--- a/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
+++ b/packages/app/src/ui/components/IdentityList/__tests__/IdentityList.test.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from "react-router-dom";
 import { ZERO_ADDRESS } from "@src/config/const";
 import { mockDefaultConnection } from "@src/config/mock/zk";
 import { Paths } from "@src/constants";
+import { disconnect } from "@src/ui/ducks/connections";
 import { useAppDispatch } from "@src/ui/ducks/hooks";
 import { deleteIdentity, setIdentityName, useIdentities } from "@src/ui/ducks/identities";
 import { isExtensionPopupOpen } from "@src/util/browser";
@@ -28,6 +29,10 @@ jest.mock("@src/ui/ducks/identities", (): unknown => ({
   setIdentityName: jest.fn(),
   useIdentities: jest.fn(),
   createIdentityRequest: jest.fn(),
+}));
+
+jest.mock("@src/ui/ducks/connections", (): unknown => ({
+  disconnect: jest.fn(),
 }));
 
 describe("ui/components/IdentityList", () => {
@@ -107,7 +112,7 @@ describe("ui/components/IdentityList", () => {
       selectIcon.click();
     });
 
-    expect(defaultProps.onSelect).toBeCalledTimes(1);
+    expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
   });
 
   test("should rename identity properly", async () => {
@@ -129,9 +134,9 @@ describe("ui/components/IdentityList", () => {
     const renameIcon = await screen.findByTestId(`identity-rename-${defaultIdentities[0].commitment}`);
     await act(async () => Promise.resolve(renameIcon.click()));
 
-    expect(setIdentityName).toBeCalledTimes(1);
-    expect(setIdentityName).toBeCalledWith(defaultIdentities[0].commitment, "New name");
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(setIdentityName).toHaveBeenCalledTimes(1);
+    expect(setIdentityName).toHaveBeenCalledWith(defaultIdentities[0].commitment, "New name");
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 
   test("should handle rename error properly", async () => {
@@ -181,9 +186,9 @@ describe("ui/components/IdentityList", () => {
     const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
     await act(async () => Promise.resolve(dangerModalAccept.click()));
 
-    expect(deleteIdentity).toBeCalledTimes(1);
-    expect(deleteIdentity).toBeCalledWith(defaultIdentities[0].commitment);
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(deleteIdentity).toHaveBeenCalledTimes(1);
+    expect(deleteIdentity).toHaveBeenCalledWith(defaultIdentities[0].commitment);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -207,8 +212,59 @@ describe("ui/components/IdentityList", () => {
     const dangerModalReject = await screen.findByTestId("danger-modal-reject");
     await act(async () => Promise.resolve(dangerModalReject.click()));
 
-    expect(deleteIdentity).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(0);
+    expect(deleteIdentity).toHaveBeenCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(0);
+    expect(dangerModal).not.toBeInTheDocument();
+  });
+
+  test("should accept to disconnect identity properly", async () => {
+    render(<IdentityList {...defaultProps} selectedCommitment={undefined} />);
+
+    const [menuIcon] = await screen.findAllByTestId("menu");
+    act(() => {
+      menuIcon.click();
+    });
+
+    const disconnectButton = await screen.findByText("Disconnect");
+    act(() => {
+      disconnectButton.click();
+    });
+
+    const dangerModal = await screen.findByTestId("danger-modal");
+
+    expect(dangerModal).toBeInTheDocument();
+
+    const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
+    await act(async () => Promise.resolve(dangerModalAccept.click()));
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledWith(defaultIdentities[0].commitment);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(dangerModal).not.toBeInTheDocument();
+  });
+
+  test("should reject to disconnect identity properly", async () => {
+    render(<IdentityList {...defaultProps} selectedCommitment={undefined} />);
+
+    const [menuIcon] = await screen.findAllByTestId("menu");
+    act(() => {
+      menuIcon.click();
+    });
+
+    const disconnectButton = await screen.findByText("Disconnect");
+    act(() => {
+      disconnectButton.click();
+    });
+
+    const dangerModal = await screen.findByTestId("danger-modal");
+
+    expect(dangerModal).toBeInTheDocument();
+
+    const dangerModalReject = await screen.findByTestId("danger-modal-reject");
+    await act(async () => Promise.resolve(dangerModalReject.click()));
+
+    expect(disconnect).toHaveBeenCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(0);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -218,7 +274,7 @@ describe("ui/components/IdentityList", () => {
     const createIdentityButton = await screen.findByTestId("create-new-identity");
     await act(async () => Promise.resolve(createIdentityButton.click()));
 
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 
   test("should redirect to create identity page properly", async () => {
@@ -229,7 +285,7 @@ describe("ui/components/IdentityList", () => {
     const createIdentityButton = await screen.findByTestId("create-new-identity");
     await act(async () => Promise.resolve(createIdentityButton.click()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.CREATE_IDENTITY);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.CREATE_IDENTITY);
   });
 });

--- a/packages/app/src/ui/components/MnemonicInput/__tests__/MnemonicInput.test.tsx
+++ b/packages/app/src/ui/components/MnemonicInput/__tests__/MnemonicInput.test.tsx
@@ -52,7 +52,7 @@ describe("ui/components/MnemonicInput", () => {
     const showButton = await findByText("Show");
     await act(() => Promise.resolve(showButton.click()));
 
-    expect(defaultHookData.onShowMnemonic).toBeCalledTimes(1);
+    expect(defaultHookData.onShowMnemonic).toHaveBeenCalledTimes(1);
   });
 
   test("should hide mnemonic properly", async () => {
@@ -63,7 +63,7 @@ describe("ui/components/MnemonicInput", () => {
     const hideButton = await findByText("Hide");
     await act(() => Promise.resolve(hideButton.click()));
 
-    expect(defaultHookData.onShowMnemonic).toBeCalledTimes(1);
+    expect(defaultHookData.onShowMnemonic).toHaveBeenCalledTimes(1);
   });
 
   test("should render operation pending labels", async () => {
@@ -87,7 +87,7 @@ describe("ui/components/MnemonicInput", () => {
     await act(() => Promise.resolve(copyButton.click()));
     await act(() => Promise.resolve(downloadButton.click()));
 
-    expect(defaultHookData.onCopy).toBeCalledTimes(1);
-    expect(defaultHookData.onDownload).toBeCalledTimes(1);
+    expect(defaultHookData.onCopy).toHaveBeenCalledTimes(1);
+    expect(defaultHookData.onDownload).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/MnemonicInput/__tests__/useMnemonicInput.test.ts
+++ b/packages/app/src/ui/components/MnemonicInput/__tests__/useMnemonicInput.test.ts
@@ -52,8 +52,8 @@ describe("ui/components/MnemonicInput/useMnemonicInput", () => {
 
     await act(() => Promise.resolve(result.current.onCopy()));
 
-    expect(defaultTimeoutHookData.setActive).toBeCalledTimes(1);
-    expect(copyToClipboard).toBeCalledTimes(1);
+    expect(defaultTimeoutHookData.setActive).toHaveBeenCalledTimes(1);
+    expect(copyToClipboard).toHaveBeenCalledTimes(1);
   });
 
   test("should download mnemonic properly", async () => {
@@ -61,8 +61,8 @@ describe("ui/components/MnemonicInput/useMnemonicInput", () => {
 
     await act(() => Promise.resolve(result.current.onDownload()));
 
-    expect(defaultTimeoutHookData.setActive).toBeCalledTimes(1);
-    expect(downloadFile).toBeCalledTimes(1);
+    expect(defaultTimeoutHookData.setActive).toHaveBeenCalledTimes(1);
+    expect(downloadFile).toHaveBeenCalledTimes(1);
   });
 
   test("should toggle mnemonic show properly", async () => {

--- a/packages/app/src/ui/components/PermissionModal/__tests__/PermissionModal.test.tsx
+++ b/packages/app/src/ui/components/PermissionModal/__tests__/PermissionModal.test.tsx
@@ -66,7 +66,7 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onRemoveHost).toBeCalledTimes(1);
+    expect(defaultHookData.onRemoveHost).toHaveBeenCalledTimes(1);
   });
 
   test("should close modal properly", async () => {
@@ -77,7 +77,7 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       button.click();
     });
 
-    expect(defaultProps.onClose).toBeCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
   });
 
   test("should set approval properly", async () => {
@@ -88,6 +88,6 @@ describe("ui/components/ConnectionModal/ConnectionModal", () => {
       button.click();
     });
 
-    expect(defaultHookData.onSetApproval).toBeCalledTimes(1);
+    expect(defaultHookData.onSetApproval).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/PermissionModal/__tests__/usePermissionModal.test.ts
+++ b/packages/app/src/ui/components/PermissionModal/__tests__/usePermissionModal.test.ts
@@ -78,10 +78,10 @@ describe("ui/components/ConnectionModal/useConnectionModal", () => {
       Promise.resolve(result.current.onSetApproval({ target: { checked: true } } as ChangeEvent<HTMLInputElement>)),
     );
 
-    expect(fetchHostPermissions).toBeCalledTimes(1);
-    expect(fetchHostPermissions).toBeCalledWith(result.current.url?.origin);
-    expect(setHostPermissions).toBeCalledTimes(1);
-    expect(setHostPermissions).toBeCalledWith({
+    expect(fetchHostPermissions).toHaveBeenCalledTimes(1);
+    expect(fetchHostPermissions).toHaveBeenCalledWith(result.current.url?.origin);
+    expect(setHostPermissions).toHaveBeenCalledTimes(1);
+    expect(setHostPermissions).toHaveBeenCalledWith({
       urlOrigin: result.current.url?.origin,
       canSkipApprove: true,
     });
@@ -93,11 +93,11 @@ describe("ui/components/ConnectionModal/useConnectionModal", () => {
 
     await act(async () => Promise.resolve(result.current.onRemoveHost()));
 
-    expect(fetchHostPermissions).toBeCalledTimes(1);
-    expect(fetchHostPermissions).toBeCalledWith(result.current.url?.origin);
-    expect(removeHost).toBeCalledTimes(1);
-    expect(removeHost).toBeCalledWith(result.current.url?.origin);
-    expect(defaultArgs.refreshConnectionStatus).toBeCalledTimes(1);
-    expect(defaultArgs.onClose).toBeCalledTimes(1);
+    expect(fetchHostPermissions).toHaveBeenCalledTimes(1);
+    expect(fetchHostPermissions).toHaveBeenCalledWith(result.current.url?.origin);
+    expect(removeHost).toHaveBeenCalledTimes(1);
+    expect(removeHost).toHaveBeenCalledWith(result.current.url?.origin);
+    expect(defaultArgs.refreshConnectionStatus).toHaveBeenCalledTimes(1);
+    expect(defaultArgs.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/UploadButton/__tests__/useUploadButton.test.tsx
+++ b/packages/app/src/ui/components/UploadButton/__tests__/useUploadButton.test.tsx
@@ -32,6 +32,6 @@ describe("ui/components/UploadButton/useUploadButton", () => {
 
     await act(() => fireEvent.drop(container.querySelector("div")!, data));
 
-    expect(defaultHookArgs.onDrop).toBeCalledTimes(1);
+    expect(defaultHookArgs.onDrop).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/UploadInput/__tests__/useUploadInput.test.tsx
+++ b/packages/app/src/ui/components/UploadInput/__tests__/useUploadInput.test.tsx
@@ -32,6 +32,6 @@ describe("ui/components/UploadInput/useUploadInput", () => {
 
     await act(() => fireEvent.drop(container.querySelector("div")!, data));
 
-    expect(defaultHookArgs.onDrop).toBeCalledTimes(1);
+    expect(defaultHookArgs.onDrop).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/Display/__tests__/VerifiableCredentialDisplay.test.tsx
+++ b/packages/app/src/ui/components/VerifiableCredential/Display/__tests__/VerifiableCredentialDisplay.test.tsx
@@ -125,7 +125,7 @@ describe("ui/components/VerifiableCredential/Display", () => {
     const submitRenameIcon = await screen.findByTestId("verifiable-credential-display-submit-rename");
     fireEvent.click(submitRenameIcon);
 
-    expect(defaultProps.onRenameVerifiableCredential).toBeCalledTimes(1);
-    expect(defaultProps.onRenameVerifiableCredential).toBeCalledWith("My Favorite Credential");
+    expect(defaultProps.onRenameVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onRenameVerifiableCredential).toHaveBeenCalledWith("My Favorite Credential");
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/Display/__tests__/useVerifiableCredentialDisplay.test.ts
+++ b/packages/app/src/ui/components/VerifiableCredential/Display/__tests__/useVerifiableCredentialDisplay.test.ts
@@ -66,7 +66,7 @@ describe("ui/components/VerifiableCredential/Display/useVerifiableCredentialDisp
       result.current.onSubmit(mockEvent);
     });
 
-    expect(useVerifiableCredentialDisplayArgs.onRename).toBeCalledTimes(1);
+    expect(useVerifiableCredentialDisplayArgs.onRename).toHaveBeenCalledTimes(1);
     expect(result.current.isRenaming).toBe(false);
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/Item/__tests__/VerifiableCredentialItem.test.tsx
+++ b/packages/app/src/ui/components/VerifiableCredential/Item/__tests__/VerifiableCredentialItem.test.tsx
@@ -113,8 +113,8 @@ describe("ui/components/VerifiableCredential/Item", () => {
     const submitRenameIcon = await screen.findByTestId("verifiable-credential-row-submit-rename");
     await act(async () => Promise.resolve(submitRenameIcon.click()));
 
-    expect(defaultProps.onRenameVerifiableCredential).toBeCalledTimes(1);
-    expect(defaultProps.onRenameVerifiableCredential).toBeCalledWith("0x123", "My Favorite Credential");
+    expect(defaultProps.onRenameVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onRenameVerifiableCredential).toHaveBeenCalledWith("0x123", "My Favorite Credential");
   });
 
   test("should accept to delete verifiable credential properly", async () => {
@@ -133,8 +133,8 @@ describe("ui/components/VerifiableCredential/Item", () => {
     const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
     await act(async () => Promise.resolve(dangerModalAccept.click()));
 
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledTimes(1);
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledWith(defaultProps.metadata.hash);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledWith(defaultProps.metadata.hash);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -154,7 +154,7 @@ describe("ui/components/VerifiableCredential/Item", () => {
     const dangerModalReject = await screen.findByTestId("danger-modal-reject");
     await act(async () => Promise.resolve(dangerModalReject.click()));
 
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledTimes(0);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledTimes(0);
     expect(dangerModal).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/Item/__tests__/useVerifiableCredentialItem.test.ts
+++ b/packages/app/src/ui/components/VerifiableCredential/Item/__tests__/useVerifiableCredentialItem.test.ts
@@ -67,7 +67,7 @@ describe("ui/components/VerifiableCredential/Item/useVerifiableCredentialItem", 
     await act(async () => Promise.resolve(result.current.onToggleRenaming()));
     await act(async () => Promise.resolve(result.current.onSubmit(mockEvent)));
 
-    expect(defaultHookArgs.onRename).toBeCalledTimes(1);
+    expect(defaultHookArgs.onRename).toHaveBeenCalledTimes(1);
     expect(result.current.isRenaming).toBe(false);
   });
 
@@ -76,8 +76,8 @@ describe("ui/components/VerifiableCredential/Item/useVerifiableCredentialItem", 
 
     await act(async () => result.current.onDelete());
 
-    expect(defaultHookArgs.onDelete).toBeCalledTimes(1);
-    expect(defaultHookArgs.onDelete).toBeCalledWith(defaultHookArgs.metadata.hash);
+    expect(defaultHookArgs.onDelete).toHaveBeenCalledTimes(1);
+    expect(defaultHookArgs.onDelete).toHaveBeenCalledWith(defaultHookArgs.metadata.hash);
   });
 
   test("should handle selection properly", () => {
@@ -85,7 +85,7 @@ describe("ui/components/VerifiableCredential/Item/useVerifiableCredentialItem", 
 
     act(() => result.current.onToggleSelect());
 
-    expect(defaultHookArgs.onSelect).toBeCalledTimes(1);
-    expect(defaultHookArgs.onSelect).toBeCalledWith(defaultHookArgs.metadata.hash);
+    expect(defaultHookArgs.onSelect).toHaveBeenCalledTimes(1);
+    expect(defaultHookArgs.onSelect).toHaveBeenCalledWith(defaultHookArgs.metadata.hash);
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/List/__tests__/useVerifiableCredentialList.test.ts
+++ b/packages/app/src/ui/components/VerifiableCredential/List/__tests__/useVerifiableCredentialList.test.ts
@@ -98,8 +98,8 @@ describe("ui/components/VerifiableCredential/List/useVerifiableCredentialList", 
 
     await act(async () => result.current.onRenameVerifiableCredential("name", "hash"));
 
-    expect(renameVerifiableCredential).toBeCalledTimes(1);
-    expect(fetchVerifiableCredentials).toBeCalledTimes(2);
+    expect(renameVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(fetchVerifiableCredentials).toHaveBeenCalledTimes(2);
   });
 
   test("should call delete properly", async () => {
@@ -107,7 +107,7 @@ describe("ui/components/VerifiableCredential/List/useVerifiableCredentialList", 
 
     await act(async () => result.current.onDeleteVerifiableCredential("hash"));
 
-    expect(deleteVerifiableCredential).toBeCalledTimes(1);
-    expect(fetchVerifiableCredentials).toBeCalledTimes(2);
+    expect(deleteVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(fetchVerifiableCredentials).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/app/src/ui/components/VerifiableCredential/__tests__/VerifiableCredentialItem.test.tsx
+++ b/packages/app/src/ui/components/VerifiableCredential/__tests__/VerifiableCredentialItem.test.tsx
@@ -79,8 +79,8 @@ describe("ui/components/VerifiableCredential/Item", () => {
     const dangerModalAccept = await screen.findByTestId("danger-modal-accept");
     await act(async () => Promise.resolve(dangerModalAccept.click()));
 
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledTimes(1);
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledWith(defaultProps.metadata.hash);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledWith(defaultProps.metadata.hash);
     expect(dangerModal).not.toBeInTheDocument();
   });
 
@@ -104,7 +104,7 @@ describe("ui/components/VerifiableCredential/Item", () => {
     const dangerModalreject = await screen.findByTestId("danger-modal-reject");
     await act(async () => Promise.resolve(dangerModalreject.click()));
 
-    expect(defaultProps.onDeleteVerifiableCredential).toBeCalledTimes(0);
+    expect(defaultProps.onDeleteVerifiableCredential).toHaveBeenCalledTimes(0);
     expect(dangerModal).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/ui/ducks/__tests__/app.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/app.test.tsx
@@ -98,8 +98,8 @@ describe("ui/ducks/app", () => {
     const { app } = store.getState();
 
     expect(app).toStrictEqual(expectedState);
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.SET_CONNECT_WALLET,
       payload: { isDisconnectedPermanently: true },
     });
@@ -120,8 +120,8 @@ describe("ui/ducks/app", () => {
     const { app } = store.getState();
 
     expect(app).toStrictEqual(expectedState);
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GET_CONNECT_WALLET,
     });
   });
@@ -129,43 +129,43 @@ describe("ui/ducks/app", () => {
   test("should call close popup action properly", async () => {
     await Promise.resolve(store.dispatch(closePopup()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.CLOSE_POPUP });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.CLOSE_POPUP });
   });
 
   test("should call lock action properly", async () => {
     await Promise.resolve(store.dispatch(lock()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.LOCK });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.LOCK });
   });
 
   test("should call unlock action properly", async () => {
     await Promise.resolve(store.dispatch(unlock("password")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.UNLOCK, payload: "password" });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.UNLOCK, payload: "password" });
   });
 
   test("should call storage clear action properly", async () => {
     await Promise.resolve(store.dispatch(deleteStorage()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.CLEAR_STORAGE });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.CLEAR_STORAGE });
   });
 
   test("should call setup password action properly", async () => {
     await Promise.resolve(store.dispatch(setupPassword("password")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.SETUP_PASSWORD, payload: "password" });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.SETUP_PASSWORD, payload: "password" });
   });
 
   test("should call reset password action properly", async () => {
     await Promise.resolve(store.dispatch(resetPassword({ password: "password", mnemonic: defaultMnemonic })));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.RESET_PASSWORD,
       payload: { password: "password", mnemonic: defaultMnemonic },
     });
@@ -182,8 +182,8 @@ describe("ui/ducks/app", () => {
       isDisconnectedPermanently: true,
       mnemonic: "",
     });
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.SAVE_MNEMONIC });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.SAVE_MNEMONIC });
   });
 
   test("should select account properly", async () => {
@@ -199,8 +199,8 @@ describe("ui/ducks/app", () => {
       selectedAccount: ZERO_ADDRESS,
     });
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.SELECT_ACCOUNT, payload: ZERO_ADDRESS });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.SELECT_ACCOUNT, payload: ZERO_ADDRESS });
   });
 
   test("should get selected account properly", async () => {
@@ -218,8 +218,8 @@ describe("ui/ducks/app", () => {
       selectedAccount: ZERO_ADDRESS,
     });
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.GET_SELECTED_ACCOUNT });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.GET_SELECTED_ACCOUNT });
   });
 
   test("should generate mnemonic properly", async () => {
@@ -245,8 +245,8 @@ describe("ui/ducks/app", () => {
   test("should check mnemonic properly", async () => {
     await Promise.resolve(store.dispatch(checkMnemonic(defaultMnemonic)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CHECK_MNEMONIC,
       payload: { mnemonic: defaultMnemonic, strict: true },
     });
@@ -258,8 +258,8 @@ describe("ui/ducks/app", () => {
     const mnemonic = await Promise.resolve(store.dispatch(getMnemonic()));
 
     expect(mnemonic).toBe(defaultMnemonic);
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GET_MNEMONIC,
     });
   });
@@ -270,8 +270,8 @@ describe("ui/ducks/app", () => {
     const result = await Promise.resolve(store.dispatch(checkPassword("password")));
 
     expect(result).toBe(true);
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CHECK_PASSWORD,
       payload: {
         password: "password",

--- a/packages/app/src/ui/ducks/__tests__/backup.test.ts
+++ b/packages/app/src/ui/ducks/__tests__/backup.test.ts
@@ -19,16 +19,16 @@ describe("ui/ducks/backup", () => {
 
     const result = await Promise.resolve(store.dispatch(downloadBackup("password")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({ method: RPCInternalAction.DOWNLOAD_BACKUP, payload: "password" });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({ method: RPCInternalAction.DOWNLOAD_BACKUP, payload: "password" });
     expect(result).toBe("content");
   });
 
   test("should create upload backup request properly", async () => {
     await Promise.resolve(store.dispatch(createUploadBackupRequest()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REQUEST_UPLOAD_BACKUP,
     });
   });
@@ -36,8 +36,8 @@ describe("ui/ducks/backup", () => {
   test("should create onboarding backup request properly", async () => {
     await Promise.resolve(store.dispatch(createOnboardingBackupRequest()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REQUEST_ONBOARDING_BACKUP,
     });
   });
@@ -47,8 +47,8 @@ describe("ui/ducks/backup", () => {
       store.dispatch(uploadBackup({ password: "password", backupPassword: "password", content: "content" })),
     );
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.UPLOAD_BACKUP,
       payload: { password: "password", backupPassword: "password", content: "content" },
     });

--- a/packages/app/src/ui/ducks/__tests__/connections.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/connections.test.tsx
@@ -17,6 +17,7 @@ import {
   useConnection,
   revealConnectedIdentityCommitment,
   connect,
+  disconnect,
   useConnectedOrigins,
 } from "../connections";
 
@@ -68,8 +69,8 @@ describe("ui/ducks/identities", () => {
       ),
     );
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CONNECT,
       payload: {
         commitment: mockDefaultConnection.commitment,
@@ -80,13 +81,31 @@ describe("ui/ducks/identities", () => {
     });
   });
 
+  test("should disconnect properly", async () => {
+    (postMessage as jest.Mock).mockResolvedValue(true);
+
+    await Promise.resolve(store.dispatch(disconnect(mockDefaultConnection.commitment)));
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenNthCalledWith(1, {
+      method: RPCInternalAction.DISCONNECT,
+      payload: {
+        identityCommitment: mockDefaultConnection.commitment,
+      },
+    });
+    expect(postMessage).toHaveBeenNthCalledWith(2, {
+      method: RPCInternalAction.GET_CONNECTIONS,
+      payload: {},
+    });
+  });
+
   test("should reveal connected identity commitment properly", async () => {
     (postMessage as jest.Mock).mockResolvedValue(mockDefaultConnection.commitment);
 
     await Promise.resolve(store.dispatch(revealConnectedIdentityCommitment(mockDefaultConnection.urlOrigin)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REVEAL_CONNECTED_IDENTITY_COMMITMENT,
       payload: {},
       meta: { urlOrigin: mockDefaultConnection.urlOrigin },

--- a/packages/app/src/ui/ducks/__tests__/groups.test.ts
+++ b/packages/app/src/ui/ducks/__tests__/groups.test.ts
@@ -22,8 +22,8 @@ describe("ui/ducks/groups", () => {
 
     const result = await Promise.resolve(store.dispatch(joinGroup(args, "urlOrigin")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.JOIN_GROUP,
       payload: args,
       meta: { urlOrigin: "urlOrigin" },
@@ -37,8 +37,8 @@ describe("ui/ducks/groups", () => {
 
     const result = await Promise.resolve(store.dispatch(generateGroupMerkleProof(args, "urlOrigin")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GENERATE_GROUP_MERKLE_PROOF,
       payload: args,
       meta: { urlOrigin: "urlOrigin" },
@@ -52,8 +52,8 @@ describe("ui/ducks/groups", () => {
 
     const result = await Promise.resolve(store.dispatch(checkGroupMembership(args, "urlOrigin")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CHECK_GROUP_MEMBERSHIP,
       payload: args,
       meta: { urlOrigin: "urlOrigin" },

--- a/packages/app/src/ui/ducks/__tests__/identities.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/identities.test.tsx
@@ -175,8 +175,8 @@ describe("ui/ducks/identities", () => {
   test("should call create identity request action properly", async () => {
     await Promise.resolve(store.dispatch(createIdentityRequest({ urlOrigin: "http://localhost:3000" })));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CREATE_IDENTITY_REQUEST,
       payload: { urlOrigin: "http://localhost:3000" },
     });
@@ -196,8 +196,8 @@ describe("ui/ducks/identities", () => {
       ),
     );
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.CREATE_IDENTITY,
       payload: {
         messageSignature: "signature",
@@ -221,8 +221,8 @@ describe("ui/ducks/identities", () => {
 
     await Promise.resolve(store.dispatch(importIdentity(args)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.IMPORT_IDENTITY,
       payload: args,
     });
@@ -231,8 +231,8 @@ describe("ui/ducks/identities", () => {
   test("should call set identity name action properly", async () => {
     await Promise.resolve(store.dispatch(setIdentityName("1", "name")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.SET_IDENTITY_NAME,
       payload: {
         identityCommitment: "1",
@@ -244,8 +244,8 @@ describe("ui/ducks/identities", () => {
   test("should call delete identity action properly", async () => {
     await Promise.resolve(store.dispatch(deleteIdentity("1")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.DELETE_IDENTITY,
       payload: {
         identityCommitment: "1",
@@ -274,8 +274,8 @@ describe("ui/ducks/identities", () => {
   test("should call delete all identities action properly", async () => {
     await Promise.resolve(store.dispatch(deleteAllIdentities()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.DELETE_ALL_IDENTITIES,
     });
   });

--- a/packages/app/src/ui/ducks/__tests__/permissions.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/permissions.test.tsx
@@ -42,8 +42,8 @@ describe("ui/ducks/permissions", () => {
       [defaultHost]: { urlOrigin: defaultHost, ...defaultPermission },
     });
     expect(result.current).toStrictEqual({ urlOrigin: defaultHost, ...defaultPermission });
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GET_HOST_PERMISSIONS,
       payload: defaultHost,
     });
@@ -62,8 +62,8 @@ describe("ui/ducks/permissions", () => {
       [defaultHost]: { urlOrigin: defaultHost, canSkipApprove: false },
     });
     expect(result.current).toStrictEqual({ urlOrigin: defaultHost, canSkipApprove: false });
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.SET_HOST_PERMISSIONS,
       payload: {
         urlOrigin: defaultHost,
@@ -81,8 +81,8 @@ describe("ui/ducks/permissions", () => {
 
     expect(permissions.canSkipApprovals).toStrictEqual({});
     expect(result.current).toBeUndefined();
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REMOVE_HOST,
       payload: {
         urlOrigin: defaultHost,
@@ -96,8 +96,8 @@ describe("ui/ducks/permissions", () => {
     const result = await store.dispatch(checkHostApproval(defaultHost));
 
     expect(result).toBe(true);
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.IS_HOST_APPROVED,
       payload: defaultHost,
     });

--- a/packages/app/src/ui/ducks/__tests__/requests.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/requests.test.tsx
@@ -51,8 +51,8 @@ describe("ui/ducks/requests", () => {
       ),
     );
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.FINALIZE_REQUEST,
       payload: {
         id: "1",
@@ -64,8 +64,8 @@ describe("ui/ducks/requests", () => {
   test("should reject user request properly", async () => {
     await Promise.resolve(store.dispatch(rejectUserRequest({ type: "request" }, "urlOrigin")));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.PUSH_EVENT,
       payload: {
         type: EventName.USER_REJECT,

--- a/packages/app/src/ui/ducks/__tests__/verifiableCredentials.test.tsx
+++ b/packages/app/src/ui/ducks/__tests__/verifiableCredentials.test.tsx
@@ -105,8 +105,8 @@ describe("ui/ducks/verifiableCredentials", () => {
 
     await Promise.resolve(store.dispatch(addVerifiableCredential(mockSerializedVerifiableCredential, mockName)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.ADD_VERIFIABLE_CREDENTIAL,
       payload: {
         serializedVerifiableCredential: mockSerializedVerifiableCredential,
@@ -118,8 +118,8 @@ describe("ui/ducks/verifiableCredentials", () => {
   test("should reject verifiable credential request properly", async () => {
     await Promise.resolve(store.dispatch(rejectVerifiableCredentialRequest()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REJECT_VERIFIABLE_CREDENTIAL_REQUEST,
     });
   });
@@ -129,8 +129,8 @@ describe("ui/ducks/verifiableCredentials", () => {
 
     await Promise.resolve(store.dispatch(renameVerifiableCredential(mockPayload)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.RENAME_VERIFIABLE_CREDENTIAL,
       payload: mockPayload,
     });
@@ -141,8 +141,8 @@ describe("ui/ducks/verifiableCredentials", () => {
 
     await Promise.resolve(store.dispatch(deleteVerifiableCredential(mockHash)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.DELETE_VERIFIABLE_CREDENTIAL,
       payload: mockHash,
     });
@@ -151,8 +151,8 @@ describe("ui/ducks/verifiableCredentials", () => {
   test("should generate verfifiable presentation properly", async () => {
     await Promise.resolve(store.dispatch(generateVerifiablePresentation(mockVerifiablePresentation)));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GENERATE_VERIFIABLE_PRESENTATION,
       payload: mockVerifiablePresentation,
     });
@@ -169,8 +169,8 @@ describe("ui/ducks/verifiableCredentials", () => {
       ),
     );
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.GENERATE_VERIFIABLE_PRESENTATION_WITH_CRYPTKEEPER,
       payload: { verifiablePresentation: mockVerifiablePresentation, address: mockAddress },
     });
@@ -179,8 +179,8 @@ describe("ui/ducks/verifiableCredentials", () => {
   test("should reject a verfifiable presentation request properly", async () => {
     await Promise.resolve(store.dispatch(rejectVerifiablePresentationRequest()));
 
-    expect(postMessage).toBeCalledTimes(1);
-    expect(postMessage).toBeCalledWith({
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
       method: RPCInternalAction.REJECT_VERIFIABLE_PRESENTATION_REQUEST,
     });
   });

--- a/packages/app/src/ui/ducks/connections.ts
+++ b/packages/app/src/ui/ducks/connections.ts
@@ -52,6 +52,21 @@ export const fetchConnections = (): TypedThunk<Promise<void>> => async (dispatch
   dispatch(setConnections(connections));
 };
 
+export const disconnect =
+  (identityCommitment: string): TypedThunk<Promise<boolean>> =>
+  async (dispatch) => {
+    const result = await postMessage<boolean>({
+      method: RPCInternalAction.DISCONNECT,
+      payload: {
+        identityCommitment,
+      },
+    });
+
+    dispatch(fetchConnections());
+
+    return result;
+  };
+
 export const revealConnectedIdentityCommitment =
   (urlOrigin: string): TypedThunk<Promise<void>> =>
   async () => {

--- a/packages/app/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
+++ b/packages/app/src/ui/hooks/wallet/__tests__/useCryptKeeperWallet.test.ts
@@ -87,7 +87,7 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
 
     await act(async () => result.current.onConnect());
 
-    expect(activateSpy).toBeCalledTimes(1);
+    expect(activateSpy).toHaveBeenCalledTimes(1);
   });
 
   test("should connect eagerly properly", async () => {
@@ -96,7 +96,7 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
 
     await act(async () => result.current.onConnectEagerly());
 
-    expect(connectEagerlySpy).toBeCalledTimes(1);
+    expect(connectEagerlySpy).toHaveBeenCalledTimes(1);
   });
 
   test("should disconnect properly", async () => {
@@ -105,7 +105,7 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
 
     await act(async () => result.current.onDisconnect());
 
-    expect(resetStateSpy).toBeCalledTimes(1);
+    expect(resetStateSpy).toHaveBeenCalledTimes(1);
   });
 
   test("should lock properly", async () => {
@@ -113,6 +113,6 @@ describe("ui/hooks/useCryptKeeperWallet", () => {
 
     await act(async () => Promise.resolve(result.current.onLock()));
 
-    expect(lock).toBeCalledTimes(1);
+    expect(lock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/hooks/wallet/__tests__/useEthWallet.test.ts
+++ b/packages/app/src/ui/hooks/wallet/__tests__/useEthWallet.test.ts
@@ -134,9 +134,9 @@ describe("ui/hooks/useEthWallet", () => {
 
     await act(async () => result.current.onConnect());
 
-    expect(activateSpy).toBeCalledTimes(1);
-    expect(setWalletConnection).toBeCalledTimes(1);
-    expect(setWalletConnection).toBeCalledWith(false);
+    expect(activateSpy).toHaveBeenCalledTimes(1);
+    expect(setWalletConnection).toHaveBeenCalledTimes(1);
+    expect(setWalletConnection).toHaveBeenCalledWith(false);
   });
 
   test("should connect eagerly properly", async () => {
@@ -146,8 +146,8 @@ describe("ui/hooks/useEthWallet", () => {
 
     await act(async () => result.current.onConnectEagerly());
 
-    expect(connectEagerlySpy).toBeCalledTimes(1);
-    expect(getWalletConnection).toBeCalledTimes(1);
+    expect(connectEagerlySpy).toHaveBeenCalledTimes(1);
+    expect(getWalletConnection).toHaveBeenCalledTimes(1);
   });
 
   test("should disconnect properly", async () => {
@@ -156,9 +156,9 @@ describe("ui/hooks/useEthWallet", () => {
 
     await act(async () => result.current.onDisconnect());
 
-    expect(resetStateSpy).toBeCalledTimes(1);
-    expect(setWalletConnection).toBeCalledTimes(1);
-    expect(setWalletConnection).toBeCalledWith(true);
+    expect(resetStateSpy).toHaveBeenCalledTimes(1);
+    expect(setWalletConnection).toHaveBeenCalledTimes(1);
+    expect(setWalletConnection).toHaveBeenCalledWith(true);
   });
 
   test("should lock properly", async () => {
@@ -166,6 +166,6 @@ describe("ui/hooks/useEthWallet", () => {
 
     await act(async () => Promise.resolve(result.current.onLock()));
 
-    expect(lock).toBeCalledTimes(1);
+    expect(lock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/AddVerifiableCredential/__tests__/useAddVerifiableCredential.test.ts
+++ b/packages/app/src/ui/pages/AddVerifiableCredential/__tests__/useAddVerifiableCredential.test.ts
@@ -103,8 +103,8 @@ describe("ui/pages/AddVerifiableCredential/useAddVerifiableCredential", () => {
       result.current.onCloseModal();
     });
 
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 
   test("should toggle renaming properly", async () => {
@@ -132,7 +132,7 @@ describe("ui/pages/AddVerifiableCredential/useAddVerifiableCredential", () => {
 
     await act(async () => result.current.onApproveVerifiableCredential());
 
-    expect(addVerifiableCredential).toBeCalledTimes(1);
+    expect(addVerifiableCredential).toHaveBeenCalledTimes(1);
   });
 
   test("should reject the verifiable credential properly", async () => {
@@ -144,8 +144,8 @@ describe("ui/pages/AddVerifiableCredential/useAddVerifiableCredential", () => {
 
     await act(async () => Promise.resolve(result.current.onRejectVerifiableCredential()));
 
-    expect(rejectVerifiableCredentialRequest).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(2);
+    expect(rejectVerifiableCredentialRequest).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
   });
 
   test("should handle an error properly", async () => {

--- a/packages/app/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
+++ b/packages/app/src/ui/pages/ConnectIdentity/__tests__/ConnectedIdentity.test.tsx
@@ -97,7 +97,7 @@ describe("ui/pages/ConnectIdentity", () => {
     const button = await findByText("Connect");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should reject connection properly", async () => {
@@ -112,6 +112,6 @@ describe("ui/pages/ConnectIdentity", () => {
     const button = await findByText("Reject");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultHookData.onReject).toBeCalledTimes(1);
+    expect(defaultHookData.onReject).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
+++ b/packages/app/src/ui/pages/ConnectIdentity/__tests__/useConnectIdentity.test.ts
@@ -103,9 +103,9 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
   const waitForData = async (current: IUseConnectIdentityData) => {
     await waitFor(() => current.faviconUrl !== "");
     await waitFor(() => {
-      expect(mockDispatch).toBeCalledTimes(2);
-      expect(fetchIdentities).toBeCalledTimes(1);
-      expect(fetchConnections).toBeCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      expect(fetchIdentities).toHaveBeenCalledTimes(1);
+      expect(fetchConnections).toHaveBeenCalledTimes(1);
     });
   };
 
@@ -134,12 +134,12 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onReject()));
 
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should connect properly", async () => {
@@ -149,14 +149,14 @@ describe("ui/pages/ConnectIdentity/useConnectIdentity", () => {
     await waitFor(() => result.current.selectedIdentityCommitment === "1");
     await act(() => Promise.resolve(result.current.onConnect()));
 
-    expect(mockDispatch).toBeCalledTimes(4);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(connect).toBeCalledTimes(1);
-    expect(connect).toBeCalledWith({ commitment: "1", urlOrigin: "http://localhost:3000" });
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(4);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith({ commitment: "1", urlOrigin: "http://localhost:3000" });
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should change tab properly", async () => {

--- a/packages/app/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
+++ b/packages/app/src/ui/pages/CreateIdentity/__tests__/CreateIdentity.test.tsx
@@ -133,7 +133,7 @@ describe("ui/pages/CreateIdentity", () => {
 
     await act(async () => Promise.resolve(fireEvent.click(metamaskButton)));
 
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should render warning message for non-deterministic identity properly", async () => {
@@ -164,13 +164,13 @@ describe("ui/pages/CreateIdentity", () => {
     const button = await screen.findByText("Sign with CryptKeeper");
     await act(async () => Promise.resolve(fireEvent.click(button)));
 
-    expect(signWithSigner).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledWith({
+    expect(signWithSigner).toHaveBeenCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledWith({
       groups: [],
       messageSignature: undefined,
       urlOrigin: undefined,

--- a/packages/app/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
+++ b/packages/app/src/ui/pages/CreateIdentity/__tests__/useCreateIdentity.test.ts
@@ -96,11 +96,11 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSign(SignatureOptions.ETH_WALLET)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(signWithSigner).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledWith({
+    expect(signWithSigner).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledWith({
       groups: [],
       messageSignature: mockSignedMessage,
       urlOrigin: undefined,
@@ -108,8 +108,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
       options: { account: ZERO_ADDRESS, message: mockMessage, nonce: 0 },
       walletType: EWallet.ETH_WALLET,
     });
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should create identity properly and go back", async () => {
@@ -120,10 +120,10 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSign(SignatureOptions.ETH_WALLET)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(signWithSigner).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledWith({
+    expect(signWithSigner).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledWith({
       groups: [],
       urlOrigin: "http://localhost:3000",
       messageSignature: mockSignedMessage,
@@ -131,8 +131,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
       options: { account: ZERO_ADDRESS, message: mockMessage, nonce: 0 },
       walletType: EWallet.ETH_WALLET,
     });
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
       `${Paths.CONNECT_IDENTITY}?urlOrigin=http://localhost:3000&back=${Paths.CONNECT_IDENTITY}`,
     );
   });
@@ -144,7 +144,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSign(SignatureOptions.ETH_WALLET)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should handle error when trying to connect with eth wallet", async () => {
@@ -168,11 +168,11 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSign(SignatureOptions.CRYPTKEEPER_WALLET)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(signWithSigner).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledTimes(1);
-    expect(createIdentity).toBeCalledWith({
+    expect(signWithSigner).toHaveBeenCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledTimes(1);
+    expect(createIdentity).toHaveBeenCalledWith({
       groups: [],
       messageSignature: undefined,
       urlOrigin: undefined,
@@ -180,8 +180,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
       options: { account: defaultWalletHookData.address, message: mockMessage, nonce: 0 },
       walletType: EWallet.CRYPTKEEPER_WALLET,
     });
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should close modal properly", async () => {
@@ -189,7 +189,7 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onCloseModal()));
 
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 
   test("should go back properly", async () => {
@@ -199,8 +199,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onCloseModal()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(-1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
   test("should go to import identity properly", async () => {
@@ -210,8 +210,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onGoToImportIdentity()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(`${Paths.IMPORT_IDENTITY}?back=${Paths.CREATE_IDENTITY}&urlOrigin=`);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`${Paths.IMPORT_IDENTITY}?back=${Paths.CREATE_IDENTITY}&urlOrigin=`);
   });
 
   test("should go to import identity properly with redirect", async () => {
@@ -221,8 +221,8 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onGoToImportIdentity()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(`${Paths.IMPORT_IDENTITY}?back=${Paths.CONNECT_IDENTITY}&urlOrigin=`);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`${Paths.IMPORT_IDENTITY}?back=${Paths.CONNECT_IDENTITY}&urlOrigin=`);
   });
 
   test("should handle create identity error properly", async () => {
@@ -246,6 +246,6 @@ describe("ui/pages/CreateIdentity/useCreateIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSign(9000)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/app/src/ui/pages/DownloadBackup/__tests__/DownloadBackup.test.tsx
+++ b/packages/app/src/ui/pages/DownloadBackup/__tests__/DownloadBackup.test.tsx
@@ -110,6 +110,6 @@ describe("ui/pages/DownloadBackup", () => {
     const button = await screen.findByTestId("download-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(mockDispatch).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
+++ b/packages/app/src/ui/pages/DownloadBackup/__tests__/useDownloadBackup.test.ts
@@ -70,11 +70,11 @@ describe("ui/pages/DownloadBackup/useDownloadBackup", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(downloadBackup).toBeCalledTimes(1);
-    expect(downloadFile).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(downloadBackup).toHaveBeenCalledTimes(1);
+    expect(downloadFile).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should handle submit error", async () => {

--- a/packages/app/src/ui/pages/GenerateMnemonic/__tests__/GenerateMnemonic.test.tsx
+++ b/packages/app/src/ui/pages/GenerateMnemonic/__tests__/GenerateMnemonic.test.tsx
@@ -53,7 +53,7 @@ describe("ui/pages/GenerateMnemonic", () => {
     const button = await findByTestId("change-mode-button");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultHookData.onChooseInputMode).toBeCalledTimes(1);
+    expect(defaultHookData.onChooseInputMode).toHaveBeenCalledTimes(1);
   });
 
   test("should change to generate mode properly", async () => {
@@ -65,7 +65,7 @@ describe("ui/pages/GenerateMnemonic", () => {
     const button = await findByTestId("change-mode-button");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultHookData.onChooseGenerateMode).toBeCalledTimes(1);
+    expect(defaultHookData.onChooseGenerateMode).toHaveBeenCalledTimes(1);
   });
 
   test("should render error properly", async () => {
@@ -89,6 +89,6 @@ describe("ui/pages/GenerateMnemonic", () => {
     const button = await findByTestId("submit-button");
     await act(() => fireEvent.submit(button));
 
-    expect(defaultHookData.onSaveMnemonic).toBeCalledTimes(1);
+    expect(defaultHookData.onSaveMnemonic).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/GenerateMnemonic/__tests__/useGenerateMnemonic.test.ts
+++ b/packages/app/src/ui/pages/GenerateMnemonic/__tests__/useGenerateMnemonic.test.ts
@@ -72,8 +72,8 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
     renderHook(() => useGenerateMnemonic());
 
     await waitFor(() => {
-      expect(mockNavigate).toBeCalledTimes(1);
-      expect(mockNavigate).toBeCalledWith(Paths.HOME);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
     });
   });
 
@@ -83,7 +83,7 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
     renderHook(() => useGenerateMnemonic());
 
     await waitFor(() => {
-      expect(generateMnemonic).toBeCalledTimes(1);
+      expect(generateMnemonic).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -92,10 +92,10 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
 
     await act(() => Promise.resolve(result.current.onSaveMnemonic()));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(saveMnemonic).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(saveMnemonic).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should save user mnemonic and go home properly", async () => {
@@ -104,11 +104,11 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
     await act(() => Promise.resolve(result.current.onChooseInputMode()));
     await act(() => Promise.resolve(result.current.onSaveMnemonic()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(generateMnemonic).toBeCalledTimes(1);
-    expect(saveMnemonic).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(generateMnemonic).toHaveBeenCalledTimes(1);
+    expect(saveMnemonic).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should set error if generate mnemonic is not successful", async () => {
@@ -121,7 +121,7 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
     await act(() => Promise.resolve(result.current.onSaveMnemonic()));
 
     expect(result.current.errors.mnemonic).toBe(error.message);
-    expect(mockNavigate).toBeCalledTimes(0);
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
   });
 
   test("should set error if save mnemonic is not successful", async () => {
@@ -133,7 +133,7 @@ describe("ui/pages/GenerateMnemonic/useGenerateMnemonic", () => {
     await act(() => Promise.resolve(result.current.onSaveMnemonic()));
 
     expect(result.current.errors.mnemonic).toBe(error.message);
-    expect(mockNavigate).toBeCalledTimes(0);
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
   });
 
   test("should change modes properly", async () => {

--- a/packages/app/src/ui/pages/GroupMerkleProof/__tests__/useGroupMerkleProof.test.ts
+++ b/packages/app/src/ui/pages/GroupMerkleProof/__tests__/useGroupMerkleProof.test.ts
@@ -87,7 +87,7 @@ describe("ui/pages/GroupMerkleProof/useGroupMerkleProof", () => {
 
   const waitForData = async (data: IUseGroupMerkleProofData): Promise<void> => {
     await waitFor(() => !data.isLoading);
-    await waitFor(() => expect(fetchIdentities).toBeCalledTimes(1));
+    await waitFor(() => expect(fetchIdentities).toHaveBeenCalledTimes(1));
   };
 
   test("should return initial data", async () => {
@@ -108,14 +108,14 @@ describe("ui/pages/GroupMerkleProof/useGroupMerkleProof", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
-    expect(mockDispatch).toBeCalledTimes(5);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(checkGroupMembership).toBeCalledTimes(1);
-    expect(rejectUserRequest).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(5);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(checkGroupMembership).toHaveBeenCalledTimes(1);
+    expect(rejectUserRequest).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should handle error properly", async () => {
@@ -147,8 +147,8 @@ describe("ui/pages/GroupMerkleProof/useGroupMerkleProof", () => {
 
     await act(() => Promise.resolve(result.current.onGoToHost()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 
   test("should go to group properly", async () => {
@@ -157,8 +157,8 @@ describe("ui/pages/GroupMerkleProof/useGroupMerkleProof", () => {
 
     await act(() => Promise.resolve(result.current.onGoToGroup()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(`${getBandadaUrl()}/groups/off-chain/groupId`);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(`${getBandadaUrl()}/groups/off-chain/groupId`);
   });
 
   test("should generate group merkle proof properly", async () => {
@@ -168,14 +168,14 @@ describe("ui/pages/GroupMerkleProof/useGroupMerkleProof", () => {
     await act(() => Promise.resolve(result.current.onGenerateMerkleProof()));
     await waitFor(() => !result.current.isSubmitting);
 
-    expect(mockDispatch).toBeCalledTimes(5);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(checkGroupMembership).toBeCalledTimes(1);
-    expect(generateGroupMerkleProof).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(5);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(checkGroupMembership).toHaveBeenCalledTimes(1);
+    expect(generateGroupMerkleProof).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle generate group merkle proof error properly", async () => {

--- a/packages/app/src/ui/pages/Home/__tests__/useHome.test.ts
+++ b/packages/app/src/ui/pages/Home/__tests__/useHome.test.ts
@@ -106,10 +106,10 @@ describe("ui/pages/Home/useHome", () => {
 
     expect(result.current.address).toBe(defaultWalletHookData.address);
     expect(result.current.identities).toStrictEqual(defaultIdentities);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(mockDispatch).toBeCalledTimes(3);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
   });
 
   test("should refresh connection status properly", async () => {
@@ -117,8 +117,8 @@ describe("ui/pages/Home/useHome", () => {
 
     await act(async () => result.current.refreshConnectionStatus());
 
-    expect(checkHostApproval).toBeCalledTimes(1);
-    expect(checkHostApproval).toBeCalledWith(defaultUrl.origin);
+    expect(checkHostApproval).toHaveBeenCalledTimes(1);
+    expect(checkHostApproval).toHaveBeenCalledWith(defaultUrl.origin);
   });
 
   test("should not refresh connection status if there is no any tab", async () => {

--- a/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/ActivityList.test.tsx
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/ActivityList.test.tsx
@@ -87,7 +87,7 @@ describe("ui/pages/Home/components/ActivityList", () => {
     const yesButton = await screen.findByText("Yes");
     await act(async () => Promise.resolve(yesButton.click()));
 
-    expect(defaultHookData.onDeleteHistoryOperation).toBeCalledTimes(1);
-    expect(defaultHookData.onDeleteHistoryOperation).toBeCalledWith("1");
+    expect(defaultHookData.onDeleteHistoryOperation).toHaveBeenCalledTimes(1);
+    expect(defaultHookData.onDeleteHistoryOperation).toHaveBeenCalledWith("1");
   });
 });

--- a/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/ActivityListItem.test.tsx
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/ActivityListItem.test.tsx
@@ -52,8 +52,8 @@ describe("ui/pages/Home/components/ActivityList/Item", () => {
     const yesButton = await screen.findByText("Yes");
     await act(async () => Promise.resolve(yesButton.click()));
 
-    expect(defaultProps.onDelete).toBeCalledTimes(1);
-    expect(defaultProps.onDelete).toBeCalledWith("1");
+    expect(defaultProps.onDelete).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDelete).toHaveBeenCalledWith("1");
   });
 
   test("should go to connected url origin properly", async () => {
@@ -62,8 +62,8 @@ describe("ui/pages/Home/components/ActivityList/Item", () => {
     const urlOrigin = await screen.findByTestId("url-origin");
     await act(() => fireEvent.click(urlOrigin));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(defaultProps.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(defaultProps.urlOrigin);
   });
 
   test("should go to group properly", async () => {
@@ -72,7 +72,7 @@ describe("ui/pages/Home/components/ActivityList/Item", () => {
     const group = await screen.findByTestId("group");
     await act(() => fireEvent.click(group));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(getBandadaGroupUrl(defaultProps.operation.group!.id!));
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(getBandadaGroupUrl(defaultProps.operation.group!.id!));
   });
 });

--- a/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/useActivityList.test.ts
+++ b/packages/app/src/ui/pages/Home/components/ActivityList/__tests__/useActivityList.test.ts
@@ -88,9 +88,9 @@ describe("ui/pages/Home/components/ActivityList/useActivityList", () => {
 
     await act(async () => Promise.resolve(result.current.onDeleteHistoryOperation("1")));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(deleteHistoryOperation).toBeCalledTimes(1);
-    expect(deleteHistoryOperation).toBeCalledWith("1");
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(deleteHistoryOperation).toHaveBeenCalledTimes(1);
+    expect(deleteHistoryOperation).toHaveBeenCalledWith("1");
   });
 });

--- a/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
+++ b/packages/app/src/ui/pages/Identity/__tests__/Idenity.test.tsx
@@ -158,7 +158,7 @@ describe("ui/pages/Identity", () => {
     const button = await findByText("Delete");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultHookData.onConfirmDeleteIdentity).toBeCalledTimes(1);
+    expect(defaultHookData.onConfirmDeleteIdentity).toHaveBeenCalledTimes(1);
   });
 
   test("should delete identity properly", async () => {
@@ -177,11 +177,11 @@ describe("ui/pages/Identity", () => {
 
     const noButton = await findByTestId("danger-modal-reject");
     await act(() => Promise.resolve(noButton.click()));
-    expect(defaultHookData.onConfirmDeleteIdentity).toBeCalledTimes(1);
+    expect(defaultHookData.onConfirmDeleteIdentity).toHaveBeenCalledTimes(1);
 
     const yesButton = await findByTestId("danger-modal-accept");
     await act(() => Promise.resolve(yesButton.click()));
-    expect(defaultHookData.onDeleteIdentity).toBeCalledTimes(1);
+    expect(defaultHookData.onDeleteIdentity).toHaveBeenCalledTimes(1);
   });
 
   test("should render update form properly", async () => {
@@ -201,6 +201,6 @@ describe("ui/pages/Identity", () => {
     const confirmButton = await findByText("Confirm");
     await act(() => Promise.resolve(confirmButton.click()));
 
-    expect(defaultHookData.onConfirmUpdate).toBeCalledTimes(1);
+    expect(defaultHookData.onConfirmUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/Identity/__tests__/useIdentityPage.test.ts
+++ b/packages/app/src/ui/pages/Identity/__tests__/useIdentityPage.test.ts
@@ -69,7 +69,7 @@ describe("ui/pages/Identity/useIdentityPage", () => {
   const waitForData = async (data: IUseIdentityPageData): Promise<void> => {
     await waitFor(() => !data.isLoading);
     await waitFor(() => {
-      expect(fetchIdentities).toBeCalledTimes(1);
+      expect(fetchIdentities).toHaveBeenCalledTimes(1);
     });
   };
 
@@ -90,8 +90,8 @@ describe("ui/pages/Identity/useIdentityPage", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle error properly", async () => {
@@ -114,13 +114,13 @@ describe("ui/pages/Identity/useIdentityPage", () => {
 
     await act(() => Promise.resolve(result.current.onDeleteIdentity()));
 
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(deleteIdentity).toBeCalledTimes(1);
-    expect(deleteIdentity).toBeCalledWith(result.current.commitment);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(deleteIdentity).toHaveBeenCalledTimes(1);
+    expect(deleteIdentity).toHaveBeenCalledWith(result.current.commitment);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle delete identity error properly", async () => {
@@ -154,10 +154,10 @@ describe("ui/pages/Identity/useIdentityPage", () => {
     await act(() => Promise.resolve(result.current.onConfirmUpdate()));
 
     expect(result.current.isUpdating).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(setIdentityName).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(setIdentityName).toHaveBeenCalledTimes(1);
   });
 
   test("should handle confirm update error properly", async () => {
@@ -190,7 +190,7 @@ describe("ui/pages/Identity/useIdentityPage", () => {
 
     await act(() => Promise.resolve(result.current.onGoToHost()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 });

--- a/packages/app/src/ui/pages/ImportIdentity/__tests__/useImportIdentity.test.ts
+++ b/packages/app/src/ui/pages/ImportIdentity/__tests__/useImportIdentity.test.ts
@@ -149,11 +149,11 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(rejectUserRequest).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(rejectUserRequest).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should go back properly without closing popup", async () => {
@@ -163,11 +163,11 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(-1);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(rejectUserRequest).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(0);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(rejectUserRequest).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(0);
   });
 
   test("should go to host properly", async () => {
@@ -175,8 +175,8 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
 
     await act(() => Promise.resolve(result.current.onGoToHost()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 
   test("should drop object file properly", async () => {
@@ -253,12 +253,12 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(() => result.current.register("name").onChange({ target: { value: "name" } }));
     await act(() => Promise.resolve(result.current.onSubmit(EWallet.CRYPTKEEPER_WALLET)));
 
-    expect(signWithSigner).toBeCalledTimes(0);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(importIdentity).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(signWithSigner).toHaveBeenCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(importIdentity).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should connect eth wallet properly", async () => {
@@ -268,7 +268,7 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSubmit(EWallet.ETH_WALLET)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
   });
 
   test("should handle error when trying to connect with eth wallet", async () => {
@@ -294,7 +294,7 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
 
     await act(async () => Promise.resolve(result.current.onSubmit(EWallet.ETH_WALLET)));
 
-    expect(mockDispatch).toBeCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(0);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.errors.root).toBe(error.message);
   });
@@ -305,11 +305,11 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(() => result.current.register("name").onChange({ target: { value: "name" } }));
     await act(() => Promise.resolve(result.current.onSubmit(EWallet.ETH_WALLET)));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(importIdentity).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(importIdentity).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should submit and go back properly", async () => {
@@ -322,10 +322,10 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(() => result.current.register("name").onChange({ target: { value: "name" } }));
     await act(() => Promise.resolve(result.current.onSubmit(EWallet.CRYPTKEEPER_WALLET)));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(importIdentity).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(importIdentity).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
       `${Paths.CONNECT_IDENTITY}?urlOrigin=${mockDefaultConnection.urlOrigin}&back=${Paths.CONNECT_IDENTITY}`,
     );
   });
@@ -340,10 +340,10 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(() => result.current.register("name").onChange({ target: { value: "name" } }));
     await act(() => Promise.resolve(result.current.onSubmit(EWallet.CRYPTKEEPER_WALLET)));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(importIdentity).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(importIdentity).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error properly", async () => {
@@ -364,6 +364,6 @@ describe("ui/pages/ImportIdentity/useImportIdentity", () => {
     await act(async () => Promise.resolve(result.current.onSubmit(9000)));
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(0);
+    expect(mockDispatch).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/app/src/ui/pages/JoinGroup/__tests__/useJoinGroup.test.ts
+++ b/packages/app/src/ui/pages/JoinGroup/__tests__/useJoinGroup.test.ts
@@ -86,7 +86,7 @@ describe("ui/pages/JoinGroup/useJoinGroup", () => {
 
   const waitForData = async (data: IUseJoinGroupData): Promise<void> => {
     await waitFor(() => !data.isLoading);
-    await waitFor(() => expect(fetchIdentities).toBeCalledTimes(1));
+    await waitFor(() => expect(fetchIdentities).toHaveBeenCalledTimes(1));
   };
 
   test("should return initial data", async () => {
@@ -110,14 +110,14 @@ describe("ui/pages/JoinGroup/useJoinGroup", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
-    expect(mockDispatch).toBeCalledTimes(5);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(checkGroupMembership).toBeCalledTimes(1);
-    expect(rejectUserRequest).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(5);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(checkGroupMembership).toHaveBeenCalledTimes(1);
+    expect(rejectUserRequest).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should handle error properly", async () => {
@@ -149,8 +149,8 @@ describe("ui/pages/JoinGroup/useJoinGroup", () => {
 
     await act(() => Promise.resolve(result.current.onGoToHost()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 
   test("should go to group properly", async () => {
@@ -159,8 +159,8 @@ describe("ui/pages/JoinGroup/useJoinGroup", () => {
 
     await act(() => Promise.resolve(result.current.onGoToGroup()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(`${getBandadaUrl()}/groups/off-chain/groupId`);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(`${getBandadaUrl()}/groups/off-chain/groupId`);
   });
 
   test("should join group properly", async () => {
@@ -170,14 +170,14 @@ describe("ui/pages/JoinGroup/useJoinGroup", () => {
     await act(() => Promise.resolve(result.current.onJoin()));
     await waitFor(() => !result.current.isSubmitting);
 
-    expect(mockDispatch).toBeCalledTimes(5);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(checkGroupMembership).toBeCalledTimes(1);
-    expect(joinGroup).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(5);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(checkGroupMembership).toHaveBeenCalledTimes(1);
+    expect(joinGroup).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle join group error properly", async () => {

--- a/packages/app/src/ui/pages/Login/__tests__/Login.test.tsx
+++ b/packages/app/src/ui/pages/Login/__tests__/Login.test.tsx
@@ -133,11 +133,11 @@ describe("ui/pages/Login", () => {
     const button = await screen.findByTestId("unlock-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(unlock).toBeCalledTimes(1);
-    expect(unlock).toBeCalledWith("password");
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(unlock).toHaveBeenCalledTimes(1);
+    expect(unlock).toHaveBeenCalledWith("password");
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 });

--- a/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
+++ b/packages/app/src/ui/pages/Login/__tests__/useLogin.test.ts
@@ -61,9 +61,9 @@ describe("ui/pages/Login/useLogin", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error", async () => {

--- a/packages/app/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
+++ b/packages/app/src/ui/pages/Onboarding/__tests__/Onboarding.test.tsx
@@ -144,8 +144,8 @@ describe("ui/pages/Onboarding", () => {
     const button = await screen.findByTestId("submit-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(setupPassword).toBeCalledTimes(1);
-    expect(setupPassword).toBeCalledWith("Password123@");
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(setupPassword).toHaveBeenCalledTimes(1);
+    expect(setupPassword).toHaveBeenCalledWith("Password123@");
   });
 });

--- a/packages/app/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
+++ b/packages/app/src/ui/pages/Onboarding/__tests__/useOnboarding.test.ts
@@ -75,9 +75,9 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.GENERATE_MNEMONIC);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.GENERATE_MNEMONIC);
   });
 
   test("should handle submit error", async () => {
@@ -129,7 +129,7 @@ describe("ui/pages/Onboarding/useOnboarding", () => {
       result.current.onGoToOnboardingBackup();
     });
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(createOnboardingBackupRequest).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(createOnboardingBackupRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/OnboardingBackup/__tests__/OnboardingBackup.test.tsx
+++ b/packages/app/src/ui/pages/OnboardingBackup/__tests__/OnboardingBackup.test.tsx
@@ -85,7 +85,7 @@ describe("ui/pages/OnboardingBackup", () => {
     const button = await findByTestId("upload-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(defaultHookData.onDrop).toBeCalledTimes(1);
-    expect(defaultHookData.onSubmit).toBeCalledTimes(1);
+    expect(defaultHookData.onDrop).toHaveBeenCalledTimes(1);
+    expect(defaultHookData.onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/OnboardingBackup/__tests__/useOnboardingBackup.test.ts
+++ b/packages/app/src/ui/pages/OnboardingBackup/__tests__/useOnboardingBackup.test.ts
@@ -102,10 +102,10 @@ describe("ui/pages/OnboardingBackup/useOnboardingBackup", () => {
       result.current.onGoBack();
     });
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.ONBOARDING);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.ONBOARDING);
   });
 
   test("should drop files properly", () => {
@@ -143,12 +143,12 @@ describe("ui/pages/OnboardingBackup/useOnboardingBackup", () => {
 
     await act(() => Promise.resolve(result.current.onSubmit()));
 
-    expect(uploadBackup).toBeCalledTimes(1);
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(uploadBackup).toHaveBeenCalledTimes(1);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should submit properly and keep popup open", async () => {
@@ -164,13 +164,13 @@ describe("ui/pages/OnboardingBackup/useOnboardingBackup", () => {
 
     await act(() => Promise.resolve(result.current.onSubmit()));
 
-    expect(uploadBackup).toBeCalledTimes(1);
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(0);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(uploadBackup).toHaveBeenCalledTimes(1);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(0);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error properly", async () => {

--- a/packages/app/src/ui/pages/Popup/__tests__/usePopup.test.ts
+++ b/packages/app/src/ui/pages/Popup/__tests__/usePopup.test.ts
@@ -54,7 +54,7 @@ describe("ui/pages/Popup/usePopup", () => {
   const waitForData = async (current: IUsePopupData) => {
     await waitFor(() => current.isLoading);
     await waitFor(() => {
-      expect(mockDispatch).toBeCalledTimes(current.isUnlocked && current.isMnemonicGenerated ? 3 : 2);
+      expect(mockDispatch).toHaveBeenCalledTimes(current.isUnlocked && current.isMnemonicGenerated ? 3 : 2);
     });
     await waitFor(() => !current.isLoading);
   };
@@ -104,10 +104,10 @@ describe("ui/pages/Popup/usePopup", () => {
     await waitForData(result.current);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(defaultWalletHookData.onConnectEagerly).toBeCalledTimes(2);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(defaultWalletHookData.onConnectEagerly).toHaveBeenCalledTimes(2);
   });
 
   test("should get selected account properly when mnemonic generated", async () => {
@@ -117,15 +117,15 @@ describe("ui/pages/Popup/usePopup", () => {
 
     await waitFor(() => result.current.isLoading);
     await waitFor(() => {
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(getSelectedAccount).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(getSelectedAccount).toHaveBeenCalledTimes(1);
   });
 
   test("should get selected account properly when mnemonic generated", async () => {
@@ -135,15 +135,15 @@ describe("ui/pages/Popup/usePopup", () => {
 
     await waitFor(() => result.current.isLoading);
     await waitFor(() => {
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchStatus).toBeCalledTimes(1);
-    expect(fetchPendingRequests).toBeCalledTimes(1);
-    expect(getSelectedAccount).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(fetchPendingRequests).toHaveBeenCalledTimes(1);
+    expect(getSelectedAccount).toHaveBeenCalledTimes(1);
   });
 
   test("should handle load data error", async () => {
@@ -152,14 +152,14 @@ describe("ui/pages/Popup/usePopup", () => {
 
     const { result } = renderHook(() => usePopup());
     await waitFor(() => {
-      expect(mockDispatch).toBeCalledTimes(0);
+      expect(mockDispatch).toHaveBeenCalledTimes(0);
       expect(result.current.isLoading).toBe(false);
     });
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(log.error).toBeCalledTimes(1);
+    expect(log.error).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(log.error).toBeCalledWith(err);
+    expect(log.error).toHaveBeenCalledWith(err);
   });
 
   test("should redirect to create identity page", async () => {
@@ -173,8 +173,8 @@ describe("ui/pages/Popup/usePopup", () => {
 
     expect(result.current.isUnlocked).toBe(true);
     expect(result.current.isMnemonicGenerated).toBe(true);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
       `${Paths.CREATE_IDENTITY}?urlOrigin=${encodeURIComponent("http://localhost:3000")}`,
     );
   });
@@ -185,8 +185,8 @@ describe("ui/pages/Popup/usePopup", () => {
     const { result } = renderHook(() => usePopup());
     await waitForData(result.current);
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.LOGIN);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.LOGIN);
   });
 
   test("should bypass redirection if location is referenced to common path", async () => {
@@ -196,7 +196,7 @@ describe("ui/pages/Popup/usePopup", () => {
     const { result } = renderHook(() => usePopup());
     await waitForData(result.current);
 
-    expect(mockNavigate).toBeCalledTimes(0);
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
   });
 
   test("should redirect to onboarding page", async () => {
@@ -209,8 +209,8 @@ describe("ui/pages/Popup/usePopup", () => {
     const { result } = renderHook(() => usePopup());
     await waitForData(result.current);
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.ONBOARDING);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.ONBOARDING);
   });
 
   test("should redirect to mnemonic page", async () => {
@@ -223,8 +223,8 @@ describe("ui/pages/Popup/usePopup", () => {
     const { result } = renderHook(() => usePopup());
     await waitForData(result.current);
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.GENERATE_MNEMONIC);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.GENERATE_MNEMONIC);
   });
 
   test("should redirect to pending requests page", async () => {
@@ -236,7 +236,7 @@ describe("ui/pages/Popup/usePopup", () => {
 
     expect(result.current.isUnlocked).toBe(true);
     expect(result.current.isMnemonicGenerated).toBe(true);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.REQUESTS);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.REQUESTS);
   });
 });

--- a/packages/app/src/ui/pages/PresentVerifiableCredential/__tests__/PresentVerifiableCredential.test.tsx
+++ b/packages/app/src/ui/pages/PresentVerifiableCredential/__tests__/PresentVerifiableCredential.test.tsx
@@ -142,7 +142,7 @@ describe("ui/pages/PresentVerifiableCredential", () => {
     const button = await findByTestId("reject-verifiable-presentation-request");
     fireEvent.click(button);
 
-    expect(defaultHookData.onRejectRequest).toBeCalledTimes(1);
+    expect(defaultHookData.onRejectRequest).toHaveBeenCalledTimes(1);
   });
 
   test("should sign with metamask", async () => {
@@ -157,6 +157,6 @@ describe("ui/pages/PresentVerifiableCredential", () => {
     const button = await findByTestId("dropdown-button");
     fireEvent.click(button);
 
-    expect(defaultHookData.onSubmitVerifiablePresentation).toBeCalledTimes(1);
+    expect(defaultHookData.onSubmitVerifiablePresentation).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/PresentVerifiableCredential/__tests__/usePresentVerifiableCredential.test.ts
+++ b/packages/app/src/ui/pages/PresentVerifiableCredential/__tests__/usePresentVerifiableCredential.test.ts
@@ -159,8 +159,8 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       act(() => result.current.onCloseModal());
 
-      expect(closePopup).toBeCalledTimes(1);
-      expect(mockDispatch).toBeCalledTimes(2);
+      expect(closePopup).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
     });
 
     test("should check if menu item is disabled", async () => {
@@ -185,9 +185,9 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       await act(async () => Promise.resolve(result.current.onRejectRequest()));
 
-      expect(rejectVerifiablePresentationRequest).toBeCalledTimes(1);
-      expect(closePopup).toBeCalledTimes(1);
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(rejectVerifiablePresentationRequest).toHaveBeenCalledTimes(1);
+      expect(closePopup).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
 
     test("should toggle selecting a verifiable credential", async () => {
@@ -236,9 +236,9 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
       act(() => result.current.onToggleSelection(hash));
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.WITHOUT_SIGNATURE));
 
-      expect(generateVerifiablePresentation).toBeCalledTimes(1);
-      expect(closePopup).toBeCalledTimes(1);
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(generateVerifiablePresentation).toHaveBeenCalledTimes(1);
+      expect(closePopup).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
 
     test("should fail to submit an empty verifiable presentation", async () => {
@@ -250,7 +250,7 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.WITHOUT_SIGNATURE));
 
-      expect(generateVerifiablePresentation).toBeCalledTimes(0);
+      expect(generateVerifiablePresentation).toHaveBeenCalledTimes(0);
       expect(result.current.error).toBe("Please select at least one credential.");
     });
 
@@ -266,9 +266,9 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
       act(() => result.current.onToggleSelection(hash));
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.CRYPTKEEPER));
 
-      expect(generateVerifiablePresentationWithCryptkeeper).toBeCalledTimes(1);
-      expect(closePopup).toBeCalledTimes(1);
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(generateVerifiablePresentationWithCryptkeeper).toHaveBeenCalledTimes(1);
+      expect(closePopup).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
 
     test("should fail to submit an empty verifiable presentation with cryptkeeper", async () => {
@@ -280,7 +280,7 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.CRYPTKEEPER));
 
-      expect(generateVerifiablePresentationWithCryptkeeper).toBeCalledTimes(0);
+      expect(generateVerifiablePresentationWithCryptkeeper).toHaveBeenCalledTimes(0);
       expect(result.current.error).toBe("Please select at least one credential.");
     });
 
@@ -296,9 +296,9 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
       act(() => result.current.onToggleSelection(hash));
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.METAMASK));
 
-      expect(generateVerifiablePresentation).toBeCalledTimes(1);
-      expect(closePopup).toBeCalledTimes(1);
-      expect(mockDispatch).toBeCalledTimes(3);
+      expect(generateVerifiablePresentation).toHaveBeenCalledTimes(1);
+      expect(closePopup).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
 
     test("should fail to submit an empty verifiable presentation with metamask", async () => {
@@ -310,7 +310,7 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       await act(() => result.current.onSubmitVerifiablePresentation(MenuItems.METAMASK));
 
-      expect(generateVerifiablePresentationWithCryptkeeper).toBeCalledTimes(0);
+      expect(generateVerifiablePresentationWithCryptkeeper).toHaveBeenCalledTimes(0);
       expect(result.current.error).toBe("Please select at least one credential.");
     });
 
@@ -323,8 +323,8 @@ describe("ui/pages/PresentVerifiableCredential/usePresentVerifiableCredential", 
 
       await act(() => result.current.onSubmitVerifiablePresentation(3));
 
-      expect(generateVerifiablePresentation).toBeCalledTimes(0);
-      expect(generateVerifiablePresentationWithCryptkeeper).toBeCalledTimes(0);
+      expect(generateVerifiablePresentation).toHaveBeenCalledTimes(0);
+      expect(generateVerifiablePresentationWithCryptkeeper).toHaveBeenCalledTimes(0);
       expect(result.current.error).toBe("Invalid menu index.");
     });
   });

--- a/packages/app/src/ui/pages/Recover/__tests__/Recover.test.tsx
+++ b/packages/app/src/ui/pages/Recover/__tests__/Recover.test.tsx
@@ -85,9 +85,9 @@ describe("ui/pages/Recover", () => {
     const button = await findByTestId("submit-button");
     await act(() => Promise.resolve(button.click()));
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(checkMnemonic).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(`${Paths.RESET_PASSWORD}?mnemonic=${defaultMnemonic}`);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(checkMnemonic).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`${Paths.RESET_PASSWORD}?mnemonic=${defaultMnemonic}`);
   });
 });

--- a/packages/app/src/ui/pages/Recover/__tests__/useRecover.test.ts
+++ b/packages/app/src/ui/pages/Recover/__tests__/useRecover.test.ts
@@ -57,8 +57,8 @@ describe("ui/pages/Recover/useRecover", () => {
 
     await act(async () => Promise.resolve(result.current.onClose()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should submit form properly", async () => {
@@ -78,10 +78,10 @@ describe("ui/pages/Recover/useRecover", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(checkMnemonic).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(`${Paths.RESET_PASSWORD}?mnemonic=${defaultMnemonic}`);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(checkMnemonic).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`${Paths.RESET_PASSWORD}?mnemonic=${defaultMnemonic}`);
   });
 
   test("should handle submit error", async () => {

--- a/packages/app/src/ui/pages/ResetPassword/__tests__/ResetPassword.test.tsx
+++ b/packages/app/src/ui/pages/ResetPassword/__tests__/ResetPassword.test.tsx
@@ -124,8 +124,8 @@ describe("ui/pages/ResetPassword", () => {
     const button = await screen.findByTestId("submit-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error properly", async () => {

--- a/packages/app/src/ui/pages/ResetPassword/__tests__/useResetPassword.test.ts
+++ b/packages/app/src/ui/pages/ResetPassword/__tests__/useResetPassword.test.ts
@@ -62,8 +62,8 @@ describe("ui/pages/ResetPassword/useResetPassword", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should submit form properly", async () => {
@@ -81,10 +81,10 @@ describe("ui/pages/ResetPassword/useResetPassword", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(resetPassword).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(resetPassword).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error properly", async () => {
@@ -128,7 +128,7 @@ describe("ui/pages/ResetPassword/useResetPassword", () => {
 
     await act(async () => Promise.resolve(result.current.onClose()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.RECOVER);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.RECOVER);
   });
 });

--- a/packages/app/src/ui/pages/RevealIdentityCommitment/__tests__/useRevealIdentityCommitment.test.ts
+++ b/packages/app/src/ui/pages/RevealIdentityCommitment/__tests__/useRevealIdentityCommitment.test.ts
@@ -71,7 +71,7 @@ describe("ui/pages/RevealIdentityCommitment/useRevealIdentityCommitment", () => 
 
   const waitForData = async (data: IUseRevealIdentityCommitmentData): Promise<void> => {
     await waitFor(() => !data.isLoading);
-    await waitFor(() => expect(fetchIdentities).toBeCalledTimes(1));
+    await waitFor(() => expect(fetchIdentities).toHaveBeenCalledTimes(1));
   };
 
   test("should return initial data", async () => {
@@ -89,13 +89,13 @@ describe("ui/pages/RevealIdentityCommitment/useRevealIdentityCommitment", () => 
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
-    expect(mockDispatch).toBeCalledTimes(4);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(rejectUserRequest).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(4);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(rejectUserRequest).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
   });
 
   test("should handle error properly", async () => {
@@ -115,8 +115,8 @@ describe("ui/pages/RevealIdentityCommitment/useRevealIdentityCommitment", () => 
 
     await act(() => Promise.resolve(result.current.onGoToHost()));
 
-    expect(redirectToNewTab).toBeCalledTimes(1);
-    expect(redirectToNewTab).toBeCalledWith(mockDefaultConnection.urlOrigin);
+    expect(redirectToNewTab).toHaveBeenCalledTimes(1);
+    expect(redirectToNewTab).toHaveBeenCalledWith(mockDefaultConnection.urlOrigin);
   });
 
   test("should reveal connected identity commitment properly", async () => {
@@ -125,13 +125,13 @@ describe("ui/pages/RevealIdentityCommitment/useRevealIdentityCommitment", () => 
 
     await act(() => Promise.resolve(result.current.onReveal()));
 
-    expect(mockDispatch).toBeCalledTimes(4);
-    expect(fetchIdentities).toBeCalledTimes(1);
-    expect(fetchConnections).toBeCalledTimes(1);
-    expect(revealConnectedIdentityCommitment).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(4);
+    expect(fetchIdentities).toHaveBeenCalledTimes(1);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
+    expect(revealConnectedIdentityCommitment).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle reveal connected identity commitment error properly", async () => {

--- a/packages/app/src/ui/pages/RevealMnemonic/__tests__/RevealMnemonic.test.tsx
+++ b/packages/app/src/ui/pages/RevealMnemonic/__tests__/RevealMnemonic.test.tsx
@@ -55,7 +55,7 @@ describe("ui/pages/RevealMnemonic", () => {
     const button = await findByTestId("unlock-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(defaultHookData.onSubmit).toBeCalledTimes(1);
+    expect(defaultHookData.onSubmit).toHaveBeenCalledTimes(1);
   });
 
   test("should render error properly", async () => {
@@ -82,6 +82,6 @@ describe("ui/pages/RevealMnemonic", () => {
     const icon = await findByTestId("close-icon");
     await act(() => Promise.resolve(icon.click()));
 
-    expect(defaultHookData.onGoBack).toBeCalledTimes(1);
+    expect(defaultHookData.onGoBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/RevealMnemonic/__tests__/useRevealMnemonic.test.ts
+++ b/packages/app/src/ui/pages/RevealMnemonic/__tests__/useRevealMnemonic.test.ts
@@ -65,8 +65,8 @@ describe("ui/pages/RevealMnemonic/useRevealMnemonic", () => {
 
     await act(() => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should handle submit error properly", async () => {
@@ -95,9 +95,9 @@ describe("ui/pages/RevealMnemonic/useRevealMnemonic", () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.mnemonic).toBe(defaultMnemonic);
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(checkPassword).toBeCalledTimes(1);
-    expect(getMnemonic).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(checkPassword).toHaveBeenCalledTimes(1);
+    expect(getMnemonic).toHaveBeenCalledTimes(1);
   });
 
   test("should toggle password visibility properly", () => {

--- a/packages/app/src/ui/pages/Settings/__tests__/useSettings.test.ts
+++ b/packages/app/src/ui/pages/Settings/__tests__/useSettings.test.ts
@@ -94,9 +94,9 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await waitFor(() => !result.current.isConfirmModalOpen);
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(clearHistory).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(clearHistory).toHaveBeenCalledTimes(1);
   });
 
   test("should show confirm storage clear modal", async () => {
@@ -111,10 +111,10 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await waitFor(() => !result.current.isConfirmStorageDelete);
 
-    expect(mockDispatch).toBeCalledTimes(3);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(deleteStorage).toBeCalledTimes(1);
-    expect(lock).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(deleteStorage).toHaveBeenCalledTimes(1);
+    expect(lock).toHaveBeenCalledTimes(1);
   });
 
   test("should delete all history properly", async () => {
@@ -124,9 +124,9 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onDeleteAllHistory()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(clearHistory).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(clearHistory).toHaveBeenCalledTimes(1);
   });
 
   test("should delete history operation properly", async () => {
@@ -136,10 +136,10 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onEnableHistory()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(enableHistory).toBeCalledTimes(1);
-    expect(enableHistory).toBeCalledWith(!defaultHistorySettings.isEnabled);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(enableHistory).toHaveBeenCalledTimes(1);
+    expect(enableHistory).toHaveBeenCalledWith(!defaultHistorySettings.isEnabled);
   });
 
   test("should change tab properly", async () => {
@@ -159,8 +159,8 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoBack()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should go to download backup page properly", async () => {
@@ -170,8 +170,8 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoToBackup()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.DOWNLOAD_BACKUP);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.DOWNLOAD_BACKUP);
   });
 
   test("should open upload backup modal properly", async () => {
@@ -181,9 +181,9 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoToUploadBackup()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(createUploadBackupRequest).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(createUploadBackupRequest).toHaveBeenCalledTimes(1);
   });
 
   test("should go to upload backup page properly", async () => {
@@ -194,8 +194,8 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoToUploadBackup()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.UPLOAD_BACKUP);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.UPLOAD_BACKUP);
   });
 
   test("should go to reset password page properly", async () => {
@@ -205,8 +205,8 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoToResetPassword()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.RECOVER);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.RECOVER);
   });
 
   test("should delete all identities properly", async () => {
@@ -216,9 +216,9 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onDeleteAllIdentities()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(fetchHistory).toBeCalledTimes(1);
-    expect(deleteAllIdentities).toBeCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+    expect(deleteAllIdentities).toHaveBeenCalledTimes(1);
   });
 
   test("should go to reveal mnemonic page properly", async () => {
@@ -228,7 +228,7 @@ describe("ui/pages/Settings/useSettings", () => {
 
     await act(async () => Promise.resolve(result.current.onGoRevealMnemonic()));
 
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.REVEAL_MNEMONIC);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.REVEAL_MNEMONIC);
   });
 });

--- a/packages/app/src/ui/pages/Settings/components/__tests__/Backup.test.tsx
+++ b/packages/app/src/ui/pages/Settings/components/__tests__/Backup.test.tsx
@@ -32,7 +32,7 @@ describe("ui/pages/Settings/components/Backup", () => {
     const button = await findByText("Delete all identities");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onDeleteIdentities).toBeCalledTimes(1);
+    expect(defaultProps.onDeleteIdentities).toHaveBeenCalledTimes(1);
   });
 
   test("should clear storage properly", async () => {
@@ -47,7 +47,7 @@ describe("ui/pages/Settings/components/Backup", () => {
     const button = await findByText("Delete storage");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onDeleteStorage).toBeCalledTimes(1);
+    expect(defaultProps.onDeleteStorage).toHaveBeenCalledTimes(1);
   });
 
   test("should download backup data properly", async () => {
@@ -62,7 +62,7 @@ describe("ui/pages/Settings/components/Backup", () => {
     const button = await findByText("Download backup");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onGoToBackup).toBeCalledTimes(1);
+    expect(defaultProps.onGoToBackup).toHaveBeenCalledTimes(1);
   });
 
   test("should go to upload backup data properly", async () => {
@@ -77,7 +77,7 @@ describe("ui/pages/Settings/components/Backup", () => {
     const button = await findByText("Upload backup");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onGoToUploadBackup).toBeCalledTimes(1);
+    expect(defaultProps.onGoToUploadBackup).toHaveBeenCalledTimes(1);
   });
 
   test("should render loading state properly", async () => {

--- a/packages/app/src/ui/pages/Settings/components/__tests__/General.test.tsx
+++ b/packages/app/src/ui/pages/Settings/components/__tests__/General.test.tsx
@@ -31,7 +31,7 @@ describe("ui/pages/Settings/components/General", () => {
     const checkbox = await findByTestId("keepTrackHistory");
     await act(() => Promise.resolve(checkbox.click()));
 
-    expect(defaultProps.onEnableHistory).toBeCalledTimes(1);
+    expect(defaultProps.onEnableHistory).toHaveBeenCalledTimes(1);
   });
 
   test("should clear history properly", async () => {
@@ -46,7 +46,7 @@ describe("ui/pages/Settings/components/General", () => {
     const button = await findByText("Clear operation history");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onDeleteHistory).toBeCalledTimes(1);
+    expect(defaultProps.onDeleteHistory).toHaveBeenCalledTimes(1);
   });
 
   test("should render loading state properly", async () => {

--- a/packages/app/src/ui/pages/Settings/components/__tests__/Security.test.tsx
+++ b/packages/app/src/ui/pages/Settings/components/__tests__/Security.test.tsx
@@ -30,7 +30,7 @@ describe("ui/pages/Settings/components/Security", () => {
     const button = await findByTestId("change-password");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onGoToResetPassword).toBeCalledTimes(1);
+    expect(defaultProps.onGoToResetPassword).toHaveBeenCalledTimes(1);
   });
 
   test("should go to reveal mnemonic page properly", async () => {
@@ -45,7 +45,7 @@ describe("ui/pages/Settings/components/Security", () => {
     const button = await findByTestId("reveal-mnemonic");
     await act(() => Promise.resolve(button.click()));
 
-    expect(defaultProps.onGoRevealMnemonic).toBeCalledTimes(1);
+    expect(defaultProps.onGoRevealMnemonic).toHaveBeenCalledTimes(1);
   });
 
   test("should render loading state properly", async () => {

--- a/packages/app/src/ui/pages/UploadBackup/__tests__/UploadBackup.test.tsx
+++ b/packages/app/src/ui/pages/UploadBackup/__tests__/UploadBackup.test.tsx
@@ -88,7 +88,7 @@ describe("ui/pages/UploadBackup", () => {
     const button = await findByTestId("upload-button");
     await act(async () => Promise.resolve(fireEvent.submit(button)));
 
-    expect(defaultHookData.onDrop).toBeCalledTimes(1);
-    expect(defaultHookData.onSubmit).toBeCalledTimes(1);
+    expect(defaultHookData.onDrop).toHaveBeenCalledTimes(1);
+    expect(defaultHookData.onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ui/pages/UploadBackup/__tests__/useUploadBackup.test.ts
+++ b/packages/app/src/ui/pages/UploadBackup/__tests__/useUploadBackup.test.ts
@@ -92,10 +92,10 @@ describe("ui/pages/UploadBackup/useUploadBackup", () => {
       result.current.onGoBack();
     });
 
-    expect(mockDispatch).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.SETTINGS);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.SETTINGS);
   });
 
   test("should drop files properly", () => {
@@ -137,12 +137,12 @@ describe("ui/pages/UploadBackup/useUploadBackup", () => {
 
     await act(() => Promise.resolve(result.current.onSubmit()));
 
-    expect(mockDispatch).toBeCalledTimes(2);
-    expect(uploadBackup).toBeCalledTimes(1);
-    expect(defaultWalletHookData.onConnect).toBeCalledTimes(1);
-    expect(closePopup).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledTimes(1);
-    expect(mockNavigate).toBeCalledWith(Paths.HOME);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(uploadBackup).toHaveBeenCalledTimes(1);
+    expect(defaultWalletHookData.onConnect).toHaveBeenCalledTimes(1);
+    expect(closePopup).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Paths.HOME);
   });
 
   test("should handle submit error properly", async () => {

--- a/packages/app/src/ui/services/identity/__tests__/identity.test.ts
+++ b/packages/app/src/ui/services/identity/__tests__/identity.test.ts
@@ -20,8 +20,8 @@ describe("ui/services/identity", () => {
       signer: mockSigner as unknown as JsonRpcSigner,
     });
 
-    expect(mockSigner.signMessage).toBeCalledTimes(1);
-    expect(mockSigner.signMessage).toBeCalledWith(
+    expect(mockSigner.signMessage).toHaveBeenCalledTimes(1);
+    expect(mockSigner.signMessage).toHaveBeenCalledWith(
       `Sign this message with account ${ZERO_ADDRESS} to generate your Semaphore identity with key nonce: 0`,
     );
     expect(result).toBe("signed");
@@ -42,8 +42,8 @@ describe("ui/services/identity", () => {
       signer: mockSigner as unknown as JsonRpcSigner,
     });
 
-    expect(mockSigner.signMessage).toBeCalledTimes(1);
-    expect(mockSigner.signMessage).toBeCalledWith(
+    expect(mockSigner.signMessage).toHaveBeenCalledTimes(1);
+    expect(mockSigner.signMessage).toHaveBeenCalledWith(
       `Sign this message with account ${ZERO_ADDRESS} to import your Semaphore identity with trapdoor: ${mockDefaultTrapdoor}, nullifier: ${mockDefaultNullifier}`,
     );
     expect(result).toBe("signed");

--- a/packages/app/src/util/__tests__/browser.test.ts
+++ b/packages/app/src/util/__tests__/browser.test.ts
@@ -61,15 +61,15 @@ describe("util/browser", () => {
   test("should redirect to new tab properly", async () => {
     await redirectToNewTab("url");
 
-    expect(browser.tabs.create).toBeCalledTimes(1);
-    expect(browser.tabs.create).toBeCalledWith({ url: "url" });
+    expect(browser.tabs.create).toHaveBeenCalledTimes(1);
+    expect(browser.tabs.create).toHaveBeenCalledWith({ url: "url" });
   });
 
   test("should redirect to new tab properly", () => {
     getExtensionUrl("url");
 
-    expect(browser.runtime.getURL).toBeCalledTimes(1);
-    expect(browser.runtime.getURL).toBeCalledWith("url");
+    expect(browser.runtime.getURL).toHaveBeenCalledTimes(1);
+    expect(browser.runtime.getURL).toHaveBeenCalledWith("url");
   });
 
   test("should download file properly", async () => {
@@ -80,8 +80,8 @@ describe("util/browser", () => {
 
     await downloadFile("content", "filename");
 
-    expect(spyCreateElement).toBeCalledTimes(1);
-    expect(element.click).toBeCalledTimes(1);
+    expect(spyCreateElement).toHaveBeenCalledTimes(1);
+    expect(element.click).toHaveBeenCalledTimes(1);
   });
 
   test("should copy to clipboard properly", async () => {
@@ -89,8 +89,8 @@ describe("util/browser", () => {
 
     await copyToClipboard("content");
 
-    expect(spyCopy).toBeCalledTimes(1);
-    expect(spyCopy).toBeCalledWith("content");
+    expect(spyCopy).toHaveBeenCalledTimes(1);
+    expect(spyCopy).toHaveBeenCalledWith("content");
   });
 
   test("should get url origin properly", () => {
@@ -108,6 +108,6 @@ describe("util/browser", () => {
     const result = isExtensionPopupOpen();
 
     expect(result).toBe(false);
-    expect(browser.extension.getViews).toBeCalledTimes(1);
+    expect(browser.extension.getViews).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/e2e/pages/cryptKeeper/Identities.ts
+++ b/packages/e2e/pages/cryptKeeper/Identities.ts
@@ -103,6 +103,14 @@ export default class Identities extends BasePage {
     await this.page.getByText("Yes").click();
   }
 
+  async disconnect(index = 0): Promise<void> {
+    const identities = await this.page.locator(`[data-testid="identity-row"]`).all();
+    await identities[index].getByTestId("menu").click();
+
+    await this.page.getByText("Disconnect").click();
+    await this.page.getByText("Yes").click();
+  }
+
   async goToImportIdentity(): Promise<void> {
     await this.page.getByTestId("create-new-identity").click();
     await this.page.getByTestId("import-identity").click();

--- a/packages/e2e/tests/identity.test.ts
+++ b/packages/e2e/tests/identity.test.ts
@@ -168,4 +168,15 @@ test.describe("identity", () => {
 
     await expect(extension.getByText("My new account")).toBeHidden();
   });
+
+  test("should disconnect identity properly [health-check]", async ({ page }) => {
+    const extension = new CryptKeeper(page);
+    await extension.focus();
+
+    await extension.identities.disconnect();
+
+    await page.goto("/");
+
+    await expect(page.getByText(/To continue, please connect to your CryptKeeper to continue./)).toBeVisible();
+  });
 });

--- a/packages/zk/src/proof/__tests__/zkProofRLN.test.ts
+++ b/packages/zk/src/proof/__tests__/zkProofRLN.test.ts
@@ -61,8 +61,8 @@ describe("RLN proof", () => {
       defaultGenerateArgs.payload,
     );
 
-    expect(rlnServiceInstance.genProof).toBeCalledTimes(1);
-    expect(rlnServiceInstance.genProof).toBeCalledWith("serialized", defaultGenerateArgs.payload);
+    expect(rlnServiceInstance.genProof).toHaveBeenCalledTimes(1);
+    expect(rlnServiceInstance.genProof).toHaveBeenCalledWith("serialized", defaultGenerateArgs.payload);
     expect(result).toStrictEqual(emptyFullProof);
   });
 });

--- a/packages/zk/src/proof/__tests__/zkProofSemaphore.test.ts
+++ b/packages/zk/src/proof/__tests__/zkProofSemaphore.test.ts
@@ -60,8 +60,8 @@ describe("Semaphore proof", () => {
       defaultGenerateArgs.payload,
     );
 
-    expect(semaphoreServiceInstance.genProof).toBeCalledTimes(1);
-    expect(semaphoreServiceInstance.genProof).toBeCalledWith("serialized", defaultGenerateArgs.payload);
+    expect(semaphoreServiceInstance.genProof).toHaveBeenCalledTimes(1);
+    expect(semaphoreServiceInstance.genProof).toHaveBeenCalledWith("serialized", defaultGenerateArgs.payload);
     expect(result).toStrictEqual(emptyFullProof);
   });
 });

--- a/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
+++ b/packages/zk/src/proof/protocols/__tests__/proofs.test.ts
@@ -84,7 +84,7 @@ describe("background/services/protocols", () => {
 
       await rln.genProof(identityDecorator, { ...proofRequest, merkleStorageUrl: "http://localhost:3000/merkle" });
 
-      expect(mockRlnGenerateProof).toBeCalledTimes(1);
+      expect(mockRlnGenerateProof).toHaveBeenCalledTimes(1);
     });
 
     test("should generate rln proof properly with remote merkle proof but with string epoch", async () => {
@@ -109,7 +109,7 @@ describe("background/services/protocols", () => {
         merkleStorageUrl: "http://localhost:3000/merkle",
       });
 
-      expect(mockRlnGenerateProof).toBeCalledTimes(1);
+      expect(mockRlnGenerateProof).toHaveBeenCalledTimes(1);
     });
 
     test("should handle error properly when getting undefined zkey file paths", async () => {
@@ -207,8 +207,8 @@ describe("background/services/protocols", () => {
         merkleStorageUrl: "http://localhost:3000/merkle",
       });
 
-      expect(generateProof).toBeCalledTimes(1);
-      expect(generateProof).toBeCalledWith(
+      expect(generateProof).toHaveBeenCalledTimes(1);
+      expect(generateProof).toHaveBeenCalledWith(
         identityDecorator.zkIdentity,
         defaultMerkleProof,
         proofRequest.externalNullifier,

--- a/packages/zk/src/proof/protocols/__tests__/utils.test.ts
+++ b/packages/zk/src/proof/protocols/__tests__/utils.test.ts
@@ -65,7 +65,7 @@ describe("background/services/protocols/utils", () => {
       merkleStorageUrl: "http://localhost:3000/merkle",
     });
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toStrictEqual(defaultMerkleProof);
   });
 
@@ -83,7 +83,7 @@ describe("background/services/protocols/utils", () => {
         merkleStorageUrl: "http://localhost:3000/merkle",
       }),
     ).rejects.toThrowError(`Error in fetching Mock Merkle Proof ${error.message}`);
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   test("should get merkle proof from artifact properly", async () => {
@@ -114,7 +114,7 @@ describe("background/services/protocols/utils", () => {
 
     const result = await getRlnVerificationKeyJson("path");
 
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toStrictEqual({ data: {} });
   });
 


### PR DESCRIPTION
## Explanation

This PR adds disconnect action for identity home list.

Details are below:
- [x] Add disconnect identity action for home list
- [x] Add ready message for extension initialization
- [x] Get rid of jest deprecated methods

## Related Issues

Closes #933 

## Screenshots

<details>
<summary>Expand</summary>

![image](https://github.com/CryptKeeperZK/crypt-keeper-extension/assets/14254374/9c0ba32a-11d5-4f98-a8d7-87a67e8a6446)

</details>

## Manual Testing Steps

1. Try to connect identity
2. Then disconnect it
3. Check disconnect option is not available for identities without connected origin
4. Check extension doesn't throw error related to #933 

## Pre-Merge Checklist

### Assignees Checklist

- [x] PR template is filled out
- [x] Pre-commit and pre-push hook checks are passed
- [x] E2E tests are passed locally
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### Reviewers Checklist

- [ ] Manual testing checked and passed.
